### PR TITLE
feat!: Use shell for running command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,19 @@
 
 Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to define dependencies between commands as a [Directed Acyclic Graph (DAG)](https://en.wikipedia.org/wiki/Directed_acyclic_graph) in a declarative [YAML format](https://dagu.readthedocs.io/en/latest/yaml_format.html). Dagu simplifies the management and execution of complex workflows. It natively supports running Docker containers, making HTTP requests, and executing commands over SSH.
 
--   [Documentation](https://dagu.readthedocs.io)
--   [Localized Documentation](#localized-documentation)
--   [Discord Community](https://discord.gg/gpahPUjGRk)
+- **Check out our** [Documentation](https://dagu.readthedocs.io)
+- **Join our** [Discord Community](https://discord.gg/gpahPUjGRk)
+- **Explore** [Quick Start Guide](https://dagu.readthedocs.io/en/latest/quickstart.html)
+
+---
 
 ## **Highlights**
 
--   Single binary file installation
--   Declarative YAML format for defining DAGs
--   Web UI for visually managing, rerunning, and monitoring pipelines
--   Use existing programs without any modification
--   Self-contained, with no need for a DBMS
+- Single binary file installation
+- Declarative YAML format for defining DAGs
+- Web UI for visually managing, rerunning, and monitoring pipelines
+- Use existing programs without any modification
+- Self-contained, with no need for a DBMS
 
 ## **Table of Contents**
 
@@ -67,8 +69,10 @@ Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to d
   - [Configuration](#configuration)
 - [**Localized Documentation**](#localized-documentation)
 - [**Documentation**](#documentation)
-- [**Running as a daemon**](#running-as-a-daemon)
 - [**Example DAG**](#example-dag)
+  - [Minimum examples](#minimum-examples)
+  - [Complex example](#complex-example)
+- [**Running as a daemon**](#running-as-a-daemon)
 - [**Motivation**](#motivation)
 - [**Why Not Use an Existing DAG Scheduler Like Airflow?**](#why-not-use-an-existing-dag-scheduler-like-airflow)
 - [**How It Works**](#how-it-works)
@@ -77,82 +81,83 @@ Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to d
 
 ## **Features**
 
--   Web User Interface
--   Command Line Interface (CLI) with several commands for running and managing DAGs
--   YAML format for defining DAGs, with support for various features including:
-    -   Execution of custom code snippets
-    -   Parameters
-    -   Command substitution
-    -   Conditional logic
-    -   Redirection of stdout and stderr
-    -   Lifecycle hooks
-    -   Repeating task
-    -   Automatic retry
--   Executors for running different types of tasks:
-    -   Running arbitrary Docker containers
-    -   Making HTTP requests
-    -   Sending emails
-    -   Running jq command
-    -   Executing remote commands via SSH
--   Remote Node support for managing multiple Dagu instances:
-    -   Monitor DAGs across different environments
-    -   Switch between nodes through UI dropdown
-    -   Centralized management interface
--   Email notification
--   Scheduling with Cron expressions
--   REST API Interface
--   Basic Authentication over HTTPS
+- Web User Interface
+- Command Line Interface (CLI) with several commands for running and managing DAGs
+- YAML format for defining DAGs, with support for various features including:
+  - Execution of custom code snippets
+  - Parameters
+  - Command substitution
+  - Conditional logic
+  - Redirection of stdout and stderr
+  - Lifecycle hooks
+  - Repeating task
+  - Automatic retry
+- Executors for running different types of tasks:
+  - Running arbitrary Docker containers
+  - Making HTTP requests
+  - Sending emails
+  - Running jq command
+  - Executing remote commands via SSH
+- Remote Node support for managing multiple Dagu instances:
+  - Monitor DAGs across different environments
+  - Switch between nodes through UI dropdown
+  - Centralized management interface
+- Email notification
+- Scheduling with Cron expressions
+- REST API Interface
+- Basic Authentication over HTTPS
 
 ## **Use Cases**
 
--   **Data Pipeline Automation:** Schedule ETL tasks for data processing and centralization.
--   **Infrastructure Monitoring:** Periodically check infrastructure components with HTTP requests or SSH commands.
--   **Automated Reporting:** Generate and send periodic reports via email.
--   **Batch Processing:** Schedule batch jobs for tasks like data cleansing or model training.
--   **Task Dependency Management:** Manage complex workflows with interdependent tasks.
--   **Microservices Orchestration:** Define and manage dependencies between microservices.
--   **CI/CD Integration:** Automate code deployment, testing, and environment updates.
--   **Alerting System:** Create notifications based on specific triggers or conditions.
--   **Custom Task Automation:** Define and schedule custom tasks using code snippets.
+- **Data Pipeline Automation**: Schedule ETL tasks for data processing
+- **Infrastructure Monitoring**: Periodic health checks via HTTP or SSH
+- **Automated Reporting**: Generate and send routine email reports
+- **Batch Processing**: Automate data cleansing, model training, etc.
+- **Task Dependency Management**: Handle interdependent processes seamlessly
+- **Microservices Orchestration**: Manage and monitor microservice dependencies
+- **CI/CD Integration**: Automate code deployment and testing
+- **Alerting System**: Trigger notifications upon specific conditions
+- **Custom Task Automation**: Run arbitrary scripts or commands with ease
 
 ## **Web UI**
 
 ### DAG Details
 
-It shows the real-time status, logs, and DAG configurations. You can edit DAG configurations on a browser.
+Real-time statuses, logs, and configuration details for each DAG. Easily edit configurations in your browser.
 
 ![example](assets/images/demo.gif?raw=true)
 
-You can switch to the vertical graph with the button on the top right corner.
+Switch graph orientation with the toggle button at the top-right corner:
 
 ![Details-TD](assets/images/ui-details2.webp?raw=true)
 
 ### DAGs
 
-It shows all DAGs and the real-time status.
+View all DAGs in one place with live status updates.
 
 ![DAGs](assets/images/ui-dags.webp?raw=true)
 
 ### Search
 
-It greps given text across all DAG definitions.
+Search across all DAG definitions.
+
 ![History](assets/images/ui-search.webp?raw=true)
 
 ### Execution History
 
-It shows past execution results and logs.
+Review past DAG executions and logs at a glance.
 
 ![History](assets/images/ui-history.webp?raw=true)
 
 ### Log Viewer
 
-It shows the detail log and standard output of each execution and step.
+Examine detailed step-level logs and outputs.
 
 ![DAG Log](assets/images/ui-logoutput.webp?raw=true)
 
 ## **Installation**
 
-You can install Dagu quickly using Homebrew or by downloading the latest binary from the Releases page on GitHub.
+Dagu can be installed in multiple ways, such as using Homebrew or downloading a single binary from GitHub releases.
 
 ### Via Bash script
 
@@ -213,12 +218,12 @@ Example:
 ```yaml
 schedule: "* * * * *" # Run the DAG every minute
 steps:
-    - name: s1
-      command: echo Hello Dagu
-    - name: s2
-      command: echo done!
-      depends:
-          - s1
+  - name: s1
+    command: echo Hello Dagu
+  - name: s2
+    command: echo done!
+    depends:
+      - s1
 ```
 
 ### 4. Execute the DAG
@@ -263,9 +268,9 @@ dagu version
 
 Dagu supports managing multiple Dagu servers from a single UI through its remote node feature. This allows you to:
 
--   Monitor and manage DAGs across different environments (dev, staging, prod)
--   Access multiple Dagu instances from a centralized UI
--   Switch between nodes easily through the UI dropdown
+- Monitor and manage DAGs across different environments (dev, staging, prod)
+- Access multiple Dagu instances from a centralized UI
+- Switch between nodes easily through the UI dropdown
 
 See [Remote Node Configuration](https://dagu.readthedocs.io/en/latest/config_remote.html) for more details.
 
@@ -276,52 +281,165 @@ Remote nodes can be configured by creating `admin.yaml` in `$HOME/.config/dagu/`
 ```yaml
 # admin.yaml
 remoteNodes:
-    - name: "prod" # Name of the remote node
-      apiBaseUrl: "https://prod.example.com/api/v1" # Base URL of the remote node API
-    - name: "staging"
-      apiBaseUrl: "https://staging.example.com/api/v1"
+  - name: "prod" # Name of the remote node
+    apiBaseUrl: "https://prod.example.com/api/v1" # Base URL of the remote node API
+  - name: "staging"
+    apiBaseUrl: "https://staging.example.com/api/v1"
 ```
 
 ## **Localized Documentation**
 
--   [中文文档 (Chinese Documentation)](https://dagu.readthedocs.io/zh)
--   [日本語ドキュメント (Japanese Documentation)](https://dagu.readthedocs.io/ja)
+- [中文文档 (Chinese Documentation)](https://dagu.readthedocs.io/zh)
+- [日本語ドキュメント (Japanese Documentation)](https://dagu.readthedocs.io/ja)
 
 ## **Documentation**
 
--   [Installation Instructions](https://dagu.readthedocs.io/en/latest/installation.html)
--   ️[Quick Start Guide](https://dagu.readthedocs.io/en/latest/quickstart.html)
--   [Command Line Interface](https://dagu.readthedocs.io/en/latest/cli.html)
--   [Web User Interface](https://dagu.readthedocs.io/en/latest/web_interface.html)
--   Writing DAG
-    -   [Minimal DAG Definition](https://dagu.readthedocs.io/en/latest/yaml_format.html#minimal-dag-definition)
-    -   [Running Arbitrary Code Snippets](https://dagu.readthedocs.io/en/latest/yaml_format.html#running-arbitrary-code-snippets)
-    -   [Environment Variables](https://dagu.readthedocs.io/en/latest/yaml_format.html#defining-environment-variables)
-    -   [Parameters](https://dagu.readthedocs.io/en/latest/yaml_format.html#defining-and-using-parameters)
-    -   [Command Substitution](https://dagu.readthedocs.io/en/latest/yaml_format.html#using-command-substitution)
-    -   [Conditional Logic](https://dagu.readthedocs.io/en/latest/yaml_format.html#adding-conditional-logic)
-    -   [Environment Variables with Standard Output](https://dagu.readthedocs.io/en/latest/yaml_format.html#setting-environment-variables-with-standard-output)
-    -   [Redirecting Stdout and Stderr](https://dagu.readthedocs.io/en/latest/yaml_format.html#redirecting-stdout-and-stderr)
-    -   [Lifecycle Hooks](https://dagu.readthedocs.io/en/latest/yaml_format.html#adding-lifecycle-hooks)
-    -   [Repeating Task](https://dagu.readthedocs.io/en/latest/yaml_format.html#repeating-a-task-at-regular-intervals)
-    -   [Minimal DAG Definition](https://dagu.readthedocs.io/en/latest/yaml_format.html#minimal-dag-definition)
-    -   [Running Sub-DAG](https://dagu.readthedocs.io/en/latest/yaml_format.html#running-sub-dag)
-    -   [All Available Fields for a DAG](https://dagu.readthedocs.io/en/latest/yaml_format.html#all-available-fields-for-dags)
-    -   [All Available Fields for a Step](https://dagu.readthedocs.io/en/latest/yaml_format.html#all-available-fields-for-steps)
--   Example DAGs
-    -   [Hello World](https://dagu.readthedocs.io/en/latest/examples.html#hello-world)
-    -   [Conditional Steps](https://dagu.readthedocs.io/en/latest/examples.html#conditional-steps)
-    -   [File Output](https://dagu.readthedocs.io/en/latest/examples.html#file-output)
-    -   [Passing Output to Next Step](https://dagu.readthedocs.io/en/latest/examples.html#passing-output-to-next-step)
-    -   [Running a Container Image](https://dagu.readthedocs.io/en/latest/examples.html#running-a-docker-container)
-    -   [Making HTTP Requests](https://dagu.readthedocs.io/en/latest/examples.html#sending-http-requests)
-    -   [JSON Processing](https://dagu.readthedocs.io/en/latest/examples.html#querying-json-data-with-jq)
-    -   [Email](https://dagu.readthedocs.io/en/latest/examples.html#sending-email)
--   [Configurations](https://dagu.readthedocs.io/en/latest/config.html)
--   [Remote Node](https://dagu.readthedocs.io/en/latest/config_remote.html)
--   [Scheduler](https://dagu.readthedocs.io/en/latest/scheduler.html)
--   [Docker Compose](https://dagu.readthedocs.io/en/latest/docker-compose.html)
--   [REST API Documentation](https://app.swaggerhub.com/apis/YOHAMTA_1/dagu)
+- [Installation Instructions](https://dagu.readthedocs.io/en/latest/installation.html)
+- ️[Quick Start Guide](https://dagu.readthedocs.io/en/latest/quickstart.html)
+- [Command Line Interface](https://dagu.readthedocs.io/en/latest/cli.html)
+- [Web User Interface](https://dagu.readthedocs.io/en/latest/web_interface.html)
+- Writing DAG
+  - [Minimal DAG Definition](https://dagu.readthedocs.io/en/latest/yaml_format.html#minimal-dag-definition)
+  - [Running Arbitrary Code Snippets](https://dagu.readthedocs.io/en/latest/yaml_format.html#running-arbitrary-code-snippets)
+  - [Environment Variables](https://dagu.readthedocs.io/en/latest/yaml_format.html#defining-environment-variables)
+  - [Parameters](https://dagu.readthedocs.io/en/latest/yaml_format.html#defining-and-using-parameters)
+  - [Command Substitution](https://dagu.readthedocs.io/en/latest/yaml_format.html#using-command-substitution)
+  - [Conditional Logic](https://dagu.readthedocs.io/en/latest/yaml_format.html#adding-conditional-logic)
+  - [Environment Variables with Standard Output](https://dagu.readthedocs.io/en/latest/yaml_format.html#setting-environment-variables-with-standard-output)
+  - [Redirecting Stdout and Stderr](https://dagu.readthedocs.io/en/latest/yaml_format.html#redirecting-stdout-and-stderr)
+  - [Lifecycle Hooks](https://dagu.readthedocs.io/en/latest/yaml_format.html#adding-lifecycle-hooks)
+  - [Repeating Task](https://dagu.readthedocs.io/en/latest/yaml_format.html#repeating-a-task-at-regular-intervals)
+  - [Running Sub-DAG](https://dagu.readthedocs.io/en/latest/yaml_format.html#running-sub-dag)
+  - [All Available Fields for a DAG](https://dagu.readthedocs.io/en/latest/yaml_format.html#all-available-fields-for-dags)
+  - [All Available Fields for a Step](https://dagu.readthedocs.io/en/latest/yaml_format.html#all-available-fields-for-steps)
+- Example DAGs
+  - [Hello World](https://dagu.readthedocs.io/en/latest/examples.html#hello-world)
+  - [Conditional Steps](https://dagu.readthedocs.io/en/latest/examples.html#conditional-steps)
+  - [File Output](https://dagu.readthedocs.io/en/latest/examples.html#file-output)
+  - [Passing Output to Next Step](https://dagu.readthedocs.io/en/latest/examples.html#passing-output-to-next-step)
+  - [Running a Container Image](https://dagu.readthedocs.io/en/latest/examples.html#running-a-docker-container)
+  - [Making HTTP Requests](https://dagu.readthedocs.io/en/latest/examples.html#sending-http-requests)
+  - [JSON Processing](https://dagu.readthedocs.io/en/latest/examples.html#querying-json-data-with-jq)
+  - [Email](https://dagu.readthedocs.io/en/latest/examples.html#sending-email)
+- [Configurations](https://dagu.readthedocs.io/en/latest/config.html)
+- [Remote Node](https://dagu.readthedocs.io/en/latest/config_remote.html)
+- [Scheduler](https://dagu.readthedocs.io/en/latest/scheduler.html)
+- [Docker Compose](https://dagu.readthedocs.io/en/latest/docker-compose.html)
+- [REST API Documentation](https://app.swaggerhub.com/apis/YOHAMTA_1/dagu)
+
+## **Example DAG**
+
+### Minimum examples
+
+A DAG with two steps:
+
+```yaml
+steps:
+  - name: step 1
+    command: echo hello
+  - name: step 2
+    command: echo world
+    depends:
+      - step 1
+```
+
+Using a pipe:
+
+```yaml
+steps:
+  - name: step 1
+    command: echo hello world | xargs echo
+```
+
+Specifying a shell:
+
+```yaml
+steps:
+  - name: step 1
+    command: echo hello world | xargs echo
+    shell: bash
+```
+
+Note: The default shell is `$SHELL` or `sh`.
+
+### Complex example
+
+A typical data pipeline for DevOps/Data Engineering scenarios:
+
+![Details-TD](assets/images/example.webp?raw=true)
+
+The YAML code below represents this DAG:
+
+```yaml
+# Environment variables used throughout the pipeline
+env:
+  - DATA_DIR: /data
+  - SCRIPT_DIR: /scripts
+  - LOG_DIR: /log
+  # ... other variables can be added here
+
+# Handlers to manage errors and cleanup after execution
+handlerOn:
+  failure:
+    command: "echo error"
+  exit:
+    command: "echo clean up"
+
+# The schedule for the DAG execution in cron format
+# This schedule runs the DAG daily at 12:00 AM
+schedule: "0 0 * * *"
+
+steps:
+  # Step 1: Pull the latest data from a data source
+  - name: pull_data
+    command: "sh"
+    script: |
+      echo `date '+%Y-%m-%d'`
+    output: DATE
+
+  # Step 2: Cleanse and prepare the data
+  - name: cleanse_data
+    command: echo cleansing ${DATA_DIR}/${DATE}.csv
+    depends:
+      - pull_data
+
+  # Step 3: Transform the data
+  - name: transform_data
+    command: echo transforming ${DATA_DIR}/${DATE}_clean.csv
+    depends:
+      - cleanse_data
+
+  # Parallel Step 1: Load the data into a database
+  - name: load_data
+    command: echo loading ${DATA_DIR}/${DATE}_transformed.csv
+    depends:
+      - transform_data
+
+  # Parallel Step 2: Generate a statistical report
+  - name: generate_report
+    command: echo generating report ${DATA_DIR}/${DATE}_transformed.csv
+    depends:
+      - transform_data
+
+  # Step 4: Run some analytics
+  - name: run_analytics
+    command: echo running analytics ${DATA_DIR}/${DATE}_transformed.csv
+    depends:
+      - load_data
+
+  # Step 5: Send an email report
+  - name: send_report
+    command: echo sending email ${DATA_DIR}/${DATE}_analytics.csv
+    depends:
+      - run_analytics
+      - generate_report
+
+  # Step 6: Cleanup temporary files
+  - name: cleanup
+    command: echo removing ${DATE}*.csv
+    depends:
+      - send_report
+```
 
 ## **Running as a daemon**
 
@@ -340,117 +458,6 @@ else
 fi
 
 exit
-```
-
-## **Example DAG**
-
-**Minimum examples**
-
-A DAG consists of one or more steps, each with a name and command. Here's the simplest possible DAG:
-
-```yaml
-steps:
-  - name: step 1
-    command: echo hello
-  - name: step 2
-    command: echo world
-    depends:
-      - step 1
-```
-
-You can use pipe for running the command.
-
-```yaml
-steps:
-  - name: step 1
-    command: echo hello world | xargs echo
-```
-
-You can specify shell for running the command. If not specified, the `$SHELL` will be used.
-
-```yaml
-steps:
-  - name: step 1
-    command: echo hello world | xargs echo
-    shell: bash
-```
-
-**More complex one**
-This example DAG showcases a data pipeline typically implemented in DevOps and Data Engineering scenarios. It demonstrates an end-to-end data processing cycle starting from data acquisition and cleansing to transformation, loading, analysis, reporting, and ultimately, cleanup.
-
-![Details-TD](assets/images/example.webp?raw=true)
-
-The YAML code below represents this DAG:
-
-```yaml
-# Environment variables used throughout the pipeline
-env:
-    - DATA_DIR: /data
-    - SCRIPT_DIR: /scripts
-    - LOG_DIR: /log
-    # ... other variables can be added here
-
-# Handlers to manage errors and cleanup after execution
-handlerOn:
-    failure:
-        command: "echo error"
-    exit:
-        command: "echo clean up"
-
-# The schedule for the DAG execution in cron format
-# This schedule runs the DAG daily at 12:00 AM
-schedule: "0 0 * * *"
-
-steps:
-    # Step 1: Pull the latest data from a data source
-    - name: pull_data
-      command: "sh"
-      script: |
-          echo `date '+%Y-%m-%d'`
-      output: DATE
-
-    # Step 2: Cleanse and prepare the data
-    - name: cleanse_data
-      command: echo cleansing ${DATA_DIR}/${DATE}.csv
-      depends:
-          - pull_data
-
-    # Step 3: Transform the data
-    - name: transform_data
-      command: echo transforming ${DATA_DIR}/${DATE}_clean.csv
-      depends:
-          - cleanse_data
-
-    # Parallel Step 1: Load the data into a database
-    - name: load_data
-      command: echo loading ${DATA_DIR}/${DATE}_transformed.csv
-      depends:
-          - transform_data
-
-    # Parallel Step 2: Generate a statistical report
-    - name: generate_report
-      command: echo generating report ${DATA_DIR}/${DATE}_transformed.csv
-      depends:
-          - transform_data
-
-    # Step 4: Run some analytics
-    - name: run_analytics
-      command: echo running analytics ${DATA_DIR}/${DATE}_transformed.csv
-      depends:
-          - load_data
-
-    # Step 5: Send an email report
-    - name: send_report
-      command: echo sending email ${DATA_DIR}/${DATE}_analytics.csv
-      depends:
-          - run_analytics
-          - generate_report
-
-    # Step 6: Cleanup temporary files
-    - name: cleanup
-      command: echo removing ${DATE}*.csv
-      depends:
-          - send_report
 ```
 
 ## **Motivation**

--- a/README.md
+++ b/README.md
@@ -42,38 +42,38 @@ Dagu is a powerful Cron alternative that comes with a Web UI. It allows you to d
 
 ## **Table of Contents**
 
--   [**Highlights**](#highlights)
--   [**Table of Contents**](#table-of-contents)
--   [**Features**](#features)
--   [**Use Cases**](#use-cases)
--   [**Web UI**](#web-ui)
-    -   [DAG Details](#dag-details)
-    -   [DAGs](#dags)
-    -   [Search](#search)
-    -   [Execution History](#execution-history)
-    -   [Log Viewer](#log-viewer)
--   [**Installation**](#installation)
-    -   [Via Bash script](#via-bash-script)
-    -   [Via GitHub Releases Page](#via-github-releases-page)
-    -   [Via Homebrew (macOS)](#via-homebrew-macos)
-    -   [Via Docker](#via-docker)
--   [**Quick Start Guide**](#quick-start-guide)
-    -   [1. Launch the Web UI](#1-launch-the-web-ui)
-    -   [2. Create a New DAG](#2-create-a-new-dag)
-    -   [3. Edit the DAG](#3-edit-the-dag)
-    -   [4. Execute the DAG](#4-execute-the-dag)
--   [**CLI**](#cli)
--   [**Remote Node Management support**](#remote-node-management-support)
-    -   [Configuration](#configuration)
--   [**Localized Documentation**](#localized-documentation)
--   [**Documentation**](#documentation)
--   [**Running as a daemon**](#running-as-a-daemon)
--   [**Example DAG**](#example-dag)
--   [**Motivation**](#motivation)
--   [**Why Not Use an Existing DAG Scheduler Like Airflow?**](#why-not-use-an-existing-dag-scheduler-like-airflow)
--   [**How It Works**](#how-it-works)
--   [**License**](#license)
--   [**Support and Community**](#support-and-community)
+- [**Highlights**](#highlights)
+- [**Table of Contents**](#table-of-contents)
+- [**Features**](#features)
+- [**Use Cases**](#use-cases)
+- [**Web UI**](#web-ui)
+  - [DAG Details](#dag-details)
+  - [DAGs](#dags)
+  - [Search](#search)
+  - [Execution History](#execution-history)
+  - [Log Viewer](#log-viewer)
+- [**Installation**](#installation)
+  - [Via Bash script](#via-bash-script)
+  - [Via GitHub Releases Page](#via-github-releases-page)
+  - [Via Homebrew (macOS)](#via-homebrew-macos)
+  - [Via Docker](#via-docker)
+- [**Quick Start Guide**](#quick-start-guide)
+  - [1. Launch the Web UI](#1-launch-the-web-ui)
+  - [2. Create a New DAG](#2-create-a-new-dag)
+  - [3. Edit the DAG](#3-edit-the-dag)
+  - [4. Execute the DAG](#4-execute-the-dag)
+- [**CLI**](#cli)
+- [**Remote Node Management support**](#remote-node-management-support)
+  - [Configuration](#configuration)
+- [**Localized Documentation**](#localized-documentation)
+- [**Documentation**](#documentation)
+- [**Running as a daemon**](#running-as-a-daemon)
+- [**Example DAG**](#example-dag)
+- [**Motivation**](#motivation)
+- [**Why Not Use an Existing DAG Scheduler Like Airflow?**](#why-not-use-an-existing-dag-scheduler-like-airflow)
+- [**How It Works**](#how-it-works)
+- [**License**](#license)
+- [**Support and Community**](#support-and-community)
 
 ## **Features**
 
@@ -344,6 +344,38 @@ exit
 
 ## **Example DAG**
 
+**Minimum examples**
+
+A DAG consists of one or more steps, each with a name and command. Here's the simplest possible DAG:
+
+```yaml
+steps:
+  - name: step 1
+    command: echo hello
+  - name: step 2
+    command: echo world
+    depends:
+      - step 1
+```
+
+You can use pipe for running the command.
+
+```yaml
+steps:
+  - name: step 1
+    command: echo hello world | xargs echo
+```
+
+You can specify shell for running the command. If not specified, the `$SHELL` will be used.
+
+```yaml
+steps:
+  - name: step 1
+    command: echo hello world | xargs echo
+    shell: bash
+```
+
+**More complex one**
 This example DAG showcases a data pipeline typically implemented in DevOps and Data Engineering scenarios. It demonstrates an end-to-end data processing cycle starting from data acquisition and cleansing to transformation, loading, analysis, reporting, and ultimately, cleanup.
 
 ![Details-TD](assets/images/example.webp?raw=true)

--- a/docs/source/yaml_format.rst
+++ b/docs/source/yaml_format.rst
@@ -16,7 +16,7 @@ Before diving into specific features, let's understand the basic structure of a 
 
 Minimal Example
 ~~~~~~~~~~~~~~
-A DAG consists of one or more steps, each with a name and command. Here's the simplest possible DAG:
+A DAG with two steps:
 
 .. code-block:: yaml
 
@@ -28,7 +28,7 @@ A DAG consists of one or more steps, each with a name and command. Here's the si
       depends:
         - step 1
 
-You can use pipe for running the command.
+Using a pipe:
 
 .. code-block:: yaml
 
@@ -36,7 +36,7 @@ You can use pipe for running the command.
     - name: step 1
       command: echo hello world | xargs echo
 
-You can specify shell for running the command. If not specified, the ``$SHELL`` will be used.
+Specifying a shell:
 
 .. code-block:: yaml
 
@@ -110,22 +110,28 @@ Use named parameters for better clarity:
 
 Code Snippets
 ~~~~~~~~~~~~
-Run inline scripts in any language:
+
+Run shell script with `$SHELL`:
 
 .. code-block:: yaml
 
   steps:
     - name: script step
-      command: "bash"
       script: |
         cd /tmp
         echo "hello world" > hello
         cat hello
-      output: RESULT
-    - name: use result
-      command: echo ${RESULT}
-      depends:
-        - script step
+
+You can run arbitrary script with the `script` field. The script will be executed with the program specified in the `command` field. If `command` is not specified, the default shell will be used.
+
+.. code-block:: yaml
+
+  steps:
+    - name: script step
+      command: python
+      script: |
+        import os
+        print(os.getcwd())
 
 Output Handling
 --------------

--- a/docs/source/yaml_format.rst
+++ b/docs/source/yaml_format.rst
@@ -28,13 +28,22 @@ A DAG consists of one or more steps, each with a name and command. Here's the si
       depends:
         - step 1
 
-The command can be a string or list of strings. The list format is useful when passing arguments:
+You can use pipe for running the command.
 
 .. code-block:: yaml
 
   steps:
     - name: step 1
-      command: [echo, hello]
+      command: echo hello world | xargs echo
+
+You can specify shell for running the command. If not specified, the ``$SHELL`` will be used.
+
+.. code-block:: yaml
+
+  steps:
+    - name: step 1
+      command: echo hello world | xargs echo
+      shell: bash
 
 Schema Definition
 ~~~~~~~~~~~~~~~~

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -6,6 +6,7 @@ package cmdutil
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 	"unicode"
@@ -208,4 +209,23 @@ func SubstituteCommands(input string) (string, error) {
 	}
 
 	return ret, nil
+}
+
+// GetShellCommand returns the shell to use for command execution
+func GetShellCommand(configuredShell string) string {
+	if configuredShell != "" {
+		return configuredShell
+	}
+
+	// Try system shell first
+	if systemShell := os.ExpandEnv("${SHELL}"); systemShell != "" {
+		return systemShell
+	}
+
+	// Fallback to sh if available
+	if shPath, err := exec.LookPath("sh"); err == nil {
+		return shPath
+	}
+
+	return ""
 }

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -1,0 +1,211 @@
+// Copyright (C) 2024 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmdutil
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/mattn/go-shellwords"
+)
+
+var ErrCommandIsEmpty = fmt.Errorf("command is empty")
+
+// ParsePipedCommand splits a shell-style command string into a pipeline ([][]string).
+// Each sub-slice represents a single command. Unquoted "|" tokens define the boundaries.
+//
+// Example:
+//
+//	parsePipedCommand(`echo foo | grep foo | wc -l`) =>
+//	  [][]string{
+//	    {"echo", "foo"},
+//	    {"grep", "foo"},
+//	    {"wc", "-l"},
+//	  }
+//
+//	parsePipedCommand(`echo "hello|world"`) =>
+//	  [][]string{ {"echo", "hello|world"} } // single command
+func ParsePipedCommand(cmdString string) ([][]string, error) {
+	var inQuote, inBacktick, inEscape bool
+	var current []rune
+	var tokens []string
+
+	for _, r := range cmdString {
+		switch {
+		case inEscape:
+			current = append(current, r)
+			inEscape = false
+		case r == '\\':
+			current = append(current, r)
+			inEscape = true
+		case r == '"' && !inBacktick:
+			current = append(current, r)
+			inQuote = !inQuote
+		case r == '`':
+			current = append(current, r)
+			inBacktick = !inBacktick
+		case r == '|' && !inQuote && !inBacktick:
+			if len(current) > 0 {
+				tokens = append(tokens, string(current))
+				current = nil
+			}
+			tokens = append(tokens, "|")
+		case unicode.IsSpace(r) && !inQuote && !inBacktick:
+			if len(current) > 0 {
+				tokens = append(tokens, string(current))
+				current = nil
+			}
+		default:
+			current = append(current, r)
+		}
+	}
+
+	if len(current) > 0 {
+		tokens = append(tokens, string(current))
+	}
+
+	var pipeline [][]string
+	var currentCmd []string
+
+	for _, token := range tokens {
+		if token == "|" {
+			if len(currentCmd) > 0 {
+				pipeline = append(pipeline, currentCmd)
+				currentCmd = nil
+			}
+		} else {
+			currentCmd = append(currentCmd, token)
+		}
+	}
+
+	if len(currentCmd) > 0 {
+		pipeline = append(pipeline, currentCmd)
+	}
+
+	return pipeline, nil
+}
+
+func SplitCommandWithEval(cmd string) (string, []string, error) {
+	pipeline, err := ParsePipedCommand(cmd)
+	if err != nil {
+		return "", nil, err
+	}
+
+	parser := shellwords.NewParser()
+	parser.ParseBacktick = true
+	parser.ParseEnv = false
+
+	for _, command := range pipeline {
+		if len(command) < 2 {
+			continue
+		}
+		for i, arg := range command {
+			// Expand environment variables in the command.
+			command[i] = os.ExpandEnv(arg)
+			// escape the command
+			command[i] = escapeReplacer.Replace(command[i])
+			// Substitute command in the command.
+			command[i], err = SubstituteCommands(command[i])
+			if err != nil {
+				return "", nil, fmt.Errorf("failed to substitute command: %w", err)
+			}
+			// unescape the command
+			// command[i] = unescapeReplacer.Replace(command[i])
+		}
+	}
+
+	if len(pipeline) > 1 {
+		first := pipeline[0]
+		cmd := first[0]
+		args := first[1:]
+		for _, command := range pipeline[1:] {
+			args = append(args, "|")
+			args = append(args, command...)
+		}
+		return cmd, args, nil
+	}
+
+	if len(pipeline) == 0 {
+		return "", nil, ErrCommandIsEmpty
+	}
+
+	command := pipeline[0]
+	if len(command) == 0 {
+		return "", nil, ErrCommandIsEmpty
+	}
+
+	return command[0], command[1:], nil
+}
+
+var (
+	escapeReplacer = strings.NewReplacer(
+		`\t`, `\\\\t`,
+		`\r`, `\\\\r`,
+		`\n`, `\\\\n`,
+	)
+)
+
+func SplitCommand(cmd string) (string, []string, error) {
+	pipeline, err := ParsePipedCommand(cmd)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if len(pipeline) > 1 {
+		first := pipeline[0]
+		cmd := first[0]
+		args := first[1:]
+		for _, command := range pipeline[1:] {
+			args = append(args, "|")
+			args = append(args, command...)
+		}
+		return cmd, args, nil
+	}
+
+	if len(pipeline) == 0 {
+		return "", nil, ErrCommandIsEmpty
+	}
+
+	command := pipeline[0]
+	if len(command) == 0 {
+		return "", nil, ErrCommandIsEmpty
+	}
+
+	return command[0], command[1:], nil
+}
+
+// tickerMatcher matches the command in the value string.
+// Example: "`date`"
+var tickerMatcher = regexp.MustCompile("`[^`]+`")
+
+// SubstituteCommands substitutes command in the value string.
+// This logic needs to be refactored to handle more complex cases.
+func SubstituteCommands(input string) (string, error) {
+	matches := tickerMatcher.FindAllString(strings.TrimSpace(input), -1)
+	if matches == nil {
+		return input, nil
+	}
+
+	ret := input
+	for i := 0; i < len(matches); i++ {
+		// Execute the command and replace the command with the output.
+		command := matches[i]
+
+		parser := shellwords.NewParser()
+		parser.ParseBacktick = true
+		parser.ParseEnv = false
+
+		res, err := parser.Parse(escapeReplacer.Replace(command))
+		if err != nil {
+			return "", fmt.Errorf("failed to substitute command: %w", err)
+		}
+
+		ret = strings.ReplaceAll(ret, command, strings.Join(res, " "))
+	}
+
+	return ret, nil
+}

--- a/internal/cmdutil/cmdutil_test.go
+++ b/internal/cmdutil/cmdutil_test.go
@@ -1,0 +1,170 @@
+// Copyright (C) 2024 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package cmdutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitCommandWithQuotes(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		cmd, args, err := SplitCommand("ls -al test/")
+		require.NoError(t, err)
+		require.Equal(t, "ls", cmd)
+		require.Len(t, args, 2)
+		require.Equal(t, "-al", args[0])
+		require.Equal(t, "test/", args[1])
+	})
+	t.Run("WithJSON", func(t *testing.T) {
+		cmd, args, err := SplitCommand(`echo {"key":"value"}`)
+		require.NoError(t, err)
+		require.Equal(t, "echo", cmd)
+		require.Len(t, args, 1)
+		require.Equal(t, `{"key":"value"}`, args[0])
+	})
+	t.Run("WithQuotedJSON", func(t *testing.T) {
+		cmd, args, err := SplitCommand(`echo "{\"key\":\"value\"}"`)
+		require.NoError(t, err)
+		require.Equal(t, "echo", cmd)
+		require.Len(t, args, 1)
+		require.Equal(t, `"{\"key\":\"value\"}"`, args[0])
+	})
+}
+
+func TestSplitCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantCmd   string
+		wantArgs  []string
+		wantErr   bool
+		errorType error
+	}{
+		{
+			name:     "simple command no args",
+			input:    "echo",
+			wantCmd:  "echo",
+			wantArgs: []string{},
+		},
+		{
+			name:     "command with single arg",
+			input:    "echo hello",
+			wantCmd:  "echo",
+			wantArgs: []string{"hello"},
+		},
+		{
+			name:     "command with backtick",
+			input:    "echo `echo hello`",
+			wantCmd:  "echo",
+			wantArgs: []string{"`echo hello`"},
+		},
+		{
+			name:     "command with multiple args",
+			input:    "echo hello world",
+			wantCmd:  "echo",
+			wantArgs: []string{"hello", "world"},
+		},
+		{
+			name:     "command with quoted args",
+			input:    `echo "hello world"`,
+			wantCmd:  "echo",
+			wantArgs: []string{"\"hello world\""},
+		},
+		{
+			name:     "command with pipe",
+			input:    "echo foo | grep foo",
+			wantCmd:  "echo",
+			wantArgs: []string{"foo", "|", "grep", "foo"},
+		},
+		{
+			name:     "complex pipe command",
+			input:    "echo foo | grep foo | wc -l",
+			wantCmd:  "echo",
+			wantArgs: []string{"foo", "|", "grep", "foo", "|", "wc", "-l"},
+		},
+		{
+			name:     "command with quoted pipe",
+			input:    `echo "hello|world"`,
+			wantCmd:  "echo",
+			wantArgs: []string{"\"hello|world\""},
+		},
+		{
+			name:      "empty command",
+			input:     "",
+			wantErr:   true,
+			errorType: ErrCommandIsEmpty,
+		},
+		{
+			name:     "command with escaped quotes",
+			input:    `echo "\"hello world\""`,
+			wantCmd:  "echo",
+			wantArgs: []string{`"\"hello world\""`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCmd, gotArgs, err := SplitCommand(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("splitCommand() error = nil, want error")
+					return
+				}
+				if tt.errorType != nil && err != tt.errorType {
+					t.Errorf("splitCommand() error = %v, want %v", err, tt.errorType)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("splitCommand() error = %v, want nil", err)
+				return
+			}
+
+			if gotCmd != tt.wantCmd {
+				t.Errorf("splitCommand() gotCmd = %v, want %v", gotCmd, tt.wantCmd)
+			}
+
+			if len(gotArgs) != len(tt.wantArgs) {
+				t.Errorf("splitCommand() gotArgs length = %v, want %v", len(gotArgs), len(tt.wantArgs))
+				return
+			}
+
+			for i := range gotArgs {
+				if gotArgs[i] != tt.wantArgs[i] {
+					t.Errorf("splitCommand() gotArgs[%d] = %v, want %v", i, gotArgs[i], tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSplitCommandWithParse(t *testing.T) {
+	t.Run("CommandSubstitution", func(t *testing.T) {
+		cmd, args, err := SplitCommandWithEval("echo `echo hello`")
+		require.NoError(t, err)
+		require.Equal(t, "echo", cmd)
+		require.Len(t, args, 1)
+		require.Equal(t, "hello", args[0])
+	})
+	t.Run("QuotedCommandSubstitution", func(t *testing.T) {
+		cmd, args, err := SplitCommandWithEval("echo `echo \"hello world\"`")
+		require.NoError(t, err)
+		require.Equal(t, "echo", cmd)
+		require.Len(t, args, 1)
+		require.Equal(t, "hello world", args[0])
+	})
+	t.Run("EnvVar", func(t *testing.T) {
+		os.Setenv("TEST_ARG", "hello")
+		cmd, args, err := SplitCommandWithEval("echo $TEST_ARG")
+		require.NoError(t, err)
+		require.Equal(t, "echo", cmd)
+		require.Len(t, args, 1)
+		require.Equal(t, "hello", args[0])
+	})
+}

--- a/internal/digraph/assert.go
+++ b/internal/digraph/assert.go
@@ -42,9 +42,11 @@ func assertStepDef(def stepDef, funcs []*funcDef) error {
 	}
 
 	// TODO: Validate executor config for each executor type.
-	if def.Executor == nil && def.Command == nil && def.Call == nil &&
-		def.Run == "" {
-		return errStepCommandOrCallRequired
+
+	if def.Command == nil {
+		if def.Executor == nil && def.Script == "" && def.Call == nil && def.Run == "" {
+			return errStepCommandIsRequired
+		}
 	}
 
 	// validate the function call if it exists.

--- a/internal/digraph/builder.go
+++ b/internal/digraph/builder.go
@@ -51,7 +51,7 @@ var (
 	errDuplicateFunction                  = errors.New("duplicate function")
 	errFuncParamsMismatch                 = errors.New("func params and args given to func command do not match")
 	errStepNameRequired                   = errors.New("step name must be specified")
-	errStepCommandOrCallRequired          = errors.New("either step command or step call must be specified if executor is nil")
+	errStepCommandIsRequired              = errors.New("step command is required")
 	errStepCommandIsEmpty                 = errors.New("step command is empty")
 	errStepCommandMustBeArrayOrString     = errors.New("step command must be an array of strings or a string")
 	errInvalidParamValue                  = errors.New("invalid parameter value")

--- a/internal/digraph/builder_test.go
+++ b/internal/digraph/builder_test.go
@@ -25,7 +25,7 @@ func TestBuilder_Build(t *testing.T) {
 		{
 			Name:        "NoCommand",
 			InputFile:   "no_command.yaml",
-			ExpectedErr: errStepCommandOrCallRequired,
+			ExpectedErr: errStepCommandIsRequired,
 		},
 		{
 			Name:        "InvalidEnv",

--- a/internal/digraph/builder_test.go
+++ b/internal/digraph/builder_test.go
@@ -526,25 +526,3 @@ func testStep(t *testing.T, step Step, tc stepTestCase) {
 		}
 	}
 }
-
-func TestSplitCommand(t *testing.T) {
-	t.Run("Valid", func(t *testing.T) {
-		cmd, args := splitCommand("ls -al test/")
-		require.Equal(t, "ls", cmd)
-		require.Len(t, args, 2)
-		require.Equal(t, "-al", args[0])
-		require.Equal(t, "test/", args[1])
-	})
-	t.Run("WithJSON", func(t *testing.T) {
-		cmd, args := splitCommand(`echo {"key":"value"}`)
-		require.Equal(t, "echo", cmd)
-		require.Len(t, args, 1)
-		require.Equal(t, `{"key":"value"}`, args[0])
-	})
-	t.Run("WithQuotedJSON", func(t *testing.T) {
-		cmd, args := splitCommand(`echo "{\"key\":\"value\"}"`)
-		require.Equal(t, "echo", cmd)
-		require.Len(t, args, 1)
-		require.Equal(t, `"{\"key\":\"value\"}"`, args[0])
-	})
-}

--- a/internal/digraph/command.go
+++ b/internal/digraph/command.go
@@ -71,6 +71,9 @@ func buildCommand(_ BuildContext, def stepDef, step *Step) error {
 			step.Args = append(step.Args, val)
 		}
 
+		// Setup CmdWithArgs as it is used in command execution
+		step.CmdWithArgs = fmt.Sprintf("%s %v", step.Command, step.Args)
+
 	default:
 		// Unknown type for command field.
 		return errStepCommandMustBeArrayOrString

--- a/internal/digraph/command.go
+++ b/internal/digraph/command.go
@@ -1,0 +1,81 @@
+// Copyright (C) 2024 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package digraph
+
+import (
+	"fmt"
+
+	"github.com/dagu-org/dagu/internal/cmdutil"
+)
+
+// buildCommand parses the command field in the step definition.
+// Case 1: command is nil
+// Case 2: command is a string
+// Case 3: command is an array
+//
+// In case 3, the first element is the command and the rest are the arguments.
+// If the arguments are not strings, they are converted to strings.
+//
+// Example:
+// ```yaml
+// step:
+//   - name: "echo hello"
+//     command: "echo hello"
+//
+// ```
+// or
+// ```yaml
+// step:
+//   - name: "echo hello"
+//     command: ["echo", "hello"]
+//
+// ```
+// It returns an error if the command is not nil but empty.
+func buildCommand(_ BuildContext, def stepDef, step *Step) error {
+	command := def.Command
+
+	// Case 1: command is nil
+	if command == nil {
+		return nil
+	}
+
+	switch val := command.(type) {
+	case string:
+		// Case 2: command is a string
+		if val == "" {
+			return errStepCommandIsEmpty
+		}
+		// We need to split the command into command and args.
+		step.CmdWithArgs = val
+		cmd, args, err := cmdutil.SplitCommand(val)
+		if err != nil {
+			return fmt.Errorf("failed to parse command: %w", err)
+		}
+		step.Command = cmd
+		step.Args = args
+
+	case []any:
+		// Case 3: command is an array
+		for _, v := range val {
+			val, ok := v.(string)
+			if !ok {
+				// If the value is not a string, convert it to a string.
+				// This is useful when the value is an integer for example.
+				val = fmt.Sprintf("%v", v)
+			}
+			if step.Command == "" {
+				step.Command = val
+				continue
+			}
+			step.Args = append(step.Args, val)
+		}
+
+	default:
+		// Unknown type for command field.
+		return errStepCommandMustBeArrayOrString
+
+	}
+
+	return nil
+}

--- a/internal/digraph/condition.go
+++ b/internal/digraph/condition.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+
+	"github.com/dagu-org/dagu/internal/cmdutil"
 )
 
 // Condition contains a condition and the expected value.
@@ -21,7 +23,7 @@ type Condition struct {
 // eval evaluates the condition and returns the actual value.
 // It returns an error if the evaluation failed or the condition is invalid.
 func (c Condition) eval() (string, error) {
-	return substituteCommands(os.ExpandEnv(c.Condition))
+	return cmdutil.SubstituteCommands(os.ExpandEnv(c.Condition))
 }
 
 var (

--- a/internal/digraph/dag.go
+++ b/internal/digraph/dag.go
@@ -27,7 +27,6 @@ type DAG struct {
 	Tags []string `json:"Tags"`
 	// Description is the description of the DAG. optional.
 	Description string `json:"Description"`
-
 	// Schedule configuration.
 	// This is used by the scheduler to start / stop / restart the DAG.
 	Schedule        []Schedule `json:"Schedule"`

--- a/internal/digraph/executor/command.go
+++ b/internal/digraph/executor/command.go
@@ -62,6 +62,13 @@ func createCommand(ctx context.Context, step digraph.Step) *exec.Cmd {
 	if shellCommand == "" {
 		// If the shell is not specified use the system shell
 		shellCommand = os.ExpandEnv("${SHELL}")
+		if shellCommand == "" {
+			// check if `sh` is available
+			absPath, err := exec.LookPath("sh")
+			if err == nil {
+				shellCommand = absPath
+			}
+		}
 	}
 	if shellCommand == "" {
 		// If shell can not be used, run the program directly

--- a/internal/digraph/executor/command.go
+++ b/internal/digraph/executor/command.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/dagu-org/dagu/internal/cmdutil"
 	"github.com/dagu-org/dagu/internal/digraph"
 	"github.com/dagu-org/dagu/internal/fileutil"
 )
@@ -56,32 +57,14 @@ func newCommand(ctx context.Context, step digraph.Step) (Executor, error) {
 		cmd: cmd,
 	}, nil
 }
+
 func createCommand(ctx context.Context, step digraph.Step) *exec.Cmd {
-	shellCommand := getShellCommand(step.Shell)
+	shellCommand := cmdutil.GetShellCommand(step.Shell)
 
 	if shellCommand == "" {
 		return createDirectCommand(ctx, step)
 	}
 	return createShellCommand(ctx, shellCommand, step)
-}
-
-// getShellCommand returns the shell to use for command execution
-func getShellCommand(configuredShell string) string {
-	if configuredShell != "" {
-		return configuredShell
-	}
-
-	// Try system shell first
-	if systemShell := os.ExpandEnv("${SHELL}"); systemShell != "" {
-		return systemShell
-	}
-
-	// Fallback to sh if available
-	if shPath, err := exec.LookPath("sh"); err == nil {
-		return shPath
-	}
-
-	return ""
 }
 
 // createDirectCommand creates a command that runs directly without a shell

--- a/internal/digraph/scheduler/node.go
+++ b/internal/digraph/scheduler/node.go
@@ -188,7 +188,7 @@ func (n *Node) setupExec(ctx context.Context) (executor.Executor, error) {
 
 	if n.data.Step.Command == "" {
 		// If the command is empty, use the default shell as the command
-		n.data.Step.Command = cmdutil.GetShellCommand("")
+		n.data.Step.Command = cmdutil.GetShellCommand(n.data.Step.Shell)
 	}
 
 	if n.scriptFile != nil {

--- a/internal/digraph/scheduler/node.go
+++ b/internal/digraph/scheduler/node.go
@@ -186,6 +186,11 @@ func (n *Node) setupExec(ctx context.Context) (executor.Executor, error) {
 		n.data.Step.Args = args
 	}
 
+	if n.data.Step.Command == "" {
+		// If the command is empty, use the default shell as the command
+		n.data.Step.Command = cmdutil.GetShellCommand("")
+	}
+
 	if n.scriptFile != nil {
 		var args []string
 		args = append(args, n.data.Step.Args...)

--- a/internal/digraph/scheduler/node_test.go
+++ b/internal/digraph/scheduler/node_test.go
@@ -254,7 +254,7 @@ func TestOutputJson(t *testing.T) {
 	}
 }
 
-func TestOutputSpecialchar(t *testing.T) {
+func TestOutputSpecialChar(t *testing.T) {
 	for i, test := range []struct {
 		CmdWithArgs string
 		Want        string
@@ -379,26 +379,4 @@ func runTestNode(t *testing.T, n *Node) {
 	require.NoError(t, err)
 	err = n.teardown()
 	require.NoError(t, err)
-}
-
-func TestSplitCommandWithParse(t *testing.T) {
-	t.Run("CommandSubstitution", func(t *testing.T) {
-		cmd, args := splitCommandWithParse("echo `echo hello`")
-		require.Equal(t, "echo", cmd)
-		require.Len(t, args, 1)
-		require.Equal(t, "hello", args[0])
-	})
-	t.Run("QuotedCommandSubstitution", func(t *testing.T) {
-		cmd, args := splitCommandWithParse("echo `echo \"hello world\"`")
-		require.Equal(t, "echo", cmd)
-		require.Len(t, args, 1)
-		require.Equal(t, "hello world", args[0])
-	})
-	t.Run("EnvVar", func(t *testing.T) {
-		os.Setenv("TEST_ARG", "hello")
-		cmd, args := splitCommandWithParse("echo $TEST_ARG")
-		require.Equal(t, "echo", cmd)
-		require.Len(t, args, 1)
-		require.Equal(t, "hello", args[0])
-	})
 }

--- a/internal/digraph/scheduler/scheduler_test.go
+++ b/internal/digraph/scheduler/scheduler_test.go
@@ -153,10 +153,9 @@ func TestSchedulerAllowSkipped(t *testing.T) {
 }
 
 func TestSchedulerCancel(t *testing.T) {
-
 	graph, _ := NewExecutionGraph(
 		step("1", testCommand),
-		step("2", "sleep 1000", "1"),
+		step("2", "sleep 100", "1"),
 		step("3", testCommandFail, "2"),
 	)
 	cfg := &Config{MaxActiveRuns: 1, LogDir: testHomeDir}

--- a/internal/digraph/spec.go
+++ b/internal/digraph/spec.go
@@ -50,6 +50,7 @@ type stepDef struct {
 	Dir           string
 	Executor      any
 	Command       any
+	Shell         string
 	Script        string
 	Stdout        string
 	Stderr        string

--- a/internal/digraph/step.go
+++ b/internal/digraph/step.go
@@ -17,6 +17,8 @@ type Step struct {
 	Name string `json:"Name"`
 	// Description is the description of the step.
 	Description string `json:"Description,omitempty"`
+	// Shell is the shell program to execute the command. optional.
+	Shell string `json:"Shell,omitempty"`
 	// Variables contains the list of variables to be set.
 	Variables []string `json:"Variables,omitempty"`
 	// OutputVariables is a structure to store the output variables for the

--- a/internal/digraph/variables.go
+++ b/internal/digraph/variables.go
@@ -6,6 +6,8 @@ package digraph
 import (
 	"fmt"
 	"os"
+
+	"github.com/dagu-org/dagu/internal/cmdutil"
 )
 
 // loadVariables loads the environment variables from the map.
@@ -45,7 +47,7 @@ func loadVariables(ctx BuildContext, strVariables any) (
 			// This also executes command substitution.
 			var err error
 
-			value, err = substituteCommands(os.ExpandEnv(value))
+			value, err = cmdutil.SubstituteCommands(os.ExpandEnv(value))
 			if err != nil {
 				return nil, fmt.Errorf("%w: %s", errInvalidEnvValue, pair.val)
 			}


### PR DESCRIPTION
Changes command execution to use shell (`$SHELL` by default) instead of direct execution. This enables proper handling of pipes and other shell features.

### Changes
- Use shell for command execution
- Create `cmdutil` package for command parsing
- Allow explicit shell override via new `shell` field

### Example
```yaml
steps:
  - name: step 1
    command: echo hello world | xargs echo
    shell: bash  # Optional, defaults to $SHELL
```