### PR TITLE
fixed bug when using the CRON_TZ= cron expression

### DIFF
--- a/ui/src/models/index.ts
+++ b/ui/src/models/index.ts
@@ -151,14 +151,20 @@ export function getNextSchedule(data: WorkflowListItem): number {
   if (!schedules || schedules.length == 0 || data.Suspended) {
     return Number.MAX_SAFE_INTEGER;
   }
-  const tz = getConfig().tz || moment.tz.guess();
+  let tz = getConfig().tz || moment.tz.guess();
   const datesToRun = schedules.map((s) => {
+    let expressionText = s.Expression
+    const cronTzMatch = expressionText.match(/(?<=CRON_TZ=)[^\s]+/);
+    if (cronTzMatch) {
+      tz = cronTzMatch[0]
+      expressionText = expressionText.replace(`CRON_TZ=${tz}`, '')
+    }
     const expression = tz
-      ? cronParser.parseExpression(s.Expression, {
+      ? cronParser.parseExpression(expressionText, {
           currentDate: new Date(),
           tz,
         })
-      : cronParser.parseExpression(s.Expression);
+      : cronParser.parseExpression(expressionText);
     return expression.next();
   });
   const sorted = datesToRun.sort((a, b) => a.getTime() - b.getTime());


### PR DESCRIPTION
Related to https://github.com/dagu-org/dagu/issues/706, when using the `CRON_Z` in an expression

```
CRON_TZ=Asia/Tokyo 0 6 * * *
```

The `/dags`  page doesn't load, see below
![image](https://github.com/user-attachments/assets/9cc62287-5a78-41d3-9199-3a04b3b52a8a)

The fixed version

![image](https://github.com/user-attachments/assets/5c6da443-5570-4612-a136-4b12ab4cf6d9)

