### PR TITLE
fix: use the server timezone to parse the cron expression

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	APIBaseURL         string   // Base URL for API
 	Debug              bool     // Enable debug mode (verbose logging)
 	LogFormat          string   // Log format
+	TimeZone           string   // The server time zone
 }
 
 type TLS struct {
@@ -178,6 +179,7 @@ func bindEnvs() {
 	_ = viper.BindEnv("navbarColor", "DAGU_NAVBAR_COLOR")
 	_ = viper.BindEnv("navbarTitle", "DAGU_NAVBAR_TITLE")
 	_ = viper.BindEnv("apiBaseURL", "DAGU_API_BASE_URL")
+	_ = viper.BindEnv("timeZone", "DAGU_TIME_ZONE")
 
 	// Basic authentication
 	_ = viper.BindEnv("isBasicAuth", "DAGU_IS_BASICAUTH")

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -43,6 +43,7 @@ func New(cfg *config.Config, lg logger.Logger, cli client.Client) *server.Server
 		NavbarColor: cfg.NavbarColor,
 		NavbarTitle: cfg.NavbarTitle,
 		APIBaseURL:  cfg.APIBaseURL,
+		TimeZone:  cfg.TimeZone,
 	}
 
 	if cfg.IsAuthToken {

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -43,7 +43,7 @@ func New(cfg *config.Config, lg logger.Logger, cli client.Client) *server.Server
 		NavbarColor: cfg.NavbarColor,
 		NavbarTitle: cfg.NavbarTitle,
 		APIBaseURL:  cfg.APIBaseURL,
-		TimeZone:  cfg.TimeZone,
+		TimeZone:    cfg.TimeZone,
 	}
 
 	if cfg.IsAuthToken {

--- a/internal/frontend/server/server.go
+++ b/internal/frontend/server/server.go
@@ -63,7 +63,7 @@ type NewServerArgs struct {
 	NavbarColor string
 	NavbarTitle string
 	APIBaseURL  string
-	TimeZone  string
+	TimeZone    string
 }
 
 type BasicAuth struct {
@@ -93,7 +93,7 @@ func New(params NewServerArgs) *Server {
 			NavbarColor: params.NavbarColor,
 			NavbarTitle: params.NavbarTitle,
 			APIBaseURL:  params.APIBaseURL,
-			TimeZone:  params.TimeZone,
+			TimeZone:    params.TimeZone,
 		},
 	}
 }

--- a/internal/frontend/server/server.go
+++ b/internal/frontend/server/server.go
@@ -63,6 +63,7 @@ type NewServerArgs struct {
 	NavbarColor string
 	NavbarTitle string
 	APIBaseURL  string
+	TimeZone  string
 }
 
 type BasicAuth struct {
@@ -92,6 +93,7 @@ func New(params NewServerArgs) *Server {
 			NavbarColor: params.NavbarColor,
 			NavbarTitle: params.NavbarTitle,
 			APIBaseURL:  params.APIBaseURL,
+			TimeZone:  params.TimeZone,
 		},
 	}
 }

--- a/internal/frontend/server/templates.go
+++ b/internal/frontend/server/templates.go
@@ -57,6 +57,7 @@ type funcsConfig struct {
 	NavbarColor string
 	NavbarTitle string
 	APIBaseURL  string
+	TimeZone  string
 }
 
 func defaultFunctions(cfg funcsConfig) template.FuncMap {
@@ -79,6 +80,9 @@ func defaultFunctions(cfg funcsConfig) template.FuncMap {
 		},
 		"apiURL": func() string {
 			return cfg.APIBaseURL
+		},
+		"timeZone": func() string {
+			return cfg.TimeZone
 		},
 	}
 }

--- a/internal/frontend/server/templates.go
+++ b/internal/frontend/server/templates.go
@@ -57,7 +57,7 @@ type funcsConfig struct {
 	NavbarColor string
 	NavbarTitle string
 	APIBaseURL  string
-	TimeZone  string
+	TimeZone    string
 }
 
 func defaultFunctions(cfg funcsConfig) template.FuncMap {

--- a/internal/frontend/templates/base.gohtml
+++ b/internal/frontend/templates/base.gohtml
@@ -1,27 +1,26 @@
 {{define "base"}}
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{navbarTitle}}</title>
-  <script>
-    function getConfig() {
-      return {
-        apiURL: "{{ apiURL }}",
-        title: "{{ navbarTitle }}",
-        navbarColor: "{{ navbarColor }}",
-        version: "{{ version }}",
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ navbarTitle }}</title>
+    <script>
+      function getConfig() {
+        return {
+          apiURL: "{{ apiURL }}",
+          title: "{{ navbarTitle }}",
+          navbarColor: "{{ navbarColor }}",
+          version: "{{ version }}",
+          timeZone: "{{ timeZone }}",
+        };
       }
-    }
-  </script>
-  <script defer="defer" src="/assets/bundle.js?v={{ version }}"></script>
-</head>
-<body>
-  {{template "content" .}}
-</body>
-
+    </script>
+    <script defer="defer" src="/assets/bundle.js?v={{ version }}"></script>
+  </head>
+  <body>
+    {{template "content" .}}
+  </body>
 </html>
 {{ end }}

--- a/ui/index.html
+++ b/ui/index.html
@@ -12,6 +12,7 @@
           title: '',
           navbarColor: '',
           version: '',
+          timeZone: '',
         };
       }
     </script>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -13,6 +13,7 @@ export type Config = {
   apiURL: string;
   title: string;
   navbarColor: string;
+  timeZone: string;
   version: string;
 };
 

--- a/ui/src/components/molecules/DAGTable.tsx
+++ b/ui/src/components/molecules/DAGTable.tsx
@@ -251,7 +251,9 @@ const defaultColumns = [
   }),
   columnHelper.accessor('Type', {
     id: 'Schedule',
-    header: 'Schedule',
+    header: getConfig().timeZone
+      ? `Schedule in ${getConfig().timeZone}`
+      : 'Schedule',
     enableSorting: true,
     cell: (props) => {
       const data = props.row.original!;
@@ -389,7 +391,15 @@ const defaultColumns = [
   }),
 ];
 
-function DAGTable({ DAGs = [], group = '', refreshFn, searchText, handleSearchTextChange, searchTag, handleSearchTagChange }: Props) {
+function DAGTable({
+  DAGs = [],
+  group = '',
+  refreshFn,
+  searchText,
+  handleSearchTextChange,
+  searchTag,
+  handleSearchTagChange,
+}: Props) {
   const [columns] = React.useState<typeof defaultColumns>(() => [
     ...defaultColumns,
   ]);
@@ -444,7 +454,7 @@ function DAGTable({ DAGs = [], group = '', refreshFn, searchText, handleSearchTe
   const instance = useReactTable<DAGRow>({
     data,
     columns,
-    getSubRows: (row) =>row.subRows,
+    getSubRows: (row) => row.subRows,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
@@ -497,21 +507,19 @@ function DAGTable({ DAGs = [], group = '', refreshFn, searchText, handleSearchTe
           limitTags={1}
           value={searchTag}
           freeSolo
-          options={
-            DAGs.reduce<string[]>((acc, dag) => {
-              if (dag.Type == DAGDataType.DAG) {
-                const tags = dag.DAGStatus.DAG.Tags;
-                if (tags) {
-                  tags.forEach((tag) => {
-                    if (!acc.includes(tag)) {
-                      acc.push(tag);
-                    }
-                  });
-                }
+          options={DAGs.reduce<string[]>((acc, dag) => {
+            if (dag.Type == DAGDataType.DAG) {
+              const tags = dag.DAGStatus.DAG.Tags;
+              if (tags) {
+                tags.forEach((tag) => {
+                  if (!acc.includes(tag)) {
+                    acc.push(tag);
+                  }
+                });
               }
-              return acc;
-            }, [])
-          }
+            }
+            return acc;
+          }, [])}
           onChange={(_, value) => {
             const v = value || '';
             handleSearchTagChange(v);
@@ -558,9 +566,9 @@ function DAGTable({ DAGs = [], group = '', refreshFn, searchText, handleSearchTe
                           {header.isPlaceholder
                             ? null
                             : flexRender(
-                              header.column.columnDef.header,
-                              header.getContext()
-                            )}
+                                header.column.columnDef.header,
+                                header.getContext()
+                              )}
                           {{
                             asc: (
                               <ArrowUpward

--- a/ui/src/models/index.ts
+++ b/ui/src/models/index.ts
@@ -150,7 +150,7 @@ export function getNextSchedule(data: WorkflowListItem): number {
   if (!schedules || schedules.length == 0 || data.Suspended) {
     return Number.MAX_SAFE_INTEGER;
   }
-  const tz = null; // If we can work out how to get the server TZ, we can set this
+  const tz = getConfig().timeZone;
   const datesToRun = schedules.map((s) => {
     const expression = tz
       ? cronParser.parseExpression(s.Expression, {

--- a/ui/src/models/index.ts
+++ b/ui/src/models/index.ts
@@ -150,9 +150,16 @@ export function getNextSchedule(data: WorkflowListItem): number {
   if (!schedules || schedules.length == 0 || data.Suspended) {
     return Number.MAX_SAFE_INTEGER;
   }
-  const datesToRun = schedules.map((s) =>
-    cronParser.parseExpression(s.Expression).next()
-  );
+  const tz = null; // If we can work out how to get the server TZ, we can set this
+  const datesToRun = schedules.map((s) => {
+    const expression = tz
+      ? cronParser.parseExpression(s.Expression, {
+          currentDate: new Date(),
+          tz,
+        })
+      : cronParser.parseExpression(s.Expression);
+    return expression.next();
+  });
   const sorted = datesToRun.sort((a, b) => a.getTime() - b.getTime());
   return sorted[0].getTime() / 1000;
 }


### PR DESCRIPTION
There is an issue if the server is running in a timezone (eg. UTC), but the client's browser timezone is in another timezone (eg. Australia/Sydney), the cron expression incorrectly shows the Next Run incorrectly.

## Next Steps

Open on thoughts on the best way to get the server's timezone? Create an API endpoint? Open to feedback

