### PR TITLE
add support for default page

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,33 +32,34 @@ import (
 
 // Config represents the configuration for the server.
 type Config struct {
-	Host               string         // Server host
-	Port               int            // Server port
-	DAGs               string         // Location of DAG files
-	Executable         string         // Executable path
-	WorkDir            string         // Default working directory
-	IsBasicAuth        bool           // Enable basic auth
-	BasicAuthUsername  string         // Basic auth username
-	BasicAuthPassword  string         // Basic auth password
-	LogEncodingCharset string         // Log encoding charset
-	LogDir             string         // Log directory
-	DataDir            string         // Data directory
-	SuspendFlagsDir    string         // Suspend flags directory
-	AdminLogsDir       string         // Directory for admin logs
-	BaseConfig         string         // Common config file for all DAGs.
-	NavbarColor        string         // Navbar color for the web UI
-	NavbarTitle        string         // Navbar title for the web UI
-	Env                sync.Map       // Store environment variables
-	TLS                *TLS           // TLS configuration
-	IsAuthToken        bool           // Enable auth token for API
-	AuthToken          string         // Auth token for API
-	LatestStatusToday  bool           // Show latest status today or the latest status
-	BasePath           string         // Base path for the server
-	APIBaseURL         string         // Base URL for API
-	Debug              bool           // Enable debug mode (verbose logging)
-	LogFormat          string         // Log format
-	TZ                 string         // The server time zone
-	Location           *time.Location // The server location
+	Host                  string         // Server host
+	Port                  int            // Server port
+	DAGs                  string         // Location of DAG files
+	Executable            string         // Executable path
+	WorkDir               string         // Default working directory
+	IsBasicAuth           bool           // Enable basic auth
+	BasicAuthUsername     string         // Basic auth username
+	BasicAuthPassword     string         // Basic auth password
+	LogEncodingCharset    string         // Log encoding charset
+	LogDir                string         // Log directory
+	DataDir               string         // Data directory
+	SuspendFlagsDir       string         // Suspend flags directory
+	AdminLogsDir          string         // Directory for admin logs
+	BaseConfig            string         // Common config file for all DAGs.
+	NavbarColor           string         // Navbar color for the web UI
+	NavbarTitle           string         // Navbar title for the web UI
+	Env                   sync.Map       // Store environment variables
+	TLS                   *TLS           // TLS configuration
+	IsAuthToken           bool           // Enable auth token for API
+	AuthToken             string         // Auth token for API
+	LatestStatusToday     bool           // Show latest status today or the latest status
+	BasePath              string         // Base path for the server
+	APIBaseURL            string         // Base URL for API
+	Debug                 bool           // Enable debug mode (verbose logging)
+	LogFormat             string         // Log format
+	TZ                    string         // The server time zone
+	Location              *time.Location // The server location
+	MaxDashboardPageLimit int            // The default page limit for the dashboard
 }
 
 type TLS struct {
@@ -184,6 +185,7 @@ func setupViper() error {
 	viper.SetDefault("navbarTitle", "Dagu")
 	viper.SetDefault("basePath", "")
 	viper.SetDefault("apiBaseURL", "/api/v1")
+	viper.SetDefault("maxDashboardPageLimit", 100)
 
 	// Set executable path
 	// This is used for invoking the workflow process on the server.
@@ -216,6 +218,7 @@ func bindEnvs() {
 	_ = viper.BindEnv("basePath", "DAGU_BASE_PATH")
 	_ = viper.BindEnv("apiBaseURL", "DAGU_API_BASE_URL")
 	_ = viper.BindEnv("tz", "DAGU_TZ")
+	_ = viper.BindEnv("maxDashboardPageLimit", "DAGU_MAX_DASHBOARD_PAGE_LIMIT")
 
 	// Basic authentication
 	_ = viper.BindEnv("isBasicAuth", "DAGU_IS_BASICAUTH")

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -34,17 +34,17 @@ func New(cfg *config.Config, lg logger.Logger, cli client.Client) *server.Server
 	))
 
 	serverParams := server.NewServerArgs{
-		Host:        cfg.Host,
-		Port:        cfg.Port,
-		TLS:         cfg.TLS,
-		Logger:      lg,
-		Handlers:    hs,
-		AssetsFS:    assetsFS,
-		NavbarColor: cfg.NavbarColor,
-		NavbarTitle: cfg.NavbarTitle,
-		BasePath:    cfg.BasePath,
-		APIBaseURL:  cfg.APIBaseURL,
-		TimeZone:    cfg.TZ,
+		Host:                  cfg.Host,
+		Port:                  cfg.Port,
+		TLS:                   cfg.TLS,
+		Logger:                lg,
+		Handlers:              hs,
+		AssetsFS:              assetsFS,
+		NavbarColor:           cfg.NavbarColor,
+		NavbarTitle:           cfg.NavbarTitle,
+		APIBaseURL:            cfg.APIBaseURL,
+		MaxDashboardPageLimit: cfg.MaxDashboardPageLimit,
+		TimeZone:              cfg.TZ,
 	}
 
 	if cfg.IsAuthToken {

--- a/internal/frontend/server/server.go
+++ b/internal/frontend/server/server.go
@@ -60,11 +60,12 @@ type NewServerArgs struct {
 	AssetsFS  fs.FS
 
 	// Configuration for the frontend
-	NavbarColor string
-	NavbarTitle string
-	BasePath    string
-	APIBaseURL  string
-	TimeZone    string
+	NavbarColor           string
+	NavbarTitle           string
+	BasePath              string
+	APIBaseURL            string
+	TimeZone              string
+	MaxDashboardPageLimit int
 }
 
 type BasicAuth struct {
@@ -91,11 +92,12 @@ func New(params NewServerArgs) *Server {
 		handlers:  params.Handlers,
 		assets:    params.AssetsFS,
 		funcsConfig: funcsConfig{
-			NavbarColor: params.NavbarColor,
-			NavbarTitle: params.NavbarTitle,
-			BasePath:    params.BasePath,
-			APIBaseURL:  params.APIBaseURL,
-			TZ:          params.TimeZone,
+			NavbarColor:           params.NavbarColor,
+			NavbarTitle:           params.NavbarTitle,
+			BasePath:              params.BasePath,
+			APIBaseURL:            params.APIBaseURL,
+			TZ:                    params.TimeZone,
+			MaxDashboardPageLimit: params.MaxDashboardPageLimit,
 		},
 	}
 }

--- a/internal/frontend/server/templates.go
+++ b/internal/frontend/server/templates.go
@@ -55,11 +55,12 @@ func (srv *Server) useTemplate(
 }
 
 type funcsConfig struct {
-	NavbarColor string
-	NavbarTitle string
-	BasePath    string
-	APIBaseURL  string
-	TZ          string
+	NavbarColor           string
+	NavbarTitle           string
+	BasePath              string
+	APIBaseURL            string
+	TZ                    string
+	MaxDashboardPageLimit int
 }
 
 func defaultFunctions(cfg funcsConfig) template.FuncMap {
@@ -88,6 +89,9 @@ func defaultFunctions(cfg funcsConfig) template.FuncMap {
 		},
 		"tz": func() string {
 			return cfg.TZ
+		},
+		"maxDashboardPageLimit": func() int {
+			return cfg.MaxDashboardPageLimit
 		},
 	}
 }

--- a/internal/frontend/templates/base.gohtml
+++ b/internal/frontend/templates/base.gohtml
@@ -1,27 +1,28 @@
 {{define "base"}}
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>{{ navbarTitle }}</title>
-        <script>
-            function getConfig() {
-                return {
-                    apiURL: "{{ apiURL }}",
-                    basePath: "{{ basePath }}",
-                    title: "{{ navbarTitle }}",
-                    navbarColor: "{{ navbarColor }}",
-                    version: "{{ version }}",
-                    tz: "{{ tz }}",
-                };
-            }
-        </script>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ navbarTitle }}</title>
+    <script>
+      function getConfig() {
+        return {
+          apiURL: "{{ apiURL }}",
+          basePath: "{{ basePath }}",
+          title: "{{ navbarTitle }}",
+          navbarColor: "{{ navbarColor }}",
+          version: "{{ version }}",
+          tz: "{{ tz }}",
+          maxDashboardPageLimit: "{{ maxDashboardPageLimit }}",
+        };
+      }
+    </script>
         <script defer="defer" src="{{ basePath }}/assets/bundle.js?v={{ version }}"></script>
-    </head>
-    <body>
-        {{template "content" .}}
-    </body>
+  </head>
+  <body>
+    {{template "content" .}}
+  </body>
 </html>
 {{ end }}

--- a/ui/index.html
+++ b/ui/index.html
@@ -13,6 +13,7 @@
           navbarColor: '',
           version: '',
           tz: '',
+          maxDashboardPageLimit: '',
         };
       }
     </script>

--- a/ui/src/contexts/ConfigContext.tsx
+++ b/ui/src/contexts/ConfigContext.tsx
@@ -6,7 +6,8 @@ export type Config = {
   title: string;
   navbarColor: string;
   tz: string;
-  version: string;
+  version: string;  
+  maxDashboardPageLimit: number;
 };
 
 export const ConfigContext = createContext<Config>(null!);

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -23,10 +23,10 @@ for (const value in SchedulerStatus) {
 function Dashboard() {
   const [metrics, setMetrics] = React.useState<metrics>(defaultMetrics);
   const appBarContext = React.useContext(AppBarContext);
-  const { data } = useSWR<ListWorkflowsResponse>(`/dags`, null, {
+  const config = useConfig();
+  const { data } = useSWR<ListWorkflowsResponse>(`/dags?limit=${config.maxDashboardPageLimit}`, null, {
     refreshInterval: 10000,
   });
-  const config = useConfig();
 
   React.useEffect(() => {
     if (!data) {


### PR DESCRIPTION
Related to https://github.com/dagu-org/dagu/issues/721

This allows the max items returned on the dashboard page to be adjusted according to the number of DAGs.

It feels a little hacky, so open to further thoughts? 

What if we have an new API to aggregate the results? (to provide the values to the highlighted in green)
![image](https://github.com/user-attachments/assets/027d3c9a-f485-4b99-b321-3df9a4e42977)

Or we filter the results based on time? (in red, sorry for the bad drawings) eg only show those that ran "today"
