### PR TITLE
[#730] Add Remote-Node support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to d
     -   [3. Edit the DAG](#3-edit-the-dag)
     -   [4. Execute the DAG](#4-execute-the-dag)
 -   [**CLI**](#cli)
+-   [**Remote Node Management support**](#remote-node-management-support)
+    -   [Configuration](#configuration)
 -   [**Localized Documentation**](#localized-documentation)
 -   [**Documentation**](#documentation)
 -   [**Running as a daemon**](#running-as-a-daemon)
@@ -92,6 +94,10 @@ Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to d
     -   Sending emails
     -   Running jq command
     -   Executing remote commands via SSH
+-   Remote Node support for managing multiple Dagu instances:
+    -   Monitor DAGs across different environments
+    -   Switch between nodes through UI dropdown
+    -   Centralized management interface
 -   Email notification
 -   Scheduling with Cron expressions
 -   REST API Interface
@@ -253,6 +259,29 @@ dagu scheduler [--dags=<path to directory>]
 dagu version
 ```
 
+## **Remote Node Management support**
+
+Dagu supports managing multiple Dagu servers from a single UI through its remote node feature. This allows you to:
+
+-   Monitor and manage DAGs across different environments (dev, staging, prod)
+-   Access multiple Dagu instances from a centralized UI
+-   Switch between nodes easily through the UI dropdown
+
+See [Remote Node Configuration](https://dagu.readthedocs.io/en/latest/config_remote.html) for more details.
+
+### Configuration
+
+Remote nodes can be configured by creating `admin.yaml` in `$HOME/.config/dagu/`:
+
+```yaml
+# admin.yaml
+remoteNodes:
+    - name: "prod" # Name of the remote node
+      apiBaseUrl: "https://prod.example.com/api/v1" # Base URL of the remote node API
+    - name: "staging"
+      apiBaseUrl: "https://staging.example.com/api/v1"
+```
+
 ## **Localized Documentation**
 
 -   [中文文档 (Chinese Documentation)](https://dagu.readthedocs.io/zh)
@@ -289,6 +318,7 @@ dagu version
     -   [JSON Processing](https://dagu.readthedocs.io/en/latest/examples.html#querying-json-data-with-jq)
     -   [Email](https://dagu.readthedocs.io/en/latest/examples.html#sending-email)
 -   [Configurations](https://dagu.readthedocs.io/en/latest/config.html)
+-   [Remote Node](https://dagu.readthedocs.io/en/latest/config_remote.html)
 -   [Scheduler](https://dagu.readthedocs.io/en/latest/scheduler.html)
 -   [Docker Compose](https://dagu.readthedocs.io/en/latest/docker-compose.html)
 -   [REST API Documentation](https://app.swaggerhub.com/apis/YOHAMTA_1/dagu)

--- a/docs/source/config_remote.rst
+++ b/docs/source/config_remote.rst
@@ -1,0 +1,42 @@
+.. _Remote Node Configuration:
+
+Remote Node
+===========
+
+.. contents::
+    :local:
+
+Introduction
+-------------
+Dagu UI can be configured to connect to remote nodes, allowing management of DAGs across different environments from a single interface.
+
+How to configure
+----------------
+Create ``admin.yaml`` in ``$HOME/.config/dagu/`` to configure remote nodes. Example configuration:
+
+.. code-block:: yaml
+
+    # Remote Node Configuration
+    remoteNodes:
+    - name: "dev"                                # name of the remote node
+      apiBaseUrl: "http://localhost:8080/api/v1" # Base API URL of the remote node it must end with /api/v1
+
+      # Authentication settings for the remote node
+      # Basic authentication
+      isBasicAuth: true              # Enable basic auth (optional)
+      basicAuthUsername: "admin"     # Basic auth username (optional)
+      basicAuthPassword: "secret"    # Basic auth password (optional)
+
+      # api token authentication
+      isAuthToken: true              # Enable API token (optional)
+      authToken: "your-secret-token" # API token value (optional)
+
+Using Remote Nodes
+-----------------
+Once configured, remote nodes can be selected from the dropdown menu in the top right corner of the UI. This allows you to:
+
+- Switch between different environments
+- View and manage DAGs on remote nodes
+- Monitor execution status across nodes
+
+The UI will maintain all functionality while operating on the selected remote node.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,6 +44,9 @@ Quick Start
 :ref:`Configuration Options`
    Configuration options.
 
+:ref:`Remote Node Configuration`
+   Remote Node Configuration.
+
 .. toctree::
    :caption: Installation
    :hidden:
@@ -75,6 +78,7 @@ Quick Start
    :hidden:
 
    config
+   config_remote
    scheduler
    auth
    email

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagu-org/dagu
 
-go 1.22.5
+go 1.23
 
 require (
 	github.com/adrg/xdg v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagu-org/dagu
 
-go 1.23
+go 1.22.5
 
 require (
 	github.com/adrg/xdg v0.5.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ import (
 
 // Config represents the configuration for the server.
 type Config struct {
+	RemoteNodes           []RemoteNode   // Remote node API URLs (e.g., http://localhost:8080/api/v1)
 	Host                  string         // Server host
 	Port                  int            // Server port
 	DAGs                  string         // Location of DAG files
@@ -60,6 +61,18 @@ type Config struct {
 	TZ                    string         // The server time zone
 	Location              *time.Location // The server location
 	MaxDashboardPageLimit int            // The default page limit for the dashboard
+}
+
+// RemoteNode is the configuration for a remote host that can be proxied by the server.
+// This is useful for fetching data from a remote host and displaying it on the server.
+type RemoteNode struct {
+	Name              string // Name of the remote host
+	APIBaseURL        string // Base URL for the remote host API (e.g., http://localhost:9090/api/v1)
+	IsBasicAuth       bool   // Enable basic auth
+	BasicAuthUsername string // Basic auth username
+	BasicAuthPassword string // Basic auth password
+	IsAuthToken       bool   // Enable auth token for API
+	AuthToken         string // Auth token for API
 }
 
 type TLS struct {

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -30,8 +30,15 @@ func New(cfg *config.Config, lg logger.Logger, cli client.Client) *server.Server
 		&dag.NewHandlerArgs{
 			Client:             cli,
 			LogEncodingCharset: cfg.LogEncodingCharset,
+			RemoteNodes:        cfg.RemoteNodes,
+			ApiBasePath:        cfg.APIBaseURL,
 		},
 	))
+
+	var remoteNodes []string
+	for _, n := range cfg.RemoteNodes {
+		remoteNodes = append(remoteNodes, n.Name)
+	}
 
 	serverParams := server.NewServerArgs{
 		Host:                  cfg.Host,
@@ -45,6 +52,7 @@ func New(cfg *config.Config, lg logger.Logger, cli client.Client) *server.Server
 		APIBaseURL:            cfg.APIBaseURL,
 		MaxDashboardPageLimit: cfg.MaxDashboardPageLimit,
 		TimeZone:              cfg.TZ,
+		RemoteNodes:           remoteNodes,
 	}
 
 	if cfg.IsAuthToken {

--- a/internal/frontend/server/server.go
+++ b/internal/frontend/server/server.go
@@ -66,6 +66,7 @@ type NewServerArgs struct {
 	APIBaseURL            string
 	TimeZone              string
 	MaxDashboardPageLimit int
+	RemoteNodes           []string
 }
 
 type BasicAuth struct {
@@ -98,6 +99,7 @@ func New(params NewServerArgs) *Server {
 			APIBaseURL:            params.APIBaseURL,
 			TZ:                    params.TimeZone,
 			MaxDashboardPageLimit: params.MaxDashboardPageLimit,
+			RemoteNodes:           params.RemoteNodes,
 		},
 	}
 }

--- a/internal/frontend/server/templates.go
+++ b/internal/frontend/server/templates.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/dagu-org/dagu/internal/constants"
@@ -61,6 +62,7 @@ type funcsConfig struct {
 	APIBaseURL            string
 	TZ                    string
 	MaxDashboardPageLimit int
+	RemoteNodes           []string
 }
 
 func defaultFunctions(cfg funcsConfig) template.FuncMap {
@@ -92,6 +94,9 @@ func defaultFunctions(cfg funcsConfig) template.FuncMap {
 		},
 		"maxDashboardPageLimit": func() int {
 			return cfg.MaxDashboardPageLimit
+		},
+		"remoteNodes": func() string {
+			return strings.Join(cfg.RemoteNodes, ",")
 		},
 	}
 }

--- a/internal/frontend/templates/base.gohtml
+++ b/internal/frontend/templates/base.gohtml
@@ -1,28 +1,32 @@
 {{define "base"}}
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{{ navbarTitle }}</title>
-    <script>
-      function getConfig() {
-        return {
-          apiURL: "{{ apiURL }}",
-          basePath: "{{ basePath }}",
-          title: "{{ navbarTitle }}",
-          navbarColor: "{{ navbarColor }}",
-          version: "{{ version }}",
-          tz: "{{ tz }}",
-          maxDashboardPageLimit: "{{ maxDashboardPageLimit }}",
-        };
-      }
-    </script>
-        <script defer="defer" src="{{ basePath }}/assets/bundle.js?v={{ version }}"></script>
-  </head>
-  <body>
-    {{template "content" .}}
-  </body>
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>{{ navbarTitle }}</title>
+        <script>
+            function getConfig() {
+                return {
+                    apiURL: "{{ apiURL }}",
+                    basePath: "{{ basePath }}",
+                    title: "{{ navbarTitle }}",
+                    navbarColor: "{{ navbarColor }}",
+                    version: "{{ version }}",
+                    tz: "{{ tz }}",
+                    maxDashboardPageLimit: "{{ maxDashboardPageLimit }}",
+                    remoteNodes: "{{ remoteNodes }}",
+                };
+            }
+        </script>
+        <script
+            defer="defer"
+            src="{{ basePath }}/assets/bundle.js?v={{ version }}"
+        ></script>
+    </head>
+    <body>
+        {{template "content" .}}
+    </body>
 </html>
 {{ end }}

--- a/ui/index.html
+++ b/ui/index.html
@@ -14,6 +14,7 @@
           version: '',
           tz: '',
           maxDashboardPageLimit: '',
+          remoteNodes: '',
         };
       }
     </script>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,6 +19,15 @@ type Props = {
 function App({ config }: Props) {
   const [title, setTitle] = React.useState<string>('');
   config.tz ||= moment.tz.guess();
+  const remoteNodes = config.remoteNodes
+    .split(',')
+    .filter(Boolean)
+    .map((node) => node.trim());
+  if (!remoteNodes.includes('local')) {
+    remoteNodes.unshift('local');
+  }
+  const [selectedRemoteNode, setSelectedRemoteNode] =
+    React.useState<string>('local');
 
   return (
     <SWRConfig
@@ -33,6 +42,9 @@ function App({ config }: Props) {
         value={{
           title,
           setTitle,
+          remoteNodes,
+          selectedRemoteNode,
+          selectRemoteNode: setSelectedRemoteNode,
         }}
       >
         <ConfigContext.Provider value={config}>

--- a/ui/src/Layout.tsx
+++ b/ui/src/Layout.tsx
@@ -8,7 +8,7 @@ import Toolbar from '@mui/material/Toolbar';
 import List from '@mui/material/List';
 import Typography from '@mui/material/Typography';
 import { mainListItems } from './menu';
-import { Grid } from '@mui/material';
+import { Grid, MenuItem, Select } from '@mui/material';
 import { AppBarContext } from './contexts/AppBarContext';
 
 const drawerWidthClosed = 64;
@@ -137,7 +137,50 @@ function Content({ title, navbarColor, children }: DashboardContentProps) {
                   </NavBarTitleText>
                 )}
               </AppBarContext.Consumer>
-              <NavBarTitleText>{title || 'Dagu'}</NavBarTitleText>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'flex-end',
+                }}
+              >
+                <NavBarTitleText>{title || 'Dagu'}</NavBarTitleText>
+                <AppBarContext.Consumer>
+                  {(context) => {
+                    if (
+                      !context.remoteNodes ||
+                      context.remoteNodes.length === 0
+                    ) {
+                      return null;
+                    }
+                    return (
+                      <Select
+                        sx={{
+                          backgroundColor: 'white',
+                          color: 'black',
+                          borderRadius: '5px',
+                          border: '1px solid #ccc',
+                          marginLeft: '10px',
+                          height: '30px',
+                          width: '150px',
+                          marginBottom: '5px',
+                        }}
+                        value={context.selectedRemoteNode}
+                        onChange={(e) => {
+                          context.selectRemoteNode(e.target.value);
+                        }}
+                      >
+                        {context.remoteNodes.map((node) => (
+                          <MenuItem key={node} value={node}>
+                            {node}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    );
+                  }}
+                </AppBarContext.Consumer>
+              </Box>
             </Toolbar>
           </AppBar>
           <Grid

--- a/ui/src/components/molecules/CreateDAGButton.tsx
+++ b/ui/src/components/molecules/CreateDAGButton.tsx
@@ -1,7 +1,9 @@
 import { Button } from '@mui/material';
 import React from 'react';
+import { AppBarContext } from '../../contexts/AppBarContext';
 
 function CreateDAGButton() {
+  const appBarContext = React.useContext(AppBarContext);
   return (
     <Button
       variant="outlined"
@@ -22,15 +24,20 @@ function CreateDAGButton() {
           alert('File name cannot contain space');
           return;
         }
-        const resp = await fetch(`${getConfig().apiURL}/dags`, {
-          method: 'POST',
-          mode: 'cors',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            action: 'new',
-            value: name,
-          }),
-        });
+        const resp = await fetch(
+          `${getConfig().apiURL}/dags?remoteNode=${
+            appBarContext.selectedRemoteNode || 'local'
+          }`,
+          {
+            method: 'POST',
+            mode: 'cors',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              action: 'new',
+              value: name,
+            }),
+          }
+        );
         if (resp.ok) {
           window.location.href = `/dags/${name.replace(/.yaml$/, '')}/spec`;
         } else {

--- a/ui/src/components/molecules/DAGActions.tsx
+++ b/ui/src/components/molecules/DAGActions.tsx
@@ -10,6 +10,7 @@ import StartDAGModal from './StartDAGModal';
 import ConfirmModal from './ConfirmModal';
 import LabeledItem from '../atoms/LabeledItem';
 import { Workflow, WorkflowStatus } from '../../models/api';
+import { AppBarContext } from '../../contexts/AppBarContext';
 
 type LabelProps = {
   show: boolean;
@@ -39,6 +40,7 @@ function DAGActions({
   label = true,
 }: Props) {
   const nav = useNavigate();
+  const appBarContext = React.useContext(AppBarContext);
 
   const [isStartModal, setIsStartModal] = React.useState(false);
   const [isStopModal, setIsStopModal] = React.useState(false);
@@ -51,7 +53,9 @@ function DAGActions({
       requestId?: string;
       params?: string;
     }) => {
-      const url = `${getConfig().apiURL}/dags/${params.name}`;
+      const url = `${getConfig().apiURL}/dags/${params.name}?remoteNode=${
+        appBarContext.selectedRemoteNode || 'local'
+      }`;
       const ret = await fetch(url, {
         method: 'POST',
         headers: {

--- a/ui/src/components/molecules/DAGEditButtons.tsx
+++ b/ui/src/components/molecules/DAGEditButtons.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Button, Stack } from '@mui/material';
+import { AppBarContext } from '../../contexts/AppBarContext';
 
 type Props = {
   name: string;
 };
 
 function DAGEditButtons({ name }: Props) {
+  const appBarContext = React.useContext(AppBarContext);
   return (
     <Stack direction="row" spacing={1}>
       <Button
@@ -18,7 +20,9 @@ function DAGEditButtons({ name }: Props) {
             alert('DAG name cannot contain space');
             return;
           }
-          const url = `${getConfig().apiURL}/dags/${name}`;
+          const url = `${getConfig().apiURL}/dags/${name}?remoteNode=${
+            appBarContext.selectedRemoteNode || 'local'
+          }`;
           const resp = await fetch(url, {
             method: 'POST',
             headers: {

--- a/ui/src/components/molecules/LiveSwitch.tsx
+++ b/ui/src/components/molecules/LiveSwitch.tsx
@@ -1,6 +1,7 @@
 import { Switch } from '@mui/material';
 import React from 'react';
 import { WorkflowListItem } from '../../models/api';
+import { AppBarContext } from '../../contexts/AppBarContext';
 
 type Props = {
   inputProps?: React.HTMLProps<HTMLInputElement>;
@@ -9,10 +10,13 @@ type Props = {
 };
 
 function LiveSwitch({ DAG, refresh, inputProps }: Props) {
+  const appBarContext = React.useContext(AppBarContext);
   const [checked, setChecked] = React.useState(!DAG.Suspended);
   const onSubmit = React.useCallback(
     async (params: { name: string; action: string; value: string }) => {
-      const url = `${getConfig().apiURL}/dags/${params.name}`;
+      const url = `${getConfig().apiURL}/dags/${params.name}?remoteNode=${
+        appBarContext.selectedRemoteNode || 'local'
+      }`;
       const ret = await fetch(url, {
         method: 'POST',
         mode: 'cors',

--- a/ui/src/components/organizations/DAGSpec.tsx
+++ b/ui/src/components/organizations/DAGSpec.tsx
@@ -18,12 +18,14 @@ import {
   faXmark,
   faPenToSquare,
 } from '@fortawesome/free-solid-svg-icons';
+import { AppBarContext } from '../../contexts/AppBarContext';
 
 type Props = {
   data: GetDAGResponse;
 };
 
 function DAGSpec({ data }: Props) {
+  const appBarContext = React.useContext(AppBarContext);
   const [editing, setEditing] = React.useState(false);
   const [currentValue, setCurrentValue] = React.useState(data.Definition);
   const handlers = getHandlers(data.DAG?.DAG);
@@ -133,6 +135,8 @@ function DAGSpec({ data }: Props) {
                         onClick={async () => {
                           const url = `${getConfig().apiURL}/dags/${
                             props.name
+                          }?remoteNode=${
+                            appBarContext.selectedRemoteNode || 'local'
                           }`;
                           const resp = await fetch(url, {
                             method: 'POST',

--- a/ui/src/contexts/AppBarContext.ts
+++ b/ui/src/contexts/AppBarContext.ts
@@ -3,11 +3,19 @@ import React from 'react';
 type AppBarContextType = {
   title: string;
   setTitle(val: string): void;
+  remoteNodes: string[];
+  selectedRemoteNode: string;
+  selectRemoteNode(val: string): void;
 };
 
 export const AppBarContext = React.createContext<AppBarContextType>({
   title: '',
   setTitle: () => {
+    return;
+  },
+  selectedRemoteNode: '',
+  remoteNodes: [],
+  selectRemoteNode: () => {
     return;
   },
 });

--- a/ui/src/contexts/ConfigContext.tsx
+++ b/ui/src/contexts/ConfigContext.tsx
@@ -8,6 +8,7 @@ export type Config = {
   tz: string;
   version: string;  
   maxDashboardPageLimit: number;
+  remoteNodes: string;
 };
 
 export const ConfigContext = createContext<Config>(null!);

--- a/ui/src/hooks/useDAGPostAPI.ts
+++ b/ui/src/hooks/useDAGPostAPI.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AppBarContext } from '../contexts/AppBarContext';
 
 type Options = {
   name: string;
@@ -8,9 +9,12 @@ type Options = {
 };
 
 export function useDAGPostAPI(opts: Options) {
+  const appBarContext = React.useContext(AppBarContext);
   const doPost = React.useCallback(
     async (action: string, step?: string) => {
-      const url = `${getConfig().apiURL}/dags/${opts.name}`;
+      const url = `${getConfig().apiURL}/dags/${opts.name}?remoteNode=${
+        appBarContext.selectedRemoteNode || 'local'
+      }`;
       const ret = await fetch(url, {
         method: 'POST',
         mode: 'cors',

--- a/ui/src/pages/dags/dag/index.tsx
+++ b/ui/src/pages/dags/dag/index.tsx
@@ -31,7 +31,7 @@ function DAGDetails() {
   const { data, isValidating, mutate } = useSWR<GetDAGResponse>(
     `/dags/${params.name}?tab=${params.tab ?? ''}&${new URLSearchParams(
       window.location.search
-    ).toString()}`,
+    ).toString()}&remoteNode=${appBarContext.selectedRemoteNode || 'local'}`,
     null,
     {
       refreshInterval: 2000,

--- a/ui/src/pages/dags/index.tsx
+++ b/ui/src/pages/dags/index.tsx
@@ -41,6 +41,7 @@ function DAGs() {
     limit: preferences.pageLimit.toString(),
     searchName: apiSearchText,
     searchTag: apiSearchTag,
+    remoteNode: appBarContext.selectedRemoteNode || 'local',
   }).toString()}`;
   const { data } = useSWR<ListWorkflowsResponse>(endPoint, null, {
     refreshInterval: 10000,

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -24,9 +24,15 @@ function Dashboard() {
   const [metrics, setMetrics] = React.useState<metrics>(defaultMetrics);
   const appBarContext = React.useContext(AppBarContext);
   const config = useConfig();
-  const { data } = useSWR<ListWorkflowsResponse>(`/dags?limit=${config.maxDashboardPageLimit}`, null, {
-    refreshInterval: 10000,
-  });
+  const { data } = useSWR<ListWorkflowsResponse>(
+    `/dags?limit=${config.maxDashboardPageLimit}&remoteNode=${
+      appBarContext.selectedRemoteNode || 'local'
+    }`,
+    null,
+    {
+      refreshInterval: 10000,
+    }
+  );
 
   React.useEffect(() => {
     if (!data) {

--- a/ui/src/pages/search/index.tsx
+++ b/ui/src/pages/search/index.tsx
@@ -6,13 +6,17 @@ import Title from '../../components/atoms/Title';
 import { GetSearchResponse } from '../../models/api';
 import SearchResult from '../../components/molecules/SearchResult';
 import LoadingIndicator from '../../components/atoms/LoadingIndicator';
+import { AppBarContext } from '../../contexts/AppBarContext';
 
 function Search() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchVal, setSearchVal] = React.useState(searchParams.get('q') || '');
+  const appBarContext = React.useContext(AppBarContext);
 
   const { data, error } = useSWR<GetSearchResponse>(
-    `/search?q=${searchParams.get('q') || ''}`
+    `/search?q=${searchParams.get('q') || ''}&remoteNode=${
+      appBarContext.selectedRemoteNode || 'local'
+    }`
   );
   const ref = useRef<HTMLInputElement>(null);
 
@@ -69,30 +73,31 @@ function Search() {
         </Stack>
 
         <Box mt={2}>
-          {
-            (() => {
-              if (!data && !error) {
-                return <LoadingIndicator />;
-              }
+          {(() => {
+            if (!data && !error) {
+              return <LoadingIndicator />;
+            }
 
-              if (data && data.Results && data.Results.length > 0) {
-                return (
-                  <Box>
-                    <Typography variant="h6" style={{ fontStyle: 'bolder' }}>
-                      {data.Results.length} results found
-                    </Typography>
-                    <SearchResult results={data?.Results} />
-                  </Box>
-                );
-              }
+            if (data && data.Results && data.Results.length > 0) {
+              return (
+                <Box>
+                  <Typography variant="h6" style={{ fontStyle: 'bolder' }}>
+                    {data.Results.length} results found
+                  </Typography>
+                  <SearchResult results={data?.Results} />
+                </Box>
+              );
+            }
 
-              if ((data && !data.Results) || (data && data.Results && data.Results.length === 0)) {
-                return <Box>No results found</Box>;
-              }
+            if (
+              (data && !data.Results) ||
+              (data && data.Results && data.Results.length === 0)
+            ) {
+              return <Box>No results found</Box>;
+            }
 
-              return null
-            })()
-          }
+            return null;
+          })()}
         </Box>
       </Grid>
     </Grid>


### PR DESCRIPTION
Resolves #730 

This PR implements support for managing multiple Dagu instances from a single UI, allowing users to monitor and control DAGs across different environments through a centralized interface.

**Changes**
- Add request proxying to support remote Dagu instances
- Implement remote node configuration via admin.yaml
- Add UI dropdown for instance selection
- Add documentation for setup

**Configuration Example**
```yaml
# admin.yaml
remoteNodes:
  - name: "dev"                                # name of the remote node
    apiBaseUrl: "http://localhost:8080/api/v1" # Base API URL of the remote node it must end with /api/v1
  
    # Authentication settings for the remote node
    # Basic authentication
    isBasicAuth: true              # Enable basic auth (optional)
    basicAuthUsername: "admin"     # Basic auth username (optional)
    basicAuthPassword: "secret"    # Basic auth password (optional)
  
    # api token authentication
    isAuthToken: true              # Enable API token (optional)
    authToken: "your-secret-token" # API token value (optional)
``` 