### PR TITLE
feat: Support configurable base path for server

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -25,6 +25,7 @@ Server Configuration
 ~~~~~~~~~~~~~~~~~~
 - ``DAGU_HOST`` (``127.0.0.1``): Server binding host
 - ``DAGU_PORT`` (``8080``): Server binding port
+- ``DAGU_BASE_PATH`` (``""``): Base path to serve the application
 - ``DAGU_TZ`` (``""``): Server timezone (default: system timezone)
 - ``DAGU_CERT_FILE``: SSL certificate file path
 - ``DAGU_KEY_FILE``: SSL key file path
@@ -59,6 +60,7 @@ Create ``admin.yaml`` in ``$HOME/.config/dagu/`` to override default settings. B
     # Server Configuration
     host: "127.0.0.1"                # Web UI hostname
     port: 8080                       # Web UI port
+    basePath: ""                    # Base path to serve the application
     tz: "Asia/Tokyo"                 # Timezone (e.g., "America/New_York")
     
     # Directory Configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	IsAuthToken        bool           // Enable auth token for API
 	AuthToken          string         // Auth token for API
 	LatestStatusToday  bool           // Show latest status today or the latest status
+	BasePath           string         // Base path for the server
 	APIBaseURL         string         // Base URL for API
 	Debug              bool           // Enable debug mode (verbose logging)
 	LogFormat          string         // Log format
@@ -168,6 +169,7 @@ func setupViper() error {
 	viper.SetDefault("host", "127.0.0.1")
 	viper.SetDefault("port", "8080")
 	viper.SetDefault("navbarTitle", "Dagu")
+	viper.SetDefault("basePath", "")
 	viper.SetDefault("apiBaseURL", "/api/v1")
 
 	// Set executable path
@@ -198,6 +200,7 @@ func bindEnvs() {
 	_ = viper.BindEnv("logEncodingCharset", "DAGU_LOG_ENCODING_CHARSET")
 	_ = viper.BindEnv("navbarColor", "DAGU_NAVBAR_COLOR")
 	_ = viper.BindEnv("navbarTitle", "DAGU_NAVBAR_TITLE")
+	_ = viper.BindEnv("basePath", "DAGU_BASE_PATH")
 	_ = viper.BindEnv("apiBaseURL", "DAGU_API_BASE_URL")
 	_ = viper.BindEnv("tz", "DAGU_TZ")
 

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -42,6 +42,7 @@ func New(cfg *config.Config, lg logger.Logger, cli client.Client) *server.Server
 		AssetsFS:    assetsFS,
 		NavbarColor: cfg.NavbarColor,
 		NavbarTitle: cfg.NavbarTitle,
+		BasePath:    cfg.BasePath,
 		APIBaseURL:  cfg.APIBaseURL,
 		TimeZone:    cfg.TZ,
 	}

--- a/internal/frontend/server/server.go
+++ b/internal/frontend/server/server.go
@@ -62,6 +62,7 @@ type NewServerArgs struct {
 	// Configuration for the frontend
 	NavbarColor string
 	NavbarTitle string
+	BasePath    string
 	APIBaseURL  string
 	TimeZone    string
 }
@@ -92,6 +93,7 @@ func New(params NewServerArgs) *Server {
 		funcsConfig: funcsConfig{
 			NavbarColor: params.NavbarColor,
 			NavbarTitle: params.NavbarTitle,
+			BasePath:    params.BasePath,
 			APIBaseURL:  params.APIBaseURL,
 			TZ:          params.TimeZone,
 		},
@@ -110,8 +112,9 @@ func (svr *Server) Shutdown() {
 
 func (svr *Server) Serve(ctx context.Context) (err error) {
 	middlewareOptions := &pkgmiddleware.Options{
-		Handler: svr.defaultRoutes(chi.NewRouter()),
-		Logger:  svr.logger,
+		Handler:  svr.defaultRoutes(chi.NewRouter()),
+		Logger:   svr.logger,
+		BasePath: svr.funcsConfig.BasePath,
 	}
 	if svr.authToken != nil {
 		middlewareOptions.AuthToken = &pkgmiddleware.AuthToken{

--- a/internal/frontend/server/templates.go
+++ b/internal/frontend/server/templates.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"path"
 	"path/filepath"
 	"text/template"
 
@@ -56,6 +57,7 @@ func (srv *Server) useTemplate(
 type funcsConfig struct {
 	NavbarColor string
 	NavbarTitle string
+	BasePath    string
 	APIBaseURL  string
 	TZ          string
 }
@@ -78,8 +80,11 @@ func defaultFunctions(cfg funcsConfig) template.FuncMap {
 		"navbarTitle": func() string {
 			return cfg.NavbarTitle
 		},
+		"basePath": func() string {
+			return cfg.BasePath
+		},
 		"apiURL": func() string {
-			return cfg.APIBaseURL
+			return path.Join(cfg.BasePath, cfg.APIBaseURL)
 		},
 		"tz": func() string {
 			return cfg.TZ

--- a/internal/frontend/templates/base.gohtml
+++ b/internal/frontend/templates/base.gohtml
@@ -10,6 +10,7 @@
             function getConfig() {
                 return {
                     apiURL: "{{ apiURL }}",
+                    basePath: "{{ basePath }}",
                     title: "{{ navbarTitle }}",
                     navbarColor: "{{ navbarColor }}",
                     version: "{{ version }}",
@@ -17,7 +18,7 @@
                 };
             }
         </script>
-        <script defer="defer" src="/assets/bundle.js?v={{ version }}"></script>
+        <script defer="defer" src="{{ basePath }}/assets/bundle.js?v={{ version }}"></script>
     </head>
     <body>
         {{template "content" .}}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -37,7 +37,7 @@ function App({ config }: Props) {
       >
         <ConfigContext.Provider value={config}>
           <UserPreferencesProvider>
-            <BrowserRouter>
+            <BrowserRouter basename={config.basePath}>
               <Layout {...config}>
                 <Routes>
                   <Route path="/" element={<Dashboard />} />

--- a/ui/src/contexts/ConfigContext.tsx
+++ b/ui/src/contexts/ConfigContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext } from 'react';
 
 export type Config = {
   apiURL: string;
+  basePath: string;
   title: string;
   navbarColor: string;
   tz: string;

--- a/ui/webpack.prod.js
+++ b/ui/webpack.prod.js
@@ -21,7 +21,7 @@ module.exports = merge(common, {
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'dist'),
-    publicPath: '/assets/',
+    publicPath: 'auto',
     clean: true,
   },
 });


### PR DESCRIPTION
Closes: https://github.com/dagu-org/dagu/issues/576
Closes: https://github.com/dagu-org/dagu/issues/575

This PR Adds a BasePath config that allows the go server to respond to requests at a specific  sub path. 

To test supply the BaseBath config though the environment variable `DAGU_BASE_PATH=/foo` or through the admin.yaml file 

1. Load dagu at the root `/` 
2. Should be redirected to `/foo`
3. dagu should work with out regressions
4. Restart dagu with out base path 
5. dagu should work with out regressions as before

 