### PR TITLE
Improve Dockerfile to reduce amount of config needed in docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 COPY ui/ ./
 
 RUN rm -rf node_modules; \
-    yarn install --frozen-lockfile --non-interactive; \
-    yarn build
+  yarn install --frozen-lockfile --non-interactive; \
+  yarn build
 
 # Stage 2: Go Builder
 FROM --platform=$TARGETPLATFORM golang:1.22-alpine as go-builder
@@ -32,35 +32,28 @@ ARG USER="dagu"
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-# Create user and set permissions
-RUN apk update; \
-    apk add --no-cache sudo tzdata; \
-    addgroup -g ${USER_GID} ${USER}; \
-    adduser ${USER} -h /home/${USER} -u ${USER_UID} -G ${USER} -D -s /bin/ash; \
-    echo ${USER} ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/${USER}; \
-    chmod 0440 /etc/sudoers.d/${USER}; \
-    mkdir -p .config/dagu/dags; \
-    chown -R ${USER}:${USER} /home/${USER};
-
 COPY --from=go-builder /app/bin/dagu /usr/local/bin/
+COPY ./entrypoint.sh /entrypoint.sh
 
-USER ${USER}
-WORKDIR /home/${USER}
+# Create user and set permissions
+RUN apk update && \
+  apk add --no-cache su-exec shadow tzdata && \
+  addgroup -g ${USER_GID} ${USER} && \
+  adduser ${USER} -h /config -u ${USER_UID} -G ${USER} -D -s /bin/ash && \
+  chown -R ${USER}:${USER} /config && \
+  chmod +x /entrypoint.sh;
 
-# Add the hello_world.yaml file
-COPY --chown=${USER}:${USER} <<EOF .config/dagu/dags/hello_world.yaml
-schedule: "* * * * *"
-steps:
-  - name: hello world
-    command: sh
-    script: |
-      echo "Hello, world!"
-EOF
+WORKDIR /config
+
 
 ENV DAGU_HOST=0.0.0.0
 ENV DAGU_PORT=8080
 ENV DAGU_TZ="Etc/UTC"
+ENV PUID=${USER_UID}
+ENV PGID=${USER_GID}
+ENV DOCKER_GID=-1
 
 EXPOSE 8080
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["dagu", "start-all"]

--- a/docs/source/docker-compose.rst
+++ b/docs/source/docker-compose.rst
@@ -1,48 +1,28 @@
+.. _Using Docker Compose:
 Using Docker Compose
 ===================================
 
-To automate DAG executions based on cron expressions, it is necessary to run both the ui server and scheduler process. Here is an example `docker-compose.yml` setup for running Dagu using Docker Compose.
+Here is an example `docker-compose.yml` setup for running Dagu using Docker Compose.
 
 .. code-block:: yaml
 
-  version: "3.9"
-  services:
-      # init container updates permission
-      init:
-          image: "ghcr.io/dagu-org/dagu:latest"
-          user: root
-          volumes:
-              - dagu_config:/home/dagu/.config/dagu
-              - dagu_data:/home/dagu/.local/share
-          command: chown -R dagu /home/dagu/.config/dagu/ /home/dagu/.local/share
-      # ui server process
-      server:
-          image: "ghcr.io/dagu-org/dagu:latest"
-          environment:
-              - DAGU_PORT=8080
-              - DAGU_TZ=Asia/Tokyo
-          restart: unless-stopped
-          ports:
-              - "8080:8080"
-          volumes:
-              - dagu_config:/home/dagu/.config/dagu
-              - dagu_data:/home/dagu/.local/share
-          command: dagu server
-          depends_on:
-              - init
-      # scheduler process
-      scheduler:
-          image: "ghcr.io/dagu-org/dagu:latest"
-          environment:
-              - DAGU_TZ=Asia/Tokyo
-          restart: unless-stopped
-          volumes:
-              - dagu_config:/home/dagu/.config/dagu
-              - dagu_data:/home/dagu/.local/share
-          command: dagu scheduler
-          depends_on:
-              - init
-  volumes:
-      dagu_config: {}
-      dagu_data: {}
+    services:
+        dagu:
+            image: "ghcr.io/dagu-org/dagu:latest"
+            container_name: dagu
+            hostname: dagu
+            ports:
+            - "8080:8080"
+            environment:
+            - DAGU_PORT=8080 # optional. default is 8080
+            - DAGU_TZ=Asia/Tokyo
+            - DAGU_BASE_PATH=/dagu # optional. default is /
+            - PUID=1000 # optional. default is 1000
+            - PGID=1000 # optional. default is 1000
+            - DOCKER_GID=999 # optional. default is -1 and it will be ignored
+            volumes:
+            - dagu_config:/config
+            - /var/run/docker.sock:/var/run/docker.sock # optional. required for docker in docker
+        volumes:
+        dagu_config: {}
 

--- a/docs/source/executors.rst
+++ b/docs/source/executors.rst
@@ -81,7 +81,11 @@ See the Docker's API documentation for all available options.
 Use Host's Docker Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you are running `dagu` using a container, you need the setup below.
+If you are running `dagu` using a container, there are two options to use the host's Docker environment.
+
+1. Mount the Docker socket to the container and pass through the host's docker group id. See the example in :ref:`Using Docker Compose <Using Docker Compose>`
+
+Or
 
 1. Run a `socat` container with the command below.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env /bin/sh
+
+echo "Starting entrypoint.sh"
+
+echo "
+PUID=${PUID}
+PGID=${PGID}
+DOCKER_GID=${DOCKER_GID}
+TZ=${DAGU_TZ}
+"
+
+# Check if both DOCKER_GID is not -1. This indicates the desire for a docker group
+if [ "$DOCKER_GID" != "-1" ]; then
+  if ! getent group docker >/dev/null; then
+    echo "Creating docker group with GID ${DOCKER_GID}"
+    addgroup -g ${DOCKER_GID} docker
+    usermod -a -G docker dagu
+  fi 
+
+  echo "Changing docker group GID to ${DOCKER_GID}"
+  groupmod -o -g "$DOCKER_GID" docker
+fi
+
+groupmod -o -g "$PGID" dagu
+usermod -o -u "$PUID" dagu
+
+mkdir -p /config
+
+chown $PUID:$PGID -R /config
+
+# If DAGU_HOME is not set, try to guess if the legacy /home directory is being
+# used. If so set the HOME to /home/dagu. Otherwise force the /config directory
+# as DAGU_HOME
+if [ -z "$DAGU_HOME" ]; then
+  if [ -d /home/dagu/.config/dagu ]; then
+    echo "WARNING: Using legacy /home/dagu directory. Please consider moving to /config"
+    usermod -d /home/dagu dagu
+    chown $PUID:$PGID -R /home/dagu
+  else
+    # For ease of use set DAGU_HOME to /config so all data is located in a
+    # single directory
+    export DAGU_HOME=/config
+  fi
+fi
+
+# Run all scripts in /etc/custom-init.d. It assumes that all scripts are
+# executable
+if [ -d /etc/custom-init.d ]; then
+  for f in /etc/custom-init.d/*; do
+    if [ -x "$f" ]; then
+      echo "Running $f"
+      $f
+    fi
+  done
+fi
+
+# If DOCKER_GID is not -1 set RUN_GID to DOCKER_GID otherwise set to PGID
+if [ "$DOCKER_GID" != "-1" ]; then
+  RUN_GID=$DOCKER_GID
+else
+  RUN_GID=$PGID
+fi
+
+# Run the command as the dagu user and optionally the docker group
+su-exec $PUID:$RUN_GID "$@"

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,39 +1,19 @@
-version: "3.9"
 services:
-    # init container updates permission
-    init:
-        image: "ghcr.io/dagu-org/dagu:latest"
-        user: root
-        volumes:
-            - dagu_config:/home/dagu/.config/dagu
-            - dagu_data:/home/dagu/.local/share
-        command: chown -R dagu /home/dagu/.config/dagu/ /home/dagu/.local/share
-    # ui server process
-    server:
-        image: "ghcr.io/dagu-org/dagu:latest"
-        environment:
-            - DAGU_PORT=8080
-            - DAGU_TZ=Asia/Tokyo
-        restart: unless-stopped
-        ports:
-            - "8080:8080"
-        volumes:
-            - dagu_config:/home/dagu/.config/dagu
-            - dagu_data:/home/dagu/.local/share
-        depends_on:
-            - init
-    # scheduler process
-    scheduler:
-        image: "ghcr.io/dagu-org/dagu:latest"
-        environment:
-            - DAGU_TZ=Asia/Tokyo
-        restart: unless-stopped
-        volumes:
-            - dagu_config:/home/dagu/.config/dagu
-            - dagu_data:/home/dagu/.local/share
-        command: dagu scheduler
-        depends_on:
-            - init
+  dagu:
+    image: "ghcr.io/dagu-org/dagu:latest"
+    container_name: dagu
+    hostname: dagu
+    ports:
+      - "8080:8080"
+    environment:
+      - DAGU_PORT=8080 # optional. default is 8080
+      - DAGU_TZ=Asia/Tokyo
+      - DAGU_BASE_PATH=/dagu # optional. default is /
+      - PUID=1000 # optional. default is 1000
+      - PGID=1000 # optional. default is 1000
+      - DOCKER_GID=999 # optional. default is -1 and it will be ignored
+    volumes:
+      - dagu_config:/config
+      - /var/run/docker.sock:/var/run/docker.sock # optional. required for docker in docker
 volumes:
-    dagu_config: {}
-    dagu_data: {}
+  dagu_config: {}


### PR DESCRIPTION
Closes #715 

This work significantly changes the Dockerfile and the required docker-compose.yaml configuration. 

The changes include

- Moving to a more idiomatic `/config` directory using `DAGU_HOME`. This relies on the resolver.go behavior that places all files together when `appHomeEnv` is specified. 
- Introducing an `entrypoint.sh` file that does the following
  - Sets up the docker group if DOCKER_GID is provided
  - Updates the dagu user to the provided PUID and PGID if provided
  - Tries to guess if the running container is using the previous recommended setup using `/home/dagu` inside the container - if so it uses it 
  - Otherwise sets `DAGU_HOME=/config` if DAGU_HOME is not already set 
- Runs any scripts in `/etc/custom-init.d` during boot. This can be used to install things into the container - like python, node, etc
-  Finally executes dagu using `su-exec` 

In order to test use the updated documentation. To test the "legacy" home behavior use the following compose file 

```
services:
  dagu:
    image: dagu
    container_name: dagu
    hostname: dagu
    ports:
      - "8080:8080"
    environment:
      - DOCKER_GID=970
      - DAGU_BASE_PATH=/dagu
    volumes:
      - ./test-init:/etc/custom-init.d
      - /var/run/docker.sock:/var/run/docker.sock
      - ./test-config:/home/dagu/.config/dagu
      - ./test-data:/home/dagu/.local/share
```

Where `test-config` and `test-data` map to the previous docker volume mounts. 

The "guessing" is best effort and it could be fooled, however I tried to make it as robust as I could. 

This is a pretty large change, so please feel free to try to test this as thoroughly as possible. I'm happy to make more improvements or changes before merging. 
