### PR TITLE
[ISSUE #674] feat: Add support for env variables in executor config

### DIFF
--- a/internal/dag/executor/executor.go
+++ b/internal/dag/executor/executor.go
@@ -53,4 +53,4 @@ func Register(name string, register Creator) {
 	executors[name] = register
 }
 
-type handleExpendConfigEnv func() (interface{}, error)
+type handleExpendConfigEnv func() (any, error)

--- a/internal/dag/executor/executor.go
+++ b/internal/dag/executor/executor.go
@@ -25,6 +25,8 @@ import (
 	"github.com/dagu-org/dagu/internal/dag"
 )
 
+const daguConfigEnvPrefix = "$DAGU"
+
 type Executor interface {
 	SetStdout(out io.Writer)
 	SetStderr(out io.Writer)
@@ -50,3 +52,5 @@ func NewExecutor(ctx context.Context, step dag.Step) (Executor, error) {
 func Register(name string, register Creator) {
 	executors[name] = register
 }
+
+type handleExpendConfigEnv func() (interface{}, error)

--- a/internal/dag/executor/ssh.go
+++ b/internal/dag/executor/ssh.go
@@ -35,7 +35,7 @@ const (
 	sshExecutorConfigIPEnvKey                    = "DAGU_SSH_CONFIG_IP"
 	sshExecutorConfigPortEnvKey                  = "DAGU_SSH_CONFIG_PORT"
 	sshExecutorConfigKeyEnvKey                   = "DAGU_SSH_CONFIG_KEY"
-	sshExecutorConfigPassEnvKey                  = "DAGU_SSH_CONFIG_PASSWORD"
+	sshExecutorConfigPasswordEnvKey              = "DAGU_SSH_CONFIG_PASSWORD"
 	sshExecutorConfigStrictHostKeyCheckingEnvKey = "DAGU_SSH_CONFIG_STRICT_HOST_KEY_CHECKING"
 )
 
@@ -77,15 +77,15 @@ func selectSSHAuthMethod(cfg *sshExecConfig) (ssh.AuthMethod, error) {
 	return ssh.Password(cfg.Password), nil
 }
 
-func expendExecConfigUserKeyEnv() (interface{}, error) {
+func expendExecConfigUserKeyEnv() (any, error) {
 	return os.Getenv(sshExecutorConfigUserEnvKey), nil
 }
 
-func expendExecConfigIPKeyEnv() (interface{}, error) {
+func expendExecConfigIPKeyEnv() (any, error) {
 	return os.Getenv(sshExecutorConfigIPEnvKey), nil
 }
 
-func expendExecConfigPortKeyEnv() (interface{}, error) {
+func expendExecConfigPortKeyEnv() (any, error) {
 	var (
 		portStr = os.Getenv(sshExecutorConfigPortEnvKey)
 		port    int
@@ -99,15 +99,15 @@ func expendExecConfigPortKeyEnv() (interface{}, error) {
 	return port, nil
 }
 
-func expendExecConfigKeyKeyEnv() (interface{}, error) {
+func expendExecConfigKeyKeyEnv() (any, error) {
 	return os.Getenv(sshExecutorConfigKeyEnvKey), nil
 }
 
-func expendExecConfigPassKeyEnv() (interface{}, error) {
-	return os.Getenv(sshExecutorConfigPassEnvKey), nil
+func expendExecConfigPassKeyEnv() (any, error) {
+	return os.Getenv(sshExecutorConfigPasswordEnvKey), nil
 }
 
-func expendExecConfigStrictHostKeyCheckingKeyEnv() (interface{}, error) {
+func expendExecConfigStrictHostKeyCheckingKeyEnv() (any, error) {
 	var (
 		strictHostKeyChecking = os.Getenv(sshExecutorConfigStrictHostKeyCheckingEnvKey)
 		strictHostKey         bool
@@ -131,7 +131,7 @@ func getExpendConfigEnvFunc(key string) handleExpendConfigEnv {
 		return expendExecConfigPortKeyEnv
 	case sshExecutorConfigKeyEnvKey:
 		return expendExecConfigKeyKeyEnv
-	case sshExecutorConfigPassEnvKey:
+	case sshExecutorConfigPasswordEnvKey:
 		return expendExecConfigPassKeyEnv
 	case sshExecutorConfigStrictHostKeyCheckingEnvKey:
 		return expendExecConfigStrictHostKeyCheckingKeyEnv

--- a/internal/dag/executor/ssh.go
+++ b/internal/dag/executor/ssh.go
@@ -140,7 +140,7 @@ func getExpendConfigEnvFunc(key string) handleExpendConfigEnv {
 	return nil
 }
 
-func expendExecSingleConfigEnv(configValue interface{}) (interface{}, error) {
+func expendExecSingleConfigEnv(configValue any) (any, error) {
 	var (
 		configValueStr      string
 		ok                  bool
@@ -167,7 +167,7 @@ func expendExecSingleConfigEnv(configValue interface{}) (interface{}, error) {
 	return expendConfigValue, nil
 }
 
-func expendExecConfigEnv(cfg map[string]interface{}) error {
+func expendExecConfigEnv(cfg map[string]any) error {
 	for configKey, configValue := range cfg {
 		expendConfigValue, err := expendExecSingleConfigEnv(configValue)
 		if err != nil {

--- a/internal/dag/executor/ssh.go
+++ b/internal/dag/executor/ssh.go
@@ -147,7 +147,7 @@ func expendExecSingleConfigEnv(configValue any) (any, error) {
 		configValueStr      string
 		ok                  bool
 		expendConfigEnvFunc handleExpendConfigEnv
-		expendConfigValue   interface{}
+		expendConfigValue   any
 		err                 error
 	)
 	if configValue == nil {

--- a/internal/dag/executor/ssh.go
+++ b/internal/dag/executor/ssh.go
@@ -35,8 +35,10 @@ const (
 	sshExecutorConfigIPEnvKey                    = "DAGU_SSH_CONFIG_IP"
 	sshExecutorConfigPortEnvKey                  = "DAGU_SSH_CONFIG_PORT"
 	sshExecutorConfigKeyEnvKey                   = "DAGU_SSH_CONFIG_KEY"
-	sshExecutorConfigPasswordEnvKey              = "DAGU_SSH_CONFIG_PASSWORD"
 	sshExecutorConfigStrictHostKeyCheckingEnvKey = "DAGU_SSH_CONFIG_STRICT_HOST_KEY_CHECKING"
+
+	// #nosec G101
+	sshExecutorConfigPasswordEnvKey = "DAGU_SSH_CONFIG_PASSWORD"
 )
 
 type sshExec struct {


### PR DESCRIPTION
export env
```
export DAGU_SSH_CONFIG_PASSWORD="password"
export DAGU_SSH_CONFIG_IP="ip"
export DAGU_SSH_CONFIG_USER="user"
export DAGU_SSH_CONFIG_PORT="22"
```
func newSSHExec(_ context.Context, step dag.Step) (Executor, error) {
        // expend env
	if err = expendExecConfigEnv(step.ExecutorConfig.Config); err != nil {
		return nil, err
	}

	if err = md.Decode(step.ExecutorConfig.Config); err != nil {
		return nil, err
	}
}
![75d2aff794bde8915dd250eb16684a0](https://github.com/user-attachments/assets/1445d70c-e443-49a2-a542-1413b911b05d)
![74cd5158848c2808e1149058db0257e](https://github.com/user-attachments/assets/1b2fd1ac-67bb-4b44-8598-febbc26e0256)