### PR TITLE
ui: fix: DAG groups are not visible on UI

### DIFF
--- a/ui/src/components/molecules/DAGTable.tsx
+++ b/ui/src/components/molecules/DAGTable.tsx
@@ -441,9 +441,10 @@ function DAGTable({ DAGs = [], group = '', refreshFn, searchText, handleSearchTe
     ];
   }, [DAGs, group]);
 
-  const instance = useReactTable({
+  const instance = useReactTable<DAGRow>({
     data,
     columns,
+    getSubRows: (row) =>row.subRows,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),


### PR DESCRIPTION
Fixes #685 