### PR TITLE
[#755] dag: Support `params` as a list of key-value pairs

### DIFF
--- a/internal/digraph/builder_test.go
+++ b/internal/digraph/builder_test.go
@@ -199,6 +199,18 @@ func TestBuildDAG(t *testing.T) {
 			"BAZ=baz",
 		)
 	})
+	t.Run("ParamsAsMapOverride", func(t *testing.T) {
+		th := loadTestYAML(t, "params_as_map.yaml", withBuildOpts(
+			buildOpts{
+				parameters: "FOO=X BAZ=Y",
+			},
+		))
+		th.AssertParam(t,
+			"FOO=X",
+			"BAR=bar",
+			"BAZ=Y",
+		)
+	})
 	t.Run("ParamsWithComplexValues", func(t *testing.T) {
 		th := loadTestYAML(t, "params_with_complex_values.yaml")
 		th.AssertParam(t,

--- a/internal/digraph/builder_test.go
+++ b/internal/digraph/builder_test.go
@@ -43,6 +43,12 @@ func (th *testHelper) AssertParam(t *testing.T, params ...string) {
 
 type testOption func(*testHelper)
 
+func withBuildOpts(opts buildOpts) testOption {
+	return func(th *testHelper) {
+		th.buildOpts = opts
+	}
+}
+
 func loadTestYAML(t *testing.T, inputFile string, opts ...testOption) *testHelper {
 	t.Helper()
 	ctx := context.Background()
@@ -184,6 +190,14 @@ func TestBuildDAG(t *testing.T) {
 	t.Run("ParamsWithQuotedValues", func(t *testing.T) {
 		th := loadTestYAML(t, "params_with_quoted_values.yaml")
 		th.AssertParam(t, "x=a b c", "y=d e f")
+	})
+	t.Run("ParamsAsMap", func(t *testing.T) {
+		th := loadTestYAML(t, "params_as_map.yaml")
+		th.AssertParam(t,
+			"FOO=foo",
+			"BAR=bar",
+			"BAZ=baz",
+		)
 	})
 	t.Run("ParamsWithComplexValues", func(t *testing.T) {
 		th := loadTestYAML(t, "params_with_complex_values.yaml")

--- a/internal/digraph/params.go
+++ b/internal/digraph/params.go
@@ -10,72 +10,163 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/dagu-org/dagu/internal/cmdutil"
 )
 
 // buildParams builds the parameters for the DAG.
-func buildParams(ctx BuildContext, spec *definition, dag *DAG) (err error) {
-	dag.DefaultParams = spec.Params
+func buildParams(ctx BuildContext, spec *definition, dag *DAG) error {
+	var (
+		paramPairs []paramPair
+		envs       []string
+	)
 
-	params := dag.DefaultParams
+	if err := parseParams(ctx, spec.Params, &paramPairs, &envs); err != nil {
+		return err
+	}
+
+	// Create default parameters string in the form of "key=value key=value ..."
+	var paramsToJoin []string
+	for _, paramPair := range paramPairs {
+		paramsToJoin = append(paramsToJoin, paramPair.Escaped())
+	}
+	dag.DefaultParams = strings.Join(paramsToJoin, " ")
+
 	if ctx.opts.parameters != "" {
-		params = ctx.opts.parameters
-	}
+		// Parse the parameters from the command line and override the default parameters
+		var (
+			overridePairs []paramPair
+			overrideEnvs  []string
+		)
+		if err := parseParams(ctx, ctx.opts.parameters, &overridePairs, &overrideEnvs); err != nil {
+			return err
+		}
+		// Override the default parameters with the command line parameters
+		pairsIndex := make(map[string]int)
+		for i, paramPair := range paramPairs {
+			if paramPair.name != "" {
+				pairsIndex[paramPair.name] = i
+			}
+		}
+		for i, paramPair := range overridePairs {
+			if paramPair.name == "" {
+				// For positional parameters
+				if i < len(paramPairs) {
+					paramPairs[i] = paramPair
+				} else {
+					paramPairs = append(paramPairs, paramPair)
+				}
+				continue
+			}
 
-	var envs []string
-	dag.Params, envs, err = parseParams(ctx, params)
-	if err == nil {
-		dag.Env = append(dag.Env, envs...)
-	}
-
-	return
-}
-
-// parseParams parses and processes the parameters for the DAG.
-func parseParams(ctx BuildContext, value string) (
-	params []string,
-	envs []string,
-	err error,
-) {
-	var parsedParams []paramPair
-
-	parsedParams, err = parseParamValue(ctx, value)
-	if err != nil {
-		return
-	}
-
-	var ret []string
-	for i, p := range parsedParams {
-		if !ctx.opts.noEval {
-			p.value = os.ExpandEnv(p.value)
+			if foundIndex, ok := pairsIndex[paramPair.name]; ok {
+				paramPairs[foundIndex] = paramPair
+			} else {
+				paramPairs = append(paramPairs, paramPair)
+			}
 		}
 
-		strParam := stringifyParam(p)
-		ret = append(ret, strParam)
-
-		if p.name == "" {
-			strParam = p.value
+		envsIndex := make(map[string]int)
+		for i, env := range envs {
+			envsIndex[env] = i
 		}
-
-		if err = os.Setenv(strconv.Itoa(i+1), strParam); err != nil {
-			return
-		}
-
-		if !ctx.opts.noEval && p.name != "" {
-			envs = append(envs, strParam)
-			err = os.Setenv(p.name, p.value)
-			if err != nil {
-				return
+		for _, env := range overrideEnvs {
+			if i, ok := envsIndex[env]; !ok {
+				envs = append(envs, env)
+			} else {
+				envs[i] = env
 			}
 		}
 	}
 
-	return ret, envs, nil
+	// Convert the parameters to a string in the form of "key=value"
+	var paramStrs []string
+	for _, paramPair := range paramPairs {
+		paramStrs = append(paramStrs, paramPair.String())
+	}
+
+	// Set the parameters as environment variables for the command
+	dag.Env = append(dag.Env, envs...)
+	dag.Params = append(dag.Params, paramStrs...)
+
+	return nil
+}
+
+// parseParams parses and processes the parameters for the DAG.
+func parseParams(ctx BuildContext, value any, params *[]paramPair, envs *[]string) error {
+	var parsedPairs []paramPair
+
+	parsedPairs, err := parseParamValue(ctx, value)
+	if err != nil {
+		return fmt.Errorf("%w: %s", errInvalidParamValue, err)
+	}
+
+	for index, paramPair := range parsedPairs {
+		if !ctx.opts.noEval {
+			paramPair.value = os.ExpandEnv(paramPair.value)
+		}
+
+		*params = append(*params, paramPair)
+
+		paramStr := paramPair.String()
+
+		// Set the parameter as an environment variable for the command
+		// $1, $2, $3, ...
+		if err := os.Setenv(strconv.Itoa(index+1), paramStr); err != nil {
+			return fmt.Errorf("failed to set environment variable: %w", err)
+		}
+
+		if !ctx.opts.noEval && paramPair.name != "" {
+			*envs = append(*envs, paramStr)
+			if err := os.Setenv(paramPair.name, paramPair.value); err != nil {
+				return fmt.Errorf("failed to set environment variable: %w", err)
+			}
+		}
+	}
+
+	return nil
 }
 
 // parseParamValue parses the parameters for the DAG.
-func parseParamValue(
-	ctx BuildContext, input string,
-) ([]paramPair, error) {
+func parseParamValue(ctx BuildContext, input any) ([]paramPair, error) {
+	switch v := input.(type) {
+	case nil:
+		return nil, nil
+
+	case string:
+		return parseStringParams(ctx, v)
+
+	case []map[string]string:
+		return parseMapParams(ctx, v)
+
+	default:
+		return nil, fmt.Errorf("%w: %T", errInvalidParamValue, v)
+
+	}
+}
+
+func parseMapParams(ctx BuildContext, input []map[string]string) ([]paramPair, error) {
+	var params []paramPair
+
+	for _, m := range input {
+		for name, value := range m {
+			if !ctx.opts.noEval {
+				parsed, err := cmdutil.SubstituteWithEnvExpand(value)
+				if err != nil {
+					return nil, fmt.Errorf("%w: %s", errInvalidParamValue, err)
+				}
+				value = parsed
+			}
+
+			paramPair := paramPair{name, value}
+			params = append(params, paramPair)
+		}
+	}
+
+	return params, nil
+}
+
+func parseStringParams(ctx BuildContext, input string) ([]paramPair, error) {
 	paramRegex := regexp.MustCompile(
 		`(?:([^\s=]+)=)?("(?:\\"|[^"])*"|` + "`(" + `?:\\"|[^"]*)` + "`" + `|[^"\s]+)`,
 	)
@@ -125,18 +216,23 @@ func parseParamValue(
 	return params, nil
 }
 
-// stringifyParam converts a paramPair to a string representation.
-func stringifyParam(param paramPair) string {
-	if param.name != "" {
-		return fmt.Sprintf("%s=%s", param.name, param.value)
-	}
-	return param.value
-}
-
-// paramPair represents a key-value pair for the parameters.
 type paramPair struct {
 	name  string
 	value string
+}
+
+func (p paramPair) String() string {
+	if p.name != "" {
+		return fmt.Sprintf("%s=%s", p.name, p.value)
+	}
+	return p.value
+}
+
+func (p paramPair) Escaped() string {
+	if p.name != "" {
+		return fmt.Sprintf("%s=%q", p.name, p.value)
+	}
+	return fmt.Sprintf("%q", p.value)
 }
 
 var (

--- a/internal/digraph/spec.go
+++ b/internal/digraph/spec.go
@@ -49,7 +49,7 @@ type definition struct {
 	// MaxActiveRuns is the maximum number of concurrent steps.
 	MaxActiveRuns int
 	// Params is the default parameters for the steps.
-	Params string
+	Params any
 	// MaxCleanUpTimeSec is the maximum time in seconds to clean up the DAG.
 	// It is a wait time to kill the processes when it is requested to stop.
 	// If the time is exceeded, the process is killed.

--- a/internal/digraph/testdata/params_as_map.yaml
+++ b/internal/digraph/testdata/params_as_map.yaml
@@ -1,0 +1,4 @@
+params:
+  - FOO: foo
+  - BAR: bar
+  - BAZ: "`echo baz`"

--- a/internal/digraph/testdata/params_as_map_override.yaml
+++ b/internal/digraph/testdata/params_as_map_override.yaml
@@ -1,0 +1,4 @@
+params:
+  - FOO: foo
+  - BAR: bar
+  - BAZ: "`echo baz`"


### PR DESCRIPTION
Resolves #755 

Example:
```yaml
params:
  - FOO: foo
  - BAR: bar
  - BAZ: "`echo baz`"
steps:
  - name: step_1
    command: |
      echo ${FOO} ${BAR} ${BAZ}
```