### PR TITLE
[#736] add TLS skip verification option for remote node

### DIFF
--- a/docs/source/config_remote.rst
+++ b/docs/source/config_remote.rst
@@ -31,6 +31,9 @@ Create ``admin.yaml`` in ``$HOME/.config/dagu/`` to configure remote nodes. Exam
       isAuthToken: true              # Enable API token (optional)
       authToken: "your-secret-token" # API token value (optional)
 
+      # TLS settings
+      skipTLSVerify: false           # Skip TLS verification (optional)
+
 Using Remote Nodes
 -----------------
 Once configured, remote nodes can be selected from the dropdown menu in the top right corner of the UI. This allows you to:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,7 @@ type RemoteNode struct {
 	BasicAuthPassword string // Basic auth password
 	IsAuthToken       bool   // Enable auth token for API
 	AuthToken         string // Auth token for API
+	SkipTLSVerify     bool   // Skip TLS verification
 }
 
 type TLS struct {


### PR DESCRIPTION
Add `skipTLSVerify` configuration option for remote nodes that allows users to control TLS certificate verification on a per-node basis.

Example configuration:
```yaml
remoteNodes:
  - name: "DEV"
    apiBaseUrl: "https://dev-server:8443/api/v1"
    isAuthToken: true
    authToken: "..."
    skipTLSVerify: true  # Skip TLS verification for this node
```