### PR TITLE
[#763] Add support for `dotenv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,13 @@ You can execute the example by pressing the `Start` button. You can see "Hello D
 
 ```sh
 # Runs the DAG
-dagu start [--params=<params>] <file>
+dagu start <file>
+
+# Runs the DAG with named parameters
+dagu start <file> -- <key>=<value> ...
+
+# Runs the DAG with positional parameters
+dagu start <file> -- value1 value2 ...
 
 # Displays the current status of the DAG
 dagu status <file>

--- a/README.md
+++ b/README.md
@@ -183,10 +183,10 @@ You can execute the example by pressing the `Start` button. You can see "Hello D
 dagu start <file>
 
 # Runs the DAG with named parameters
-dagu start <file> -- <key>=<value> ...
+dagu start <file> [-- <key>=<value> ...]
 
 # Runs the DAG with positional parameters
-dagu start <file> -- value1 value2 ...
+dagu start <file> [-- value1 value2 ...]
 
 # Displays the current status of the DAG
 dagu status <file>
@@ -201,7 +201,7 @@ dagu stop <file>
 dagu restart <file>
 
 # Dry-runs the DAG
-dagu dry [--params=<params>] <file>
+dagu dry <file> [-- <key>=<value> ...]
 
 # Launches both the web UI server and scheduler process
 dagu start-all [--host=<host>] [--port=<port>] [--dags=<path to directory>]

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -45,7 +45,7 @@ type testDAG struct {
 func (td *testDAG) AssertCurrentStatus(t *testing.T, expected scheduler.Status) {
 	t.Helper()
 
-	dag, err := digraph.Load(td.Context, td.Config.Paths.BaseConfig, td.Path, "")
+	dag, err := digraph.Load(td.Context, td.Path, digraph.WithBaseDAG(td.Config.Paths.BaseConfig))
 	require.NoError(t, err)
 
 	cli := td.Client

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -45,7 +45,7 @@ type testDAG struct {
 func (td *testDAG) AssertCurrentStatus(t *testing.T, expected scheduler.Status) {
 	t.Helper()
 
-	dag, err := digraph.Load(td.Context, td.Path, digraph.WithBaseDAG(td.Config.Paths.BaseConfig))
+	dag, err := digraph.Load(td.Context, td.Path, digraph.WithBaseConfig(td.Config.Paths.BaseConfig))
 	require.NoError(t, err)
 
 	cli := td.Client

--- a/cmd/dry.go
+++ b/cmd/dry.go
@@ -42,7 +42,11 @@ func runDry(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 
-	dag, err := digraph.Load(ctx, cfg.Paths.BaseConfig, args[0], removeQuotes(params))
+	strParams := removeQuotes(params)
+	dag, err := digraph.Load(ctx, args[0],
+		digraph.WithBaseDAG(cfg.Paths.BaseConfig),
+		digraph.WithParams(strParams),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to load DAG from %s: %w", args[0], err)
 	}

--- a/cmd/dry.go
+++ b/cmd/dry.go
@@ -78,7 +78,7 @@ func runDry(cmd *cobra.Command, args []string) error {
 		cli,
 		dagStore,
 		setup.historyStore(),
-		&agent.Options{Dry: true},
+		agent.Options{Dry: true},
 	)
 
 	listenSignals(ctx, agt)

--- a/cmd/dry.go
+++ b/cmd/dry.go
@@ -44,7 +44,7 @@ func runDry(cmd *cobra.Command, args []string) error {
 
 	strParams := removeQuotes(params)
 	dag, err := digraph.Load(ctx, args[0],
-		digraph.WithBaseDAG(cfg.Paths.BaseConfig),
+		digraph.WithBaseConfig(cfg.Paths.BaseConfig),
 		digraph.WithParams(strParams),
 	)
 	if err != nil {

--- a/cmd/dry_test.go
+++ b/cmd/dry_test.go
@@ -16,6 +16,11 @@ func TestDryCommand(t *testing.T) {
 				args:        []string{"dry", th.DAGFile("success.yaml").Path},
 				expectedOut: []string{"Dry-run finished"},
 			},
+			{
+				name:        "DryRunDAGWithParamsAfterDash",
+				args:        []string{"dry", th.DAGFile("params.yaml").Path, "--", "p5", "p6"},
+				expectedOut: []string{`[p5 p6]`},
+			},
 		}
 
 		for _, tc := range tests {

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -53,7 +53,7 @@ func runRestart(cmd *cobra.Command, args []string) error {
 	specFilePath := args[0]
 
 	// Load initial DAG configuration
-	dag, err := digraph.Load(ctx, cfg.Paths.BaseConfig, specFilePath, "")
+	dag, err := digraph.Load(ctx, specFilePath, digraph.WithBaseDAG(cfg.Paths.BaseConfig))
 	if err != nil {
 		logger.Error(ctx, "Failed to load DAG", "path", specFilePath, "err", err)
 		return fmt.Errorf("failed to load DAG from %s: %w", specFilePath, err)
@@ -89,7 +89,7 @@ func handleRestartProcess(ctx context.Context, setup *setup, dag *digraph.DAG, q
 	}
 
 	// Reload DAG with parameters
-	dag, err = digraph.Load(ctx, setup.cfg.Paths.BaseConfig, specFilePath, params)
+	dag, err = digraph.Load(ctx, specFilePath, digraph.WithBaseDAG(setup.cfg.Paths.BaseConfig), digraph.WithParams(params))
 	if err != nil {
 		return fmt.Errorf("failed to reload DAG with params: %w", err)
 	}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -129,7 +129,7 @@ func executeDAG(ctx context.Context, cli client.Client, setup *setup,
 		cli,
 		dagStore,
 		setup.historyStore(),
-		&agent.Options{Dry: false})
+		agent.Options{Dry: false})
 
 	listenSignals(ctx, agt)
 	if err := agt.Run(ctx); err != nil {

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -53,7 +53,7 @@ func runRestart(cmd *cobra.Command, args []string) error {
 	specFilePath := args[0]
 
 	// Load initial DAG configuration
-	dag, err := digraph.Load(ctx, specFilePath, digraph.WithBaseDAG(cfg.Paths.BaseConfig))
+	dag, err := digraph.Load(ctx, specFilePath, digraph.WithBaseConfig(cfg.Paths.BaseConfig))
 	if err != nil {
 		logger.Error(ctx, "Failed to load DAG", "path", specFilePath, "err", err)
 		return fmt.Errorf("failed to load DAG from %s: %w", specFilePath, err)
@@ -89,7 +89,7 @@ func handleRestartProcess(ctx context.Context, setup *setup, dag *digraph.DAG, q
 	}
 
 	// Reload DAG with parameters
-	dag, err = digraph.Load(ctx, specFilePath, digraph.WithBaseDAG(setup.cfg.Paths.BaseConfig), digraph.WithParams(params))
+	dag, err = digraph.Load(ctx, specFilePath, digraph.WithBaseConfig(setup.cfg.Paths.BaseConfig), digraph.WithParams(params))
 	if err != nil {
 		return fmt.Errorf("failed to reload DAG with params: %w", err)
 	}

--- a/cmd/restart_test.go
+++ b/cmd/restart_test.go
@@ -55,7 +55,7 @@ func TestRestartCommand(t *testing.T) {
 		dagFile.AssertCurrentStatus(t, scheduler.StatusNone)
 
 		// Check parameter was the same as the first execution
-		dag, err := digraph.Load(th.Context, th.Config.Paths.BaseConfig, dagFile.Path, "")
+		dag, err := digraph.Load(th.Context, dagFile.Path, digraph.WithBaseDAG(th.Config.Paths.BaseConfig))
 		require.NoError(t, err)
 
 		setup := newSetup(th.Config)

--- a/cmd/restart_test.go
+++ b/cmd/restart_test.go
@@ -55,7 +55,7 @@ func TestRestartCommand(t *testing.T) {
 		dagFile.AssertCurrentStatus(t, scheduler.StatusNone)
 
 		// Check parameter was the same as the first execution
-		dag, err := digraph.Load(th.Context, dagFile.Path, digraph.WithBaseDAG(th.Config.Paths.BaseConfig))
+		dag, err := digraph.Load(th.Context, dagFile.Path, digraph.WithBaseConfig(th.Config.Paths.BaseConfig))
 		require.NoError(t, err)
 
 		setup := newSetup(th.Config)

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -123,7 +123,7 @@ func executeRetry(ctx context.Context, dag *digraph.DAG, setup *setup, originalS
 		cli,
 		dagStore,
 		setup.historyStore(),
-		&agent.Options{RetryTarget: &originalStatus.Status},
+		agent.Options{RetryTarget: &originalStatus.Status},
 	)
 
 	listenSignals(ctx, agt)

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -71,7 +71,7 @@ func runRetry(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to retrieve historical execution for request ID %s: %w", requestID, err)
 	}
 
-	dag, err := digraph.Load(ctx, absolutePath, digraph.WithBaseDAG(cfg.Paths.BaseConfig),
+	dag, err := digraph.Load(ctx, absolutePath, digraph.WithBaseConfig(cfg.Paths.BaseConfig),
 		digraph.WithParams(status.Status.Params))
 	if err != nil {
 		logger.Error(ctx, "Failed to load DAG specification", "path", specFilePath, "err", err)

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -71,7 +71,8 @@ func runRetry(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to retrieve historical execution for request ID %s: %w", requestID, err)
 	}
 
-	dag, err := digraph.Load(ctx, cfg.Paths.BaseConfig, absolutePath, status.Status.Params)
+	dag, err := digraph.Load(ctx, absolutePath, digraph.WithBaseDAG(cfg.Paths.BaseConfig),
+		digraph.WithParams(status.Status.Params))
 	if err != nil {
 		logger.Error(ctx, "Failed to load DAG specification", "path", specFilePath, "err", err)
 		return fmt.Errorf("failed to load DAG specification from %s with params %s: %w",

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -76,7 +76,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 }
 
 func executeDag(ctx context.Context, setup *setup, specPath, params string, quiet bool, requestID string) error {
-	dag, err := digraph.Load(ctx, setup.cfg.Paths.BaseConfig, specPath, params)
+	dag, err := digraph.Load(ctx, specPath, digraph.WithBaseDAG(setup.cfg.Paths.BaseConfig), digraph.WithParams(params))
 	if err != nil {
 		logger.Error(ctx, "Failed to load DAG", "path", specPath, "err", err)
 		return fmt.Errorf("failed to load DAG from %s: %w", specPath, err)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -122,7 +122,7 @@ func executeDag(ctx context.Context, setup *setup, specPath, params string, quie
 		cli,
 		dagStore,
 		setup.historyStore(),
-		&agent.Options{},
+		agent.Options{},
 	)
 
 	listenSignals(ctx, agt)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -20,9 +20,9 @@ const startPrefix = "start_"
 
 func startCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "start [flags] /path/to/spec.yaml",
+		Use:   "start [flags] /path/to/spec.yaml [-- params1 params2]",
 		Short: "Runs the DAG",
-		Long:  `dagu start [--params="param1 param2"] /path/to/spec.yaml`,
+		Long:  `dagu start /path/to/spec.yaml -- params1 params2`,
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  wrapRunE(runStart),
 	}
@@ -69,7 +69,6 @@ func runStart(cmd *cobra.Command, args []string) error {
 		// Get parameters from flags
 		params, err = cmd.Flags().GetString("params")
 		if err != nil {
-			logger.Error(ctx, "Failed to get parameters", "err", err)
 			return fmt.Errorf("failed to get parameters: %w", err)
 		}
 		loadOpts = append(loadOpts, digraph.WithParams(removeQuotes(params)))

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -76,7 +76,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 }
 
 func executeDag(ctx context.Context, setup *setup, specPath, params string, quiet bool, requestID string) error {
-	dag, err := digraph.Load(ctx, specPath, digraph.WithBaseDAG(setup.cfg.Paths.BaseConfig), digraph.WithParams(params))
+	dag, err := digraph.Load(ctx, specPath, digraph.WithBaseConfig(setup.cfg.Paths.BaseConfig), digraph.WithParams(params))
 	if err != nil {
 		logger.Error(ctx, "Failed to load DAG", "path", specPath, "err", err)
 		return fmt.Errorf("failed to load DAG from %s: %w", specPath, err)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -57,9 +57,8 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 	ctx := setup.loggerContext(cmd.Context(), quiet)
 
-	var loadOpts []digraph.LoadOption
-	if setup.cfg.Paths.BaseConfig != "" {
-		loadOpts = append(loadOpts, digraph.WithBaseConfig(setup.cfg.Paths.BaseConfig))
+	loadOpts := []digraph.LoadOption{
+		digraph.WithBaseConfig(setup.cfg.Paths.BaseConfig),
 	}
 
 	var params string

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -28,6 +28,11 @@ func TestStartCommand(t *testing.T) {
 			args:        []string{"start", `--params="p3 p4"`, th.DAGFile("params.yaml").Path},
 			expectedOut: []string{`params="[p3 p4]"`},
 		},
+		{
+			name:        "StartDAGWithParamsAfterDash",
+			args:        []string{"start", th.DAGFile("params.yaml").Path, "--", "p5", "p6"},
+			expectedOut: []string{`params="[p5 p6]"`},
+		},
 	}
 
 	for _, tc := range tests {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -34,7 +34,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	ctx := setup.loggerContext(cmd.Context(), false)
 
 	// Load the DAG
-	dag, err := digraph.Load(ctx, cfg.Paths.BaseConfig, args[0], "")
+	dag, err := digraph.Load(ctx, args[0], digraph.WithBaseDAG(cfg.Paths.BaseConfig))
 	if err != nil {
 		logger.Error(ctx, "Failed to load DAG", "path", args[0], "err", err)
 		return fmt.Errorf("failed to load DAG from %s: %w", args[0], err)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -34,7 +34,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	ctx := setup.loggerContext(cmd.Context(), false)
 
 	// Load the DAG
-	dag, err := digraph.Load(ctx, args[0], digraph.WithBaseDAG(cfg.Paths.BaseConfig))
+	dag, err := digraph.Load(ctx, args[0], digraph.WithBaseConfig(cfg.Paths.BaseConfig))
 	if err != nil {
 		logger.Error(ctx, "Failed to load DAG", "path", args[0], "err", err)
 		return fmt.Errorf("failed to load DAG from %s: %w", args[0], err)

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -33,7 +33,7 @@ func runStop(cmd *cobra.Command, args []string) error {
 
 	ctx := setup.loggerContext(cmd.Context(), false)
 
-	dag, err := digraph.Load(cmd.Context(), args[0], digraph.WithBaseDAG(cfg.Paths.BaseConfig))
+	dag, err := digraph.Load(cmd.Context(), args[0], digraph.WithBaseConfig(cfg.Paths.BaseConfig))
 	if err != nil {
 		logger.Error(ctx, "Failed to load DAG", "err", err)
 		return fmt.Errorf("failed to load DAG from %s: %w", args[0], err)

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -33,7 +33,7 @@ func runStop(cmd *cobra.Command, args []string) error {
 
 	ctx := setup.loggerContext(cmd.Context(), false)
 
-	dag, err := digraph.Load(cmd.Context(), cfg.Paths.BaseConfig, args[0], "")
+	dag, err := digraph.Load(cmd.Context(), args[0], digraph.WithBaseDAG(cfg.Paths.BaseConfig))
 	if err != nil {
 		logger.Error(ctx, "Failed to load DAG", "err", err)
 		return fmt.Errorf("failed to load DAG from %s: %w", args[0], err)

--- a/cmd/testdata/dry_params.yaml
+++ b/cmd/testdata/dry_params.yaml
@@ -1,0 +1,4 @@
+params: "p1 p2"
+steps:
+  - name: "1"
+    command: "echo \"params is $1 and $2\""

--- a/cmd/testdata/params_after_dash.yaml
+++ b/cmd/testdata/params_after_dash.yaml
@@ -1,0 +1,4 @@
+params: "p1 p2"
+steps:
+  - name: "1"
+    command: "echo \"params is $1 and $2\""

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -8,7 +8,13 @@ The following commands are available for interacting with Dagu:
 .. code-block:: sh
 
   # Runs the DAG
-  dagu start [--params=<params>] <file>
+  dagu start <file>
+  
+  # Runs the DAG with named parameters
+  dagu start <file> -- <key>=<value> ...
+  
+  # Runs the DAG with positional parameters
+  dagu start <file> -- value1 value2 ...
   
   # Displays the current status of the DAG
   dagu status <file>

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -11,10 +11,10 @@ The following commands are available for interacting with Dagu:
   dagu start <file>
   
   # Runs the DAG with named parameters
-  dagu start <file> -- <key>=<value> ...
+  dagu start <file> [-- <key>=<value> ...]
   
   # Runs the DAG with positional parameters
-  dagu start <file> -- value1 value2 ...
+  dagu start <file> [-- value1 value2 ...]
   
   # Displays the current status of the DAG
   dagu status <file>
@@ -29,7 +29,7 @@ The following commands are available for interacting with Dagu:
   dagu restart <file>
   
   # Dry-runs the DAG
-  dagu dry [--params=<params>] <file>
+  dagu dry <file> [-- <key>=<value> ...]
   
   # Launches both the web UI server and scheduler process
   dagu start-all [--host=<host>] [--port=<port>] [--dags=<path to directory>]

--- a/docs/source/schema.rst
+++ b/docs/source/schema.rst
@@ -62,6 +62,24 @@ These fields apply to the entire DAG. They appear at the root of the YAML file.
 
     schedule: "5 4 * * *"  # runs daily at 04:05
 
+- **dotenv** (string or list of strings, optional):
+
+  Path to a `.env` file or a list of paths to load environment variables from.  
+  Dagu reads these files before running the DAG.
+
+  **Example**:
+
+  .. code-block:: yaml
+
+    dotenv: /path/to/.env
+
+  Files can be specified as:
+  
+  - Absolute paths
+  - Relative to the DAG file directory
+  - Relative to the base config directory
+  - Relative to the user's home directory
+
 - **skipIfSuccessful** (boolean, default: false):
 
   If true, Dagu checks whether this DAG has already succeeded since the last scheduled time. If it did, Dagu will skip the current scheduled run. Manual triggers always run regardless of this setting.

--- a/docs/source/schema.rst
+++ b/docs/source/schema.rst
@@ -31,8 +31,8 @@ DAG-Level Fields
 ----------------
 These fields apply to the entire DAG. They appear at the root of the YAML file.
 
-- **name** (string, optional):
-  
+``name``
+~~~~~~~~
   The name of the DAG. If omitted, Dagu defaults the name to the YAML filename without the extension.
   
   **Example**:
@@ -41,8 +41,8 @@ These fields apply to the entire DAG. They appear at the root of the YAML file.
 
     name: My Daily DAG
 
-- **description** (string, optional):
-
+``description``
+~~~~~~~~~~~~~~
   A short description of what the DAG does.
 
   **Example**:
@@ -51,8 +51,8 @@ These fields apply to the entire DAG. They appear at the root of the YAML file.
 
     description: This DAG processes daily data and sends notifications.
 
-- **schedule** (string, optional):
-
+``schedule``
+~~~~~~~~~~~
   A cron expression (``* * * * *``) that determines how often the DAG runs.  
   If omitted, the DAG will only run manually (unless triggered via CLI or another mechanism).
 
@@ -62,8 +62,8 @@ These fields apply to the entire DAG. They appear at the root of the YAML file.
 
     schedule: "5 4 * * *"  # runs daily at 04:05
 
-- **dotenv** (string or list of strings, optional):
-
+``dotenv``
+~~~~~~~~~~
   Path to a `.env` file or a list of paths to load environment variables from.  
   Dagu reads these files before running the DAG.
 
@@ -80,8 +80,8 @@ These fields apply to the entire DAG. They appear at the root of the YAML file.
   - Relative to the base config directory
   - Relative to the user's home directory
 
-- **skipIfSuccessful** (boolean, default: false):
-
+``skipIfSuccessful``
+~~~~~~~~~~~~~~~~~~~
   If true, Dagu checks whether this DAG has already succeeded since the last scheduled time. If it did, Dagu will skip the current scheduled run. Manual triggers always run regardless of this setting.
 
   **Example**:
@@ -90,16 +90,16 @@ These fields apply to the entire DAG. They appear at the root of the YAML file.
 
     skipIfSuccessful: true
 
-- **group** (string, optional):
-
+``group``
+~~~~~~~~~
   An organizational label you can use to group DAGs (e.g., "DailyJobs", "Analytics").
 
-- **tags** (string, optional):
-
+``tags``
+~~~~~~~~
   A comma-separated list of tags. Useful for searching, grouping, or labeling runs (e.g., "finance, daily").
 
-- **env** (list of key-value, optional):
-
+``env``
+~~~~~~~
   Environment variables available to all steps in the DAG. These can use shell expansions, references to other environment variables, or command substitutions. They won't be stored in execution history data for security reasons, so if you want to retry a failed run, you need to have the same environment variables available.
 
   **Example**:
@@ -110,32 +110,32 @@ These fields apply to the entire DAG. They appear at the root of the YAML file.
       - LOG_DIR: ${HOME}/logs
       - PATH: /usr/local/bin:${PATH}
 
-- **logDir** (string, default: ``${HOME}/.local/share/logs``):
-
+``logDir``
+~~~~~~~~~~
   The base directory in which logs for this DAG are stored.
 
-- **restartWaitSec** (integer, optional):
-
+``restartWaitSec``
+~~~~~~~~~~~~~~~~~
   Number of seconds to wait before restarting a failed or stopped DAG. Typically used with a process supervisor.
 
-- **histRetentionDays** (integer, optional):
-
+``histRetentionDays``
+~~~~~~~~~~~~~~~~~~~~
   How many days of historical run data to retain for this DAG. After this period, older run logs/history can be purged.
 
-- **timeoutSec** (integer, optional):
+``timeoutSec``
+~~~~~~~~~~~~~
+  Maximum number of seconds for the entire DAG to finish. If the DAG hasn't finished after this time, it's considered timed out.
 
-  Maximum number of seconds for the entire DAG to finish. If the DAG hasn’t finished after this time, it’s considered timed out.
-
-- **delaySec** (integer, optional):
-
+``delaySec``
+~~~~~~~~~~~
   Delay (in seconds) before starting each step in a DAG run. This can be useful to stagger workloads.
 
-- **maxActiveRuns** (integer, optional):
-
+``maxActiveRuns``
+~~~~~~~~~~~~~~~
   Limit on how many runs of this DAG can be active at once (especially relevant if the DAG has a frequent schedule).
 
-- **params** (string or list of key-value, optional):
-
+``params``
+~~~~~~~~~
   Default parameters for the entire DAG, either positional or named. Steps can reference these as environment variables (``$1, $2, ...`` for positional or ``$KEY`` for named).
 
   **Example (positional)**:
@@ -152,8 +152,8 @@ These fields apply to the entire DAG. They appear at the root of the YAML file.
       - FOO: 1
       - BAR: "`echo 2`"
 
-- **preconditions** (list of condition blocks, optional):
-
+``preconditions``
+~~~~~~~~~~~~~~~
   A list of conditions that must be satisfied before the DAG can run. Each condition can use shell expansions or command substitutions to validate external states.
 
   **Example**:
@@ -164,8 +164,8 @@ These fields apply to the entire DAG. They appear at the root of the YAML file.
       - condition: "`echo $2`" 
         expected: "param2"
 
-- **mailOn** (dictionary, optional):
-
+``mailOn``
+~~~~~~~~~
   Email notifications at DAG-level events, such as ``failure`` or ``success``. Also supports ``cancel`` and ``exit``.
 
   **Example**:
@@ -176,12 +176,12 @@ These fields apply to the entire DAG. They appear at the root of the YAML file.
       failure: true
       success: false
 
-- **MaxCleanUpTimeSec** (integer, optional):
-
+``MaxCleanUpTimeSec``
+~~~~~~~~~~~~~~~~~~~
   Maximum number of seconds Dagu will spend cleaning up (stopping steps, finalizing logs, etc.) before forcing shutdown.
 
-- **handlerOn** (dictionary, optional):
-
+``handlerOn``
+~~~~~~~~~~~~
   Lifecycle event hooks at the DAG level. For each event (``success``, ``failure``, ``cancel``, ``exit``), you can run an additional command or script.
 
   **Example**:
@@ -198,8 +198,8 @@ These fields apply to the entire DAG. They appear at the root of the YAML file.
       exit:
         command: echo "all done!"
 
-- **steps** (list of step objects, required):
-
+``steps``
+~~~~~~~~
   A list of steps (tasks) to execute. Steps define your workflow logic and can depend on each other. See :ref:`Step Fields <step-fields>` below for details.
 
 ------------
@@ -210,177 +210,129 @@ Step Fields
 -----------
 Each element in the top-level ``steps`` list has its own fields for customization. A step object looks like this:
 
-- **name** (string, required):
-
+``name``
+~~~~~~~~
   A unique identifier for the step within this DAG.
 
-- **description** (string, optional):
-
+``description``
+~~~~~~~~~~~~~
   Brief description of what this step does.
 
-- **dir** (string, optional):
+``dir``
+~~~~~~
+  Working directory in which this step's command or script is executed.
 
-  Working directory in which this step’s command or script is executed.
-
-- **command** (string, optional if ``script`` is used; otherwise required):
-
+``command``
+~~~~~~~~~~
   The command or executable to run for this step.  
   Examples include ``bash``, ``python``, or direct shell commands like ``echo hello``.
 
-- **script** (string, optional):
-
+``script``
+~~~~~~~~~
   Multi-line inline script content that will be piped into the command.  
-  If ``command`` is omitted, the script is executed with the system’s default shell.
+  If ``command`` is omitted, the script is executed with the system's default shell.
 
-- **stdout** (string, optional):
+``stdout``
+~~~~~~~~~
+  Path to a file in which to store the standard output (STDOUT) of the step's command.
 
-  Path to a file in which to store the standard output (STDOUT) of the step’s command.
+``stderr``
+~~~~~~~~~
+  Path to a file in which to store the standard error (STDERR) of the step's command.
 
-- **stderr** (string, optional):
+``output``
+~~~~~~~~~
+  A variable name to store the command's STDOUT contents. You can reuse this variable in subsequent steps.
 
-  Path to a file in which to store the standard error (STDERR) of the step’s command.
-
-- **output** (string, optional):
-
-  A variable name to store the command’s STDOUT contents. You can reuse this variable in subsequent steps.
-
-- **signalOnStop** (string, optional):
-
+``signalOnStop``
+~~~~~~~~~~~~~~
   If you manually stop this step (e.g., via CLI), the signal that Dagu sends to kill the process (e.g., ``SIGINT``).
 
-- **mailOn** (dictionary, optional):
-
+``mailOn``
+~~~~~~~~~
   Email notifications at the step level (same structure as DAG-level ``mailOn``).
 
-- **continueOn** (dictionary, optional):
-
+``continueOn``
+~~~~~~~~~~~~
   Controls how Dagu handles cases where the step is skipped or fails.  
 
   - **failure**: If true, continue the DAG even if this step fails.  
   - **skipped**: If true, continue the DAG even if preconditions cause this step to skip.
 
-- **retryPolicy** (dictionary, optional):
-
+``retryPolicy``
+~~~~~~~~~~~~~
   Defines automatic retries for this step when it fails.  
 
   - **limit** (integer): How many times to retry.  
   - **intervalSec** (integer): How many seconds to wait between retries.
 
-- **repeatPolicy** (dictionary, optional):
+  .. code-block:: yaml
+  
+    retryPolicy:
+      limit: 3
+      intervalSec: 5
 
+``repeatPolicy``
+~~~~~~~~~~~~~
   Allows repeating a step multiple times in a single run.  
 
   - **repeat** (boolean): Whether to repeat.  
   - **intervalSec** (integer): Interval in seconds between repeats.
 
-- **preconditions** (list of condition blocks, optional):
+  .. code-block:: yaml
+  
+    repeatPolicy:
+      repeat: true
+      intervalSec: 60  # run every minute
 
+``preconditions``
+~~~~~~~~~~~~~~
   Conditions that must be met for this step to run. Each condition block has:
 
   - **condition** (string): A command or expression to evaluate.
   - **expected** (string): The expected output. If the output matches, the step runs; otherwise, it is skipped.
 
-- **depends** (list of strings, optional):
+  .. code-block:: yaml
+  
+    steps:
+      - name: monthly task
+        command: monthly.sh
+        preconditions:
+          - condition: "`date '+%d'`"
+            expected: "01"
 
+``depends``
+~~~~~~~~~
   Names of other steps that must complete before this step can run.
 
-- **run** (string, optional):
-
+``run``
+~~~~~~
   Reference to another YAML file (sub workflow) to run at this step.  
   If present, the sub workflow is executed in place of a command.
 
-- **params** (string or list of key-value, optional):
+  .. code-block:: yaml
+  
+    steps:
+      - name: sub workflow
+        run: sub_dag.yaml
+        params: FOO=BAR
 
+``params``
+~~~~~~~~
   Parameters to pass into a sub workflow if this step references one (via ``run``). You can also treat these as environment variables in the workflow.
 
-- **executor** (dictionary, optional):
-
+``executor``
+~~~~~~~~~~
   An executor configuration specifying how the command or script is run (e.g., Docker, SSH, HTTP, Mail, JSON).  
   For more details, see :ref:`Executors <Executors>`.
 
 ------------
 
-Additional Constructs
----------------------
-
-Parameters
-~~~~~~~~~~
-Dagu supports both positional and named parameters at the DAG level. Steps can then override or add parameters. Access them in commands/scripts as environment variables.
-
-.. code-block:: yaml
-
-  params: param1 param2
-
-  steps:
-    - name: example
-      command: echo "First param: $1, second param: $2"
-
-Or with named parameters:
-
-.. code-block:: yaml
-
-  params:
-    - FOO: 1
-    - BAR: "`echo 2`"
-
-  steps:
-    - name: named example
-      command: echo "FOO is ${FOO}, BAR is ${BAR}"
-
-Preconditions
-~~~~~~~~~~~~~
-You can define preconditions at both DAG and step levels. Each precondition runs a shell expression and checks if its output matches an ``expected`` string. If it doesn’t match, the DAG or step is skipped (unless otherwise controlled by ``continueOn``).
-
-Retry Policy
-~~~~~~~~~~~~
-Define how many times a failing step should retry, plus a wait interval:
-
-.. code-block:: yaml
-
-  retryPolicy:
-    limit: 3
-    intervalSec: 5
-
-Repeat Policy
-~~~~~~~~~~~~~
-Run the same step multiple times in a single DAG run, with a configurable delay between repeats:
-
-.. code-block:: yaml
-
-  repeatPolicy:
-    repeat: true
-    intervalSec: 60  # run every minute
-
-Sub-Workflows
-~~~~~~~~~~~~~
-Use the ``run`` field within a step to call another YAML file. This helps organize large workflows. You can pass parameters:
-
-.. code-block:: yaml
-
-  steps:
-    - name: sub workflow
-      run: sub_dag.yaml
-      params: FOO=BAR
-
-Lifecycle Hooks (handlerOn)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-React to DAG-wide events like success, failure, cancel, and exit:
-
-.. code-block:: yaml
-
-  handlerOn:
-    success:
-      command: echo "DAG succeeded!"
-    failure:
-      command: echo "DAG failed!"
-    exit:
-      command: echo "DAG exited!"
-
 Global Configuration
 --------------------
 You can place global defaults in ``$HOME/.config/dagu/base.yaml``. This file can contain:
 
-- Default environment variables
+- Default environment variables or dotenv files
 - Email notification settings
 - A global ``logDir``
 - Common organizational patterns
@@ -393,6 +345,8 @@ Example:
   logDir: /var/log/dagu
   env:
     - GLOBAL_VAR: "HelloFromGlobalConfig"
+  dotenv:
+    - /path/to/.env
   mailOn:
     success: true
     failure: true
@@ -439,7 +393,7 @@ The ``docker`` executor runs commands inside Docker containers. This can help yo
            autoRemove: true
        command: run https://raw.githubusercontent.com/denoland/deno-docs/main/by-example/hello-world.ts
 
-By default, Dagu pulls the Docker image. If you’re using a local image, set :code:`pull: false`.
+By default, Dagu pulls the Docker image. If you're using a local image, set :code:`pull: false`.
 
 You can also configure volumes, environment variables, etc.:
 

--- a/docs/source/yaml_format.rst
+++ b/docs/source/yaml_format.rst
@@ -99,6 +99,27 @@ Define variables accessible throughout the DAG:
       dir: ${SOME_DIR}
       command: python main.py ${SOME_FILE}
 
+Dotenv Files
+~~~~~~~~~~~
+Specify candidate ``.env`` files to load environment variables from. By default, no env files are loaded unless explicitly specified.
+
+.. code-block:: yaml
+
+  dotenv: .env  # Specify a candidate dotenv file
+
+  # Or specify multiple candidate files
+  dotenv:
+    - .env
+    - .env.local
+    - configs/.env.prod
+
+Files can be specified as:
+
+- Absolute paths
+- Relative to the DAG file directory
+- Relative to the base config directory
+- Relative to the user's home directory
+
 Parameters
 ~~~~~~~~~~
 Pass positional parameters to steps:

--- a/docs/source/yaml_format.rst
+++ b/docs/source/yaml_format.rst
@@ -122,27 +122,27 @@ Files can be specified as:
 
 Parameters
 ~~~~~~~~~~
-Pass positional parameters to steps:
+Define default positional parameters that can be overridden:
 
 .. code-block:: yaml
 
-  params: param1 param2
+  params: param1 param2  # Default values for $1 and $2
   steps:
     - name: parameterized task
-      command: python main.py $1 $2
+      command: python main.py $1 $2      # Will use command-line args or defaults
 
 Named Parameters
 ~~~~~~~~~~~~~~
-Use named parameters for better clarity:
+Define default named parameters that can be overridden:
 
 .. code-block:: yaml
 
   params:
-    - FOO: 1
-    - BAR: "`echo 2`"
+    - FOO: 1           # Default value for ${FOO}
+    - BAR: "`echo 2`"  # Default value for ${BAR}, using command substitution
   steps:
     - name: named params task
-      command: python main.py ${FOO} ${BAR}
+      command: python main.py ${FOO} ${BAR}  # Will use command-line args or defaults
 
 Code Snippets
 ~~~~~~~~~~~~

--- a/go.mod
+++ b/go.mod
@@ -145,6 +145,7 @@ require (
 	github.com/jgautheron/goconst v1.7.1 // indirect
 	github.com/jingyugao/rowserrcheck v1.1.1 // indirect
 	github.com/jjti/go-spancheck v0.6.2 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/julz/importas v0.1.0 // indirect
 	github.com/karamaru-alpha/copyloopvar v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -412,6 +412,8 @@ github.com/jingyugao/rowserrcheck v1.1.1 h1:zibz55j/MJtLsjP1OF4bSdgXxwL1b+Vn7Tjz
 github.com/jingyugao/rowserrcheck v1.1.1/go.mod h1:4yvlZSDb3IyDTUZJUmpZfm2Hwok+Dtp+nu2qOq+er9c=
 github.com/jjti/go-spancheck v0.6.2 h1:iYtoxqPMzHUPp7St+5yA8+cONdyXD3ug6KK15n7Pklk=
 github.com/jjti/go-spancheck v0.6.2/go.mod h1:+X7lvIrR5ZdUTkxFYqzJ0abr8Sb5LOo80uOhWNqIrYA=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -102,12 +102,6 @@ func (a *Agent) Run(ctx context.Context) error {
 	dbClient := newDBClient(a.historyStore, a.dagStore)
 	ctx = digraph.NewContext(ctx, a.dag, dbClient, a.requestID, a.logFile)
 
-	// Load environment variables for the DAG execution
-	if err := a.dag.LoadEnvs(ctx); err != nil {
-		logger.Error(ctx, "Failed to load envs", "err", err)
-		return err
-	}
-
 	// It should not run the DAG if the condition is unmet.
 	if err := a.checkPreconditions(ctx); err != nil {
 		logger.Info(ctx, "Preconditions are not met", "err", err)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -360,7 +360,7 @@ func (a *Agent) dryRun(ctx context.Context) error {
 		}
 	}()
 
-	logger.Info(ctx, "Dry-run started", "reqId", a.requestID)
+	logger.Info(ctx, "Dry-run started", "reqId", a.requestID, "name", a.dag.Name, "params", a.dag.Params)
 
 	dagCtx := digraph.NewContext(context.Background(), a.dag, newDBClient(a.historyStore, a.dagStore), a.requestID, a.logFile)
 	lastErr := a.scheduler.Schedule(dagCtx, a.graph, done)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -77,7 +77,7 @@ func New(
 	cli client.Client,
 	dagStore persistence.DAGStore,
 	historyStore persistence.HistoryStore,
-	opts *Options,
+	opts Options,
 ) *Agent {
 	return &Agent{
 		requestID:    requestID,

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -145,7 +145,7 @@ func TestAgent_DryRun(t *testing.T) {
 		th := test.Setup(t)
 
 		dag := th.LoadDAGFile(t, "dry.yaml")
-		dagAgent := dag.Agent(test.WithAgentOptions(&agent.Options{Dry: true}))
+		dagAgent := dag.Agent(test.WithAgentOptions(agent.Options{Dry: true}))
 
 		dagAgent.RunSuccess(t)
 
@@ -175,7 +175,7 @@ func TestAgent_Retry(t *testing.T) {
 		}
 
 		// Retry the DAG and check if it is successful
-		dagAgent = dag.Agent(test.WithAgentOptions(&agent.Options{
+		dagAgent = dag.Agent(test.WithAgentOptions(agent.Options{
 			RetryTarget: &status,
 		}))
 		dagAgent.RunSuccess(t)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -256,7 +256,8 @@ steps:
 		require.NoError(t, err)
 
 		// Check if the new DAG is actually created.
-		dag, err := digraph.Load(ctx, "", filepath.Join(th.Config.Paths.DAGsDir, id+".yaml"), "")
+		filePath := filepath.Join(th.Config.Paths.DAGsDir, id+".yaml")
+		dag, err := digraph.Load(ctx, filePath)
 		require.NoError(t, err)
 		require.Equal(t, "test-dag", dag.Name)
 	})

--- a/internal/digraph/assert.go
+++ b/internal/digraph/assert.go
@@ -14,19 +14,19 @@ func assertFunctions(fns []*funcDef) error {
 	nameMap := make(map[string]bool)
 	for _, funcDef := range fns {
 		if _, exists := nameMap[funcDef.Name]; exists {
-			return errDuplicateFunction
+			return WrapError("function", funcDef.Name, errDuplicateFunction)
 		}
 		nameMap[funcDef.Name] = true
 
 		definedParamNames := strings.Split(funcDef.Params, " ")
 		passedParamNames := extractParamNames(funcDef.Command)
 		if len(definedParamNames) != len(passedParamNames) {
-			return errFuncParamsMismatch
+			return WrapError("function", funcDef.Name, errFuncParamsMismatch)
 		}
 
 		for i := 0; i < len(definedParamNames); i++ {
 			if definedParamNames[i] != passedParamNames[i] {
-				return errFuncParamsMismatch
+				return WrapError("function", funcDef.Name, errFuncParamsMismatch)
 			}
 		}
 	}
@@ -38,7 +38,7 @@ func assertFunctions(fns []*funcDef) error {
 func assertStepDef(def stepDef, funcs []*funcDef) error {
 	// Step name is required.
 	if def.Name == "" {
-		return errStepNameRequired
+		return WrapError("name", def.Name, errStepNameRequired)
 	}
 
 	// TODO: Validate executor config for each executor type.
@@ -60,18 +60,18 @@ func assertStepDef(def stepDef, funcs []*funcDef) error {
 			}
 		}
 		if calledFuncDef.Name == "" {
-			return errCallFunctionNotFound
+			return WrapError("function", calledFunc, errCallFunctionNotFound)
 		}
 
 		definedParamNames := strings.Split(calledFuncDef.Params, " ")
 		if len(def.Call.Args) != len(definedParamNames) {
-			return errNumberOfParamsMismatch
+			return WrapError("function", calledFunc, errNumberOfParamsMismatch)
 		}
 
 		for _, paramName := range definedParamNames {
 			_, exists := def.Call.Args[paramName]
 			if !exists {
-				return errRequiredParameterNotFound
+				return WrapError("function", calledFunc, errRequiredParameterNotFound)
 			}
 		}
 	}

--- a/internal/digraph/assert.go
+++ b/internal/digraph/assert.go
@@ -14,19 +14,19 @@ func assertFunctions(fns []*funcDef) error {
 	nameMap := make(map[string]bool)
 	for _, funcDef := range fns {
 		if _, exists := nameMap[funcDef.Name]; exists {
-			return WrapError("function", funcDef.Name, errDuplicateFunction)
+			return wrapError("function", funcDef.Name, errDuplicateFunction)
 		}
 		nameMap[funcDef.Name] = true
 
 		definedParamNames := strings.Split(funcDef.Params, " ")
 		passedParamNames := extractParamNames(funcDef.Command)
 		if len(definedParamNames) != len(passedParamNames) {
-			return WrapError("function", funcDef.Name, errFuncParamsMismatch)
+			return wrapError("function", funcDef.Name, errFuncParamsMismatch)
 		}
 
 		for i := 0; i < len(definedParamNames); i++ {
 			if definedParamNames[i] != passedParamNames[i] {
-				return WrapError("function", funcDef.Name, errFuncParamsMismatch)
+				return wrapError("function", funcDef.Name, errFuncParamsMismatch)
 			}
 		}
 	}
@@ -38,7 +38,7 @@ func assertFunctions(fns []*funcDef) error {
 func assertStepDef(def stepDef, funcs []*funcDef) error {
 	// Step name is required.
 	if def.Name == "" {
-		return WrapError("name", def.Name, errStepNameRequired)
+		return wrapError("name", def.Name, errStepNameRequired)
 	}
 
 	// TODO: Validate executor config for each executor type.
@@ -60,18 +60,18 @@ func assertStepDef(def stepDef, funcs []*funcDef) error {
 			}
 		}
 		if calledFuncDef.Name == "" {
-			return WrapError("function", calledFunc, errCallFunctionNotFound)
+			return wrapError("function", calledFunc, errCallFunctionNotFound)
 		}
 
 		definedParamNames := strings.Split(calledFuncDef.Params, " ")
 		if len(def.Call.Args) != len(definedParamNames) {
-			return WrapError("function", calledFunc, errNumberOfParamsMismatch)
+			return wrapError("function", calledFunc, errNumberOfParamsMismatch)
 		}
 
 		for _, paramName := range definedParamNames {
 			_, exists := def.Call.Args[paramName]
 			if !exists {
-				return WrapError("function", calledFunc, errRequiredParameterNotFound)
+				return wrapError("function", calledFunc, errRequiredParameterNotFound)
 			}
 		}
 	}

--- a/internal/digraph/builder.go
+++ b/internal/digraph/builder.go
@@ -103,7 +103,7 @@ func build(ctx context.Context, spec *definition, opts buildOpts, additionalEnvs
 			continue
 		}
 		if err := builder.fn(buildCtx, spec, dag); err != nil {
-			errs.Add(WrapError(builder.name, nil, err))
+			errs.Add(wrapError(builder.name, nil, err))
 		}
 	}
 
@@ -187,7 +187,7 @@ func buildSchedule(_ BuildContext, spec *definition, dag *DAG) error {
 		for _, s := range schedule {
 			s, ok := s.(string)
 			if !ok {
-				return WrapError("schedule", s, errScheduleMustBeStringOrArray)
+				return wrapError("schedule", s, errScheduleMustBeStringOrArray)
 			}
 			starts = append(starts, s)
 		}
@@ -205,7 +205,7 @@ func buildSchedule(_ BuildContext, spec *definition, dag *DAG) error {
 
 	default:
 		// If schedule is of an invalid type, return an error.
-		return WrapError("schedule", spec.Schedule, errInvalidScheduleType)
+		return wrapError("schedule", spec.Schedule, errInvalidScheduleType)
 
 	}
 
@@ -424,7 +424,7 @@ func buildRetryPolicy(_ BuildContext, def stepDef, step *Step) error {
 		case string:
 			step.RetryPolicy.LimitStr = v
 		default:
-			return WrapError("retryPolicy.Limit", v, fmt.Errorf("invalid type: %T", v))
+			return wrapError("retryPolicy.Limit", v, fmt.Errorf("invalid type: %T", v))
 		}
 
 		switch v := def.RetryPolicy.IntervalSec.(type) {
@@ -433,7 +433,7 @@ func buildRetryPolicy(_ BuildContext, def stepDef, step *Step) error {
 		case string:
 			step.RetryPolicy.IntervalSecStr = v
 		default:
-			return WrapError("retryPolicy.IntervalSec", v, fmt.Errorf("invalid type: %T", v))
+			return wrapError("retryPolicy.IntervalSec", v, fmt.Errorf("invalid type: %T", v))
 		}
 	}
 	return nil
@@ -512,7 +512,7 @@ func buildExecutor(_ BuildContext, def stepDef, step *Step) error {
 		for k, v := range val {
 			key, ok := k.(string)
 			if !ok {
-				return WrapError("executor.config", k, errExecutorConfigMustBeString)
+				return wrapError("executor.config", k, errExecutorConfigMustBeString)
 			}
 
 			switch key {
@@ -520,7 +520,7 @@ func buildExecutor(_ BuildContext, def stepDef, step *Step) error {
 				// Executor type is a string.
 				typ, ok := v.(string)
 				if !ok {
-					return WrapError("executor.type", v, errExecutorTypeMustBeString)
+					return wrapError("executor.type", v, errExecutorTypeMustBeString)
 				}
 				step.ExecutorConfig.Type = typ
 
@@ -530,26 +530,26 @@ func buildExecutor(_ BuildContext, def stepDef, step *Step) error {
 				// It is up to the executor to parse the values.
 				executorConfig, ok := v.(map[any]any)
 				if !ok {
-					return WrapError("executor.config", v, errExecutorConfigValueMustBeMap)
+					return wrapError("executor.config", v, errExecutorConfigValueMustBeMap)
 				}
 				for k, v := range executorConfig {
 					configKey, ok := k.(string)
 					if !ok {
-						return WrapError("executor.config", k, errExecutorConfigMustBeString)
+						return wrapError("executor.config", k, errExecutorConfigMustBeString)
 					}
 					step.ExecutorConfig.Config[configKey] = v
 				}
 
 			default:
 				// Unknown key in the executor config.
-				return WrapError("executor.config", key, fmt.Errorf("%w: %s", errExecutorHasInvalidKey, key))
+				return wrapError("executor.config", key, fmt.Errorf("%w: %s", errExecutorHasInvalidKey, key))
 
 			}
 		}
 
 	default:
 		// Unknown key for executor field.
-		return WrapError("executor", val, errExecutorConfigMustBeStringOrMap)
+		return wrapError("executor", val, errExecutorConfigMustBeStringOrMap)
 
 	}
 

--- a/internal/digraph/builder.go
+++ b/internal/digraph/builder.go
@@ -103,7 +103,7 @@ func build(ctx context.Context, spec *definition, opts buildOpts, additionalEnvs
 			continue
 		}
 		if err := builder.fn(buildCtx, spec, dag); err != nil {
-			errs.Add(fmt.Errorf("%s: %w", builder.name, err))
+			errs.Add(WrapError(builder.name, nil, err))
 		}
 	}
 
@@ -187,9 +187,7 @@ func buildSchedule(_ BuildContext, spec *definition, dag *DAG) error {
 		for _, s := range schedule {
 			s, ok := s.(string)
 			if !ok {
-				return fmt.Errorf(
-					"%w, got %T: ", errScheduleMustBeStringOrArray, s,
-				)
+				return WrapError("schedule", s, errScheduleMustBeStringOrArray)
 			}
 			starts = append(starts, s)
 		}
@@ -207,7 +205,7 @@ func buildSchedule(_ BuildContext, spec *definition, dag *DAG) error {
 
 	default:
 		// If schedule is of an invalid type, return an error.
-		return fmt.Errorf("%w: %T", errInvalidScheduleType, spec.Schedule)
+		return WrapError("schedule", spec.Schedule, errInvalidScheduleType)
 
 	}
 
@@ -417,6 +415,7 @@ func buildContinueOn(_ BuildContext, def stepDef, step *Step) error {
 	return nil
 }
 
+// buildRetryPolicy builds the retry policy for a step.
 func buildRetryPolicy(_ BuildContext, def stepDef, step *Step) error {
 	if def.RetryPolicy != nil {
 		switch v := def.RetryPolicy.Limit.(type) {
@@ -425,7 +424,7 @@ func buildRetryPolicy(_ BuildContext, def stepDef, step *Step) error {
 		case string:
 			step.RetryPolicy.LimitStr = v
 		default:
-			return fmt.Errorf("invalid type for retryPolicy.Limit: %T", v)
+			return WrapError("retryPolicy.Limit", v, fmt.Errorf("invalid type: %T", v))
 		}
 
 		switch v := def.RetryPolicy.IntervalSec.(type) {
@@ -434,7 +433,7 @@ func buildRetryPolicy(_ BuildContext, def stepDef, step *Step) error {
 		case string:
 			step.RetryPolicy.IntervalSecStr = v
 		default:
-			return fmt.Errorf("invalid type for retryPolicy.IntervalSec: %T", v)
+			return WrapError("retryPolicy.IntervalSec", v, fmt.Errorf("invalid type: %T", v))
 		}
 	}
 	return nil
@@ -513,7 +512,7 @@ func buildExecutor(_ BuildContext, def stepDef, step *Step) error {
 		for k, v := range val {
 			key, ok := k.(string)
 			if !ok {
-				return errExecutorConfigMustBeString
+				return WrapError("executor.config", k, errExecutorConfigMustBeString)
 			}
 
 			switch key {
@@ -521,7 +520,7 @@ func buildExecutor(_ BuildContext, def stepDef, step *Step) error {
 				// Executor type is a string.
 				typ, ok := v.(string)
 				if !ok {
-					return errExecutorTypeMustBeString
+					return WrapError("executor.type", v, errExecutorTypeMustBeString)
 				}
 				step.ExecutorConfig.Type = typ
 
@@ -531,26 +530,26 @@ func buildExecutor(_ BuildContext, def stepDef, step *Step) error {
 				// It is up to the executor to parse the values.
 				executorConfig, ok := v.(map[any]any)
 				if !ok {
-					return errExecutorConfigValueMustBeMap
+					return WrapError("executor.config", v, errExecutorConfigValueMustBeMap)
 				}
 				for k, v := range executorConfig {
 					configKey, ok := k.(string)
 					if !ok {
-						return errExecutorConfigMustBeString
+						return WrapError("executor.config", k, errExecutorConfigMustBeString)
 					}
 					step.ExecutorConfig.Config[configKey] = v
 				}
 
 			default:
 				// Unknown key in the executor config.
-				return fmt.Errorf("%w: %s", errExecutorHasInvalidKey, key)
+				return WrapError("executor.config", key, fmt.Errorf("%w: %s", errExecutorHasInvalidKey, key))
 
 			}
 		}
 
 	default:
 		// Unknown key for executor field.
-		return errExecutorConfigMustBeStringOrMap
+		return WrapError("executor", val, errExecutorConfigMustBeStringOrMap)
 
 	}
 

--- a/internal/digraph/builder.go
+++ b/internal/digraph/builder.go
@@ -27,15 +27,14 @@ type BuildContext struct {
 type buildOpts struct {
 	// base specifies the base configuration file for the DAG.
 	base string
-	// metadataOnly specifies whether to build only the metadata.
-	metadataOnly bool
+	// onlyMetadata specifies whether to build only the metadata.
+	onlyMetadata bool
 	// parameters specifies the parameters to the DAG.
-	// parameters are used to override the default parameters for
-	// executing the DAG.
+	// parameters are used to override the default parameters in the DAG.
 	parameters string
-	// noEval specifies whether to evaluate environment variables.
-	// This is useful when loading details for a DAG, but not
-	// for execution.
+	// parametersList specifies the parameters to the DAG.
+	parametersList []string
+	// noEval specifies whether to evaluate dynamic fields.
 	noEval bool
 }
 
@@ -128,7 +127,7 @@ func build(ctx context.Context, spec *definition, opts buildOpts, additionalEnvs
 
 	var errs errorList
 	for _, builder := range builderRegistry {
-		if !builder.metadata && opts.metadataOnly {
+		if !builder.metadata && opts.onlyMetadata {
 			continue
 		}
 		if err := builder.fn(buildCtx, spec, dag); err != nil {
@@ -136,7 +135,7 @@ func build(ctx context.Context, spec *definition, opts buildOpts, additionalEnvs
 		}
 	}
 
-	if !opts.metadataOnly {
+	if !opts.onlyMetadata {
 		// TODO: Remove functions feature.
 		if err := assertFunctions(spec.Functions); err != nil {
 			errs.Add(err)

--- a/internal/digraph/builder.go
+++ b/internal/digraph/builder.go
@@ -272,6 +272,8 @@ func buildDotenv(ctx BuildContext, spec *definition, dag *DAG) error {
 		if err := godotenv.Load(resolvedPath); err != nil {
 			return wrapError("dotenv", filePath, fmt.Errorf("failed to load dotenv file %s: %w", filePath, err))
 		}
+		// Break after the first successful load.
+		break
 	}
 
 	return nil

--- a/internal/digraph/builder.go
+++ b/internal/digraph/builder.go
@@ -5,7 +5,6 @@ package digraph
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -37,33 +36,6 @@ type buildOpts struct {
 	// noEval specifies whether to evaluate dynamic fields.
 	noEval bool
 }
-
-// errors on building a DAG.
-var (
-	errInvalidSchedule                    = errors.New("invalid schedule")
-	errScheduleMustBeStringOrArray        = errors.New("schedule must be a string or an array of strings")
-	errInvalidScheduleType                = errors.New("invalid schedule type")
-	errInvalidKeyType                     = errors.New("invalid key type")
-	errExecutorConfigMustBeString         = errors.New("executor config key must be string")
-	errDuplicateFunction                  = errors.New("duplicate function")
-	errFuncParamsMismatch                 = errors.New("func params and args given to func command do not match")
-	errStepNameRequired                   = errors.New("step name must be specified")
-	errStepCommandIsRequired              = errors.New("step command is required")
-	errStepCommandIsEmpty                 = errors.New("step command is empty")
-	errStepCommandMustBeArrayOrString     = errors.New("step command must be an array of strings or a string")
-	errInvalidParamValue                  = errors.New("invalid parameter value")
-	errCallFunctionNotFound               = errors.New("call must specify a functions that exists")
-	errNumberOfParamsMismatch             = errors.New("the number of parameters defined in the function does not match the number of parameters given")
-	errRequiredParameterNotFound          = errors.New("required parameter not found")
-	errScheduleKeyMustBeString            = errors.New("schedule key must be a string")
-	errInvalidSignal                      = errors.New("invalid signal")
-	errInvalidEnvValue                    = errors.New("invalid value for env")
-	errArgsMustBeConvertibleToIntOrString = errors.New("args must be convertible to either int or string")
-	errExecutorTypeMustBeString           = errors.New("executor.type value must be string")
-	errExecutorConfigValueMustBeMap       = errors.New("executor.config value must be a map")
-	errExecutorHasInvalidKey              = errors.New("executor has invalid key")
-	errExecutorConfigMustBeStringOrMap    = errors.New("executor config must be string or map")
-)
 
 var builderRegistry = []builderEntry{
 	{metadata: true, name: "env", fn: buildEnvs},

--- a/internal/digraph/builder_test.go
+++ b/internal/digraph/builder_test.go
@@ -372,7 +372,7 @@ func TestOverrideBaseConfig(t *testing.T) {
 		// Overwrite the base config with the following values:
 		// MailOn: {Failure: false, Success: false}
 		filePath := filepath.Join(testdataDir, "overwrite.yaml")
-		dag, err := Load(context.Background(), filePath, WithBaseDAG(baseConfig))
+		dag, err := Load(context.Background(), filePath, WithBaseConfig(baseConfig))
 		require.NoError(t, err)
 
 		// The MailOn key should be overwritten.
@@ -384,7 +384,7 @@ func TestOverrideBaseConfig(t *testing.T) {
 
 		// no_overwrite.yaml does not have the MailOn key.
 		filePath := filepath.Join(testdataDir, "no_overwrite.yaml")
-		dag, err := Load(context.Background(), filePath, WithBaseDAG(baseConfig))
+		dag, err := Load(context.Background(), filePath, WithBaseConfig(baseConfig))
 		require.NoError(t, err)
 
 		// The MailOn key should be the same as the base config.

--- a/internal/digraph/builder_test.go
+++ b/internal/digraph/builder_test.go
@@ -371,7 +371,8 @@ func TestOverrideBaseConfig(t *testing.T) {
 
 		// Overwrite the base config with the following values:
 		// MailOn: {Failure: false, Success: false}
-		dag, err := Load(context.Background(), baseConfig, filepath.Join(testdataDir, "overwrite.yaml"), "")
+		filePath := filepath.Join(testdataDir, "overwrite.yaml")
+		dag, err := Load(context.Background(), filePath, WithBaseDAG(baseConfig))
 		require.NoError(t, err)
 
 		// The MailOn key should be overwritten.
@@ -382,7 +383,8 @@ func TestOverrideBaseConfig(t *testing.T) {
 		baseConfig := filepath.Join(testdataDir, "base.yaml")
 
 		// no_overwrite.yaml does not have the MailOn key.
-		dag, err := Load(context.Background(), baseConfig, filepath.Join(testdataDir, "no_overwrite.yaml"), "")
+		filePath := filepath.Join(testdataDir, "no_overwrite.yaml")
+		dag, err := Load(context.Background(), filePath, WithBaseDAG(baseConfig))
 		require.NoError(t, err)
 
 		// The MailOn key should be the same as the base config.

--- a/internal/digraph/command.go
+++ b/internal/digraph/command.go
@@ -45,13 +45,13 @@ func buildCommand(_ BuildContext, def stepDef, step *Step) error {
 	case string:
 		// Case 2: command is a string
 		if val == "" {
-			return WrapError("command", val, errStepCommandIsEmpty)
+			return wrapError("command", val, errStepCommandIsEmpty)
 		}
 		// We need to split the command into command and args.
 		step.CmdWithArgs = val
 		cmd, args, err := cmdutil.SplitCommand(val)
 		if err != nil {
-			return WrapError("command", val, fmt.Errorf("failed to parse command: %w", err))
+			return wrapError("command", val, fmt.Errorf("failed to parse command: %w", err))
 		}
 		step.Command = cmd
 		step.Args = args
@@ -84,7 +84,7 @@ func buildCommand(_ BuildContext, def stepDef, step *Step) error {
 
 	default:
 		// Unknown type for command field.
-		return WrapError("command", val, errStepCommandMustBeArrayOrString)
+		return wrapError("command", val, errStepCommandMustBeArrayOrString)
 
 	}
 

--- a/internal/digraph/command.go
+++ b/internal/digraph/command.go
@@ -45,13 +45,13 @@ func buildCommand(_ BuildContext, def stepDef, step *Step) error {
 	case string:
 		// Case 2: command is a string
 		if val == "" {
-			return errStepCommandIsEmpty
+			return WrapError("command", val, errStepCommandIsEmpty)
 		}
 		// We need to split the command into command and args.
 		step.CmdWithArgs = val
 		cmd, args, err := cmdutil.SplitCommand(val)
 		if err != nil {
-			return fmt.Errorf("failed to parse command: %w", err)
+			return WrapError("command", val, fmt.Errorf("failed to parse command: %w", err))
 		}
 		step.Command = cmd
 		step.Args = args
@@ -84,7 +84,7 @@ func buildCommand(_ BuildContext, def stepDef, step *Step) error {
 
 	default:
 		// Unknown type for command field.
-		return errStepCommandMustBeArrayOrString
+		return WrapError("command", val, errStepCommandMustBeArrayOrString)
 
 	}
 

--- a/internal/digraph/dag.go
+++ b/internal/digraph/dag.go
@@ -5,15 +5,12 @@ package digraph
 
 import (
 	// nolint // gosec
-
 	"crypto/md5"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/dagu-org/dagu/internal/fileutil"
 	"github.com/robfig/cron/v3"
 )
 
@@ -232,31 +229,4 @@ func (d *DAG) setupHandlers(workDir string) {
 			handler.setup(workDir)
 		}
 	}
-}
-
-func resolveFilePath(dagLocation, baseLocation string, file string) (string, error) {
-	if filepath.IsAbs(file) {
-		if fileutil.FileExists(file) {
-			return file, nil
-		}
-		return "", os.ErrNotExist
-	}
-
-	dagDir := filepath.Dir(dagLocation)
-	baseConfigDir := filepath.Dir(baseLocation)
-	candidates := []string{
-		filepath.Join(dagDir, file),
-		filepath.Join(baseConfigDir, file),
-	}
-	if homeDir, err := os.UserHomeDir(); err == nil {
-		candidates = append(candidates, filepath.Join(homeDir, file))
-	}
-
-	for _, candidate := range candidates {
-		if fileutil.FileExists(candidate) {
-			return candidate, nil
-		}
-	}
-
-	return file, os.ErrNotExist
 }

--- a/internal/digraph/dag.go
+++ b/internal/digraph/dag.go
@@ -20,74 +20,50 @@ type DAG struct {
 	Location string `json:"Location"`
 	// Group is the group name of the DAG. This is optional.
 	Group string `json:"Group"`
-	// Name is the name of the DAG. The default is the filename without the
-	// extension.
+	// Name is the name of the DAG. The default is the filename without the extension.
 	Name string `json:"Name"`
-	// Tags contains the list of tags for the DAG. optional.
+	// Tags contains the list of tags for the DAG. This is optional.
 	Tags []string `json:"Tags"`
-	// Description is the description of the DAG. optional.
+	// Description is the description of the DAG. This is optional.
 	Description string `json:"Description"`
-	// Schedule configuration.
-	// This is used by the scheduler to start / stop / restart the DAG.
+	// Schedule configuration for starting, stopping, and restarting the DAG.
 	Schedule        []Schedule `json:"Schedule"`
 	StopSchedule    []Schedule `json:"StopSchedule"`
 	RestartSchedule []Schedule `json:"RestartSchedule"`
-
-	// Skip if successful.
+	// SkipIfSuccessful indicates whether to skip the DAG if it was successful previously.
+	// E.g., when the DAG has already been executed manually before the scheduled time.
 	SkipIfSuccessful bool `json:"SkipIfSuccessful"`
-
-	// Env contains a list of environment variables to be set before running
-	// the DAG.
+	// Env contains a list of environment variables to be set before running the DAG.
 	Env []string `json:"Env"`
-
 	// LogDir is the directory where the logs are stored.
-	// The actual log directory is LogDir + Name (with invalid characters
-	// replaced with '_').
 	LogDir string `json:"LogDir"`
-
-	// Parameters configuration.
-	// The DAG definition contains only DefaultParams. Params are automatically
-	// set by the DAG loader.
 	// DefaultParams contains the default parameters to be passed to the DAG.
 	DefaultParams string `json:"DefaultParams"`
 	// Params contains the list of parameters to be passed to the DAG.
 	Params []string `json:"Params"`
-
-	// Commands configuration to be executed in the DAG.
 	// Steps contains the list of steps in the DAG.
 	Steps []Step `json:"Steps"`
 	// HandlerOn contains the steps to be executed on different events.
 	HandlerOn HandlerOn `json:"HandlerOn"`
-
 	// Preconditions contains the conditions to be met before running the DAG.
-	// If the conditions are not met, the whole DAG is skipped.
 	Preconditions []Condition `json:"Preconditions"`
-
-	// Mail notification configuration.
-	// MailOn contains the conditions to send mail.
 	// SMTP contains the SMTP configuration.
-	// If you don't want to repeat the SMTP configuration for each DAG, you can
-	// set it in the base configuration.
 	SMTP *SMTPConfig `json:"Smtp"`
-	// ErrorMail contains the mail configuration for error.
+	// ErrorMail contains the mail configuration for errors.
 	ErrorMail *MailConfig `json:"ErrorMail"`
-	// InfoMail contains the mail configuration for info.
+	// InfoMail contains the mail configuration for informational messages.
 	InfoMail *MailConfig `json:"InfoMail"`
 	// MailOn contains the conditions to send mail.
 	MailOn *MailOn `json:"MailOn"`
-
-	// Timeout is a field to specify the maximum execution time of the DAG task
+	// Timeout specifies the maximum execution time of the DAG task.
 	Timeout time.Duration `json:"Timeout"`
-	// Misc configuration for DAG execution.
 	// Delay is the delay before starting the DAG.
 	Delay time.Duration `json:"Delay"`
 	// RestartWait is the time to wait before restarting the DAG.
 	RestartWait time.Duration `json:"RestartWait"`
-	// MaxActiveRuns specifies the maximum concurrent steps to run in an
-	// execution.
+	// MaxActiveRuns specifies the maximum concurrent steps to run in an execution.
 	MaxActiveRuns int `json:"MaxActiveRuns"`
-	// MaxCleanUpTime is the maximum time to wait for cleanup when the DAG is
-	// stopped.
+	// MaxCleanUpTime is the maximum time to wait for cleanup when the DAG is stopped.
 	MaxCleanUpTime time.Duration `json:"MaxCleanUpTime"`
 	// HistRetentionDays is the number of days to keep the history.
 	HistRetentionDays int `json:"HistRetentionDays"`
@@ -125,12 +101,10 @@ type SMTPConfig struct {
 
 // MailConfig contains the mail configuration.
 type MailConfig struct {
-	From string `json:"From"`
-	To   string `json:"To"`
-	// Prefix is the prefix for the subject of the mail.
-	Prefix string `json:"Prefix"`
-	// AttachLogs is the flag to attach the logs in the mail.
-	AttachLogs bool `json:"AttachLogs"`
+	From       string `json:"From"`
+	To         string `json:"To"`
+	Prefix     string `json:"Prefix"`
+	AttachLogs bool   `json:"AttachLogs"`
 }
 
 // HandlerType is the type of the handler.
@@ -168,28 +142,23 @@ var (
 
 // setup sets the default values for the DAG.
 func (d *DAG) setup() {
-	// The default history retention days is 30 days.
-	// It is the number of days to keep the history.
-	// The older history is deleted when the DAG is executed.
+	// Set default history retention days to 30 if not specified.
 	if d.HistRetentionDays == 0 {
 		d.HistRetentionDays = defaultHistoryRetentionDays
 	}
 
-	// The default max cleanup time is 60 seconds.
-	// It is the maximum time to wait for cleanup when the DAG gets a stop
-	// signal. If the cleanup takes more than this time, the process of the DAG
-	// is killed.
+	// Set default max cleanup time to 60 seconds if not specified.
 	if d.MaxCleanUpTime == 0 {
 		d.MaxCleanUpTime = defaultMaxCleanUpTime
 	}
 
-	// set the default working directory for the steps if not set
+	// Set the default working directory for the steps if not set.
 	dir := filepath.Dir(d.Location)
 	for i := range d.Steps {
 		d.Steps[i].setup(dir)
 	}
 
-	// set the default working directory for the handler steps if not set
+	// Set the default working directory for the handler steps if not set.
 	if d.HandlerOn.Exit != nil {
 		d.HandlerOn.Exit.setup(dir)
 	}
@@ -211,14 +180,11 @@ func (d *DAG) HasTag(tag string) bool {
 			return true
 		}
 	}
-
 	return false
 }
 
 // SockAddr returns the unix socket address for the DAG.
 // The address is used to communicate with the agent process.
-// TODO: It needs to be unique for each process so that multiple processes can
-// run in parallel.
 func (d *DAG) SockAddr() string {
 	s := strings.ReplaceAll(d.Location, " ", "_")
 	name := strings.Replace(filepath.Base(s), filepath.Ext(filepath.Base(s)), "", 1)
@@ -238,13 +204,10 @@ func (d *DAG) SockAddr() string {
 
 // String implements the Stringer interface.
 // It returns the string representation of the DAG.
-// TODO: Remove if not needed.
 func (d *DAG) String() string {
 	ret := "{\n"
 	ret = fmt.Sprintf("%s\tName: %s\n", ret, d.Name)
-	ret = fmt.Sprintf(
-		"%s\tDescription: %s\n", ret, strings.TrimSpace(d.Description),
-	)
+	ret = fmt.Sprintf("%s\tDescription: %s\n", ret, strings.TrimSpace(d.Description))
 	ret = fmt.Sprintf("%s\tEnv: %v\n", ret, strings.Join(d.Env, ", "))
 	ret = fmt.Sprintf("%s\tLogDir: %v\n", ret, d.LogDir)
 	for i, s := range d.Steps {

--- a/internal/digraph/dag_test.go
+++ b/internal/digraph/dag_test.go
@@ -18,7 +18,8 @@ var (
 
 func TestDAG_String(t *testing.T) {
 	t.Run("DefaltConfig", func(t *testing.T) {
-		dag, err := Load(context.Background(), "", filepath.Join(testdataDir, "default.yaml"), "")
+		filePath := filepath.Join(testdataDir, "default.yaml")
+		dag, err := Load(context.Background(), filePath)
 		require.NoError(t, err)
 
 		ret := dag.String()

--- a/internal/digraph/errors.go
+++ b/internal/digraph/errors.go
@@ -9,27 +9,27 @@ import (
 	"strings"
 )
 
-// FieldError represents an error in a specific field of the configuration
-type FieldError struct {
+// LoadError represents an error in a specific field of the configuration
+type LoadError struct {
 	Field string
 	Value any
 	Err   error
 }
 
-func (e *FieldError) Error() string {
+func (e *LoadError) Error() string {
 	if e.Value == nil {
 		return fmt.Sprintf("field '%s': %v", e.Field, e.Err)
 	}
 	return fmt.Sprintf("field '%s': %v (value: %+v)", e.Field, e.Err, e.Value)
 }
 
-func (e *FieldError) Unwrap() error {
+func (e *LoadError) Unwrap() error {
 	return e.Err
 }
 
-// WrapError wraps an error with field context
-func WrapError(field string, value any, err error) error {
-	return &FieldError{
+// wrapError wraps an error with field context
+func wrapError(field string, value any, err error) error {
+	return &LoadError{
 		Field: field,
 		Value: value,
 		Err:   err,

--- a/internal/digraph/errors.go
+++ b/internal/digraph/errors.go
@@ -61,6 +61,7 @@ var (
 	errExecutorConfigValueMustBeMap       = errors.New("executor.config value must be a map")
 	errExecutorHasInvalidKey              = errors.New("executor has invalid key")
 	errExecutorConfigMustBeStringOrMap    = errors.New("executor config must be string or map")
+	errDotenvMustBeStringOrArray          = errors.New("dotenv must be a string or an array of strings")
 )
 
 // errorList is just a list of errors.

--- a/internal/digraph/errors.go
+++ b/internal/digraph/errors.go
@@ -17,6 +17,9 @@ type FieldError struct {
 }
 
 func (e *FieldError) Error() string {
+	if e.Value == nil {
+		return fmt.Sprintf("field '%s': %v", e.Field, e.Err)
+	}
 	return fmt.Sprintf("field '%s': %v (value: %+v)", e.Field, e.Err, e.Value)
 }
 

--- a/internal/digraph/errors.go
+++ b/internal/digraph/errors.go
@@ -3,7 +3,62 @@
 
 package digraph
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// FieldError represents an error in a specific field of the configuration
+type FieldError struct {
+	Field string
+	Value any
+	Err   error
+}
+
+func (e *FieldError) Error() string {
+	return fmt.Sprintf("field '%s': %v (value: %+v)", e.Field, e.Err, e.Value)
+}
+
+func (e *FieldError) Unwrap() error {
+	return e.Err
+}
+
+// WrapError wraps an error with field context
+func WrapError(field string, value any, err error) error {
+	return &FieldError{
+		Field: field,
+		Value: value,
+		Err:   err,
+	}
+}
+
+// errors on building a DAG.
+var (
+	errInvalidSchedule                    = errors.New("invalid schedule")
+	errScheduleMustBeStringOrArray        = errors.New("schedule must be a string or an array of strings")
+	errInvalidScheduleType                = errors.New("invalid schedule type")
+	errInvalidKeyType                     = errors.New("invalid key type")
+	errExecutorConfigMustBeString         = errors.New("executor config key must be string")
+	errDuplicateFunction                  = errors.New("duplicate function")
+	errFuncParamsMismatch                 = errors.New("func params and args given to func command do not match")
+	errStepNameRequired                   = errors.New("step name must be specified")
+	errStepCommandIsRequired              = errors.New("step command is required")
+	errStepCommandIsEmpty                 = errors.New("step command is empty")
+	errStepCommandMustBeArrayOrString     = errors.New("step command must be an array of strings or a string")
+	errInvalidParamValue                  = errors.New("invalid parameter value")
+	errCallFunctionNotFound               = errors.New("call must specify a functions that exists")
+	errNumberOfParamsMismatch             = errors.New("the number of parameters defined in the function does not match the number of parameters given")
+	errRequiredParameterNotFound          = errors.New("required parameter not found")
+	errScheduleKeyMustBeString            = errors.New("schedule key must be a string")
+	errInvalidSignal                      = errors.New("invalid signal")
+	errInvalidEnvValue                    = errors.New("invalid value for env")
+	errArgsMustBeConvertibleToIntOrString = errors.New("args must be convertible to either int or string")
+	errExecutorTypeMustBeString           = errors.New("executor.type value must be string")
+	errExecutorConfigValueMustBeMap       = errors.New("executor.config value must be a map")
+	errExecutorHasInvalidKey              = errors.New("executor has invalid key")
+	errExecutorConfigMustBeStringOrMap    = errors.New("executor config must be string or map")
+)
 
 // errorList is just a list of errors.
 // It is used to collect multiple errors in building a DAG.

--- a/internal/digraph/executor/docker.go
+++ b/internal/digraph/executor/docker.go
@@ -269,7 +269,8 @@ func newDocker(
 
 	if cfg, ok := execCfg.Config["container"]; ok {
 		md, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-			Result: containerConfig,
+			Result:           containerConfig,
+			WeaklyTypedInput: true,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create decoder: %w", err)

--- a/internal/digraph/executor/http.go
+++ b/internal/digraph/executor/http.go
@@ -77,7 +77,18 @@ func newHTTP(ctx context.Context, step digraph.Step) (Executor, error) {
 		}
 	}
 
+	url, err := stepContext.EvalString(step.Args[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate url: %w", err)
+	}
+
+	method, err := stepContext.EvalString(step.Command)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate method: %w", err)
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
+
 	client := resty.New()
 	if reqCfg.Debug {
 		client.SetDebug(true)
@@ -98,8 +109,8 @@ func newHTTP(ctx context.Context, step digraph.Step) (Executor, error) {
 		stdout:    os.Stdout,
 		req:       req,
 		reqCancel: cancel,
-		method:    step.Command,
-		url:       step.Args[0],
+		method:    method,
+		url:       url,
 		cfg:       &reqCfg,
 	}, nil
 }

--- a/internal/digraph/executor/http.go
+++ b/internal/digraph/executor/http.go
@@ -200,8 +200,9 @@ func (e *http) Run(_ context.Context) error {
 
 func decodeHTTPConfig(dat map[string]any, cfg *httpConfig) error {
 	md, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		ErrorUnused: false,
-		Result:      cfg,
+		WeaklyTypedInput: true,
+		ErrorUnused:      false,
+		Result:           cfg,
 	})
 	return md.Decode(dat)
 }

--- a/internal/digraph/executor/jq.go
+++ b/internal/digraph/executor/jq.go
@@ -98,8 +98,9 @@ func (e *jq) Run(_ context.Context) error {
 
 func decodeJqConfig(dat map[string]any, cfg *jqConfig) error {
 	md, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		ErrorUnused: false,
-		Result:      cfg,
+		WeaklyTypedInput: true,
+		ErrorUnused:      false,
+		Result:           cfg,
 	})
 	return md.Decode(dat)
 }

--- a/internal/digraph/executor/mail.go
+++ b/internal/digraph/executor/mail.go
@@ -101,8 +101,9 @@ func (e *mail) Run(ctx context.Context) error {
 
 func decodeMailConfig(dat map[string]any, cfg *mailConfig) error {
 	md, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		ErrorUnused: false,
-		Result:      cfg,
+		WeaklyTypedInput: true,
+		ErrorUnused:      false,
+		Result:           cfg,
 	})
 	return md.Decode(dat)
 }

--- a/internal/digraph/executor/sub.go
+++ b/internal/digraph/executor/sub.go
@@ -65,8 +65,12 @@ func newSubWorkflow(
 		"start",
 		fmt.Sprintf("--requestID=%s", requestID),
 		"--quiet",
-		fmt.Sprintf("--params=%q", config.Params),
 		subDAG.Location,
+	}
+
+	if config.Params != "" {
+		args = append(args, "--")
+		args = append(args, config.Params)
 	}
 
 	cmd := exec.CommandContext(ctx, executable, args...)

--- a/internal/digraph/loader.go
+++ b/internal/digraph/loader.go
@@ -31,7 +31,7 @@ type LoadOptions struct {
 
 type LoadOption func(*LoadOptions)
 
-func WithBaseDAG(baseDAG string) LoadOption {
+func WithBaseConfig(baseDAG string) LoadOption {
 	return func(o *LoadOptions) {
 		o.baseDAG = baseDAG
 	}
@@ -62,7 +62,7 @@ func OnlyMetadata() LoadOption {
 	}
 }
 
-// Load loads the DAG from the given file.
+// Load load the DAG from the given file.
 func Load(ctx context.Context, dag string, opts ...LoadOption) (*DAG, error) {
 	var options LoadOptions
 	for _, opt := range opts {

--- a/internal/digraph/loader.go
+++ b/internal/digraph/loader.go
@@ -78,10 +78,17 @@ func Load(ctx context.Context, dag string, opts ...LoadOption) (*DAG, error) {
 }
 
 // LoadYAML load the DAG from the given YAML data.
-func LoadYAML(ctx context.Context, data []byte) (*DAG, error) {
+func LoadYAML(ctx context.Context, data []byte, opts ...LoadOption) (*DAG, error) {
+	var options LoadOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
 	return loadYAML(ctx, data, buildOpts{
-		onlyMetadata: false,
-		noEval:       true,
+		base:           options.baseDAG,
+		parameters:     options.params,
+		parametersList: options.paramsList,
+		onlyMetadata:   options.onlyMetadata,
+		noEval:         options.noEval,
 	})
 }
 

--- a/internal/digraph/loader.go
+++ b/internal/digraph/loader.go
@@ -77,14 +77,6 @@ func Load(ctx context.Context, dag string, opts ...LoadOption) (*DAG, error) {
 	})
 }
 
-// LoadWithoutEval loads config without evaluating dynamic fields.
-func LoadWithoutEval(ctx context.Context, dag string) (*DAG, error) {
-	return loadDAG(ctx, dag, buildOpts{
-		onlyMetadata: false,
-		noEval:       true,
-	})
-}
-
 // LoadMetadata loads only basic information from the DAG.
 // E.g. name, description, schedule, etc.
 func LoadMetadata(ctx context.Context, dag string) (*DAG, error) {

--- a/internal/digraph/loader.go
+++ b/internal/digraph/loader.go
@@ -21,12 +21,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var (
-	errConfigFileRequired = errors.New("config file was not specified")
-	errReadFile           = errors.New("failed to read file")
-)
-
-// Load loads config from file.
+// Load loads the DAG from the given file.
 func Load(ctx context.Context, base, dag, params string) (*DAG, error) {
 	return loadDAG(ctx, dag, buildOpts{
 		base:         base,
@@ -36,7 +31,7 @@ func Load(ctx context.Context, base, dag, params string) (*DAG, error) {
 	})
 }
 
-// LoadWithoutEval loads config from file without evaluating env variables.
+// LoadWithoutEval loads config without evaluating dynamic fields.
 func LoadWithoutEval(ctx context.Context, dag string) (*DAG, error) {
 	return loadDAG(ctx, dag, buildOpts{
 		metadataOnly: false,
@@ -44,7 +39,8 @@ func LoadWithoutEval(ctx context.Context, dag string) (*DAG, error) {
 	})
 }
 
-// LoadMetadata loads config from file and returns only the headline data.
+// LoadMetadata loads only basic information from the DAG.
+// E.g. name, description, schedule, etc.
 func LoadMetadata(ctx context.Context, dag string) (*DAG, error) {
 	return loadDAG(ctx, dag, buildOpts{
 		metadataOnly: true,
@@ -156,6 +152,8 @@ func defaultName(file string) string {
 	return strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
 }
 
+var errConfigFileRequired = errors.New("config file was not specified")
+
 func resolveYamlFilePath(file string) (string, error) {
 	if file == "" {
 		return "", errConfigFileRequired
@@ -215,7 +213,7 @@ func (*mergeTransformer) Transformer(
 func readFile(file string) (cfg map[string]any, err error) {
 	data, err := os.ReadFile(file)
 	if err != nil {
-		return nil, fmt.Errorf("%w %s: %v", errReadFile, file, err)
+		return nil, fmt.Errorf("failed to read file %q: %v", file, err)
 	}
 
 	return unmarshalData(data)

--- a/internal/digraph/loader.go
+++ b/internal/digraph/loader.go
@@ -171,6 +171,9 @@ func loadDAG(ctx context.Context, dag string, opts buildOpts) (*DAG, error) {
 
 	// Set the absolute path to the file.
 	dest.Location = filePath
+	if opts.base != "" {
+		dest.Base = filepath.Clean(opts.base)
+	}
 
 	// Set the name if not set.
 	if dest.Name == "" {

--- a/internal/digraph/loader.go
+++ b/internal/digraph/loader.go
@@ -189,13 +189,11 @@ func defaultName(file string) string {
 	return strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
 }
 
-var errConfigFileRequired = errors.New("config file was not specified")
-
 // resolveYamlFilePath resolves the YAML file path.
 // If the file name does not have an extension, it appends ".yaml".
 func resolveYamlFilePath(file string) (string, error) {
 	if file == "" {
-		return "", errConfigFileRequired
+		return "", errors.New("file path is required")
 	}
 
 	// The file name can be specified without the extension.

--- a/internal/digraph/loader.go
+++ b/internal/digraph/loader.go
@@ -77,18 +77,7 @@ func Load(ctx context.Context, dag string, opts ...LoadOption) (*DAG, error) {
 	})
 }
 
-// LoadMetadata loads only basic information from the DAG.
-// E.g. name, description, schedule, etc.
-func LoadMetadata(ctx context.Context, dag string) (*DAG, error) {
-	return loadDAG(ctx, dag, buildOpts{
-		onlyMetadata: true,
-		noEval:       true,
-	})
-}
-
-// LoadYAML loads config from YAML data.
-// It does not evaluate the environment variables.
-// This is used to validate the YAML data.
+// LoadYAML load the DAG from the given YAML data.
 func LoadYAML(ctx context.Context, data []byte) (*DAG, error) {
 	return loadYAML(ctx, data, buildOpts{
 		onlyMetadata: false,

--- a/internal/digraph/loader.go
+++ b/internal/digraph/loader.go
@@ -21,22 +21,26 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// LoadOptions contains options for loading a DAG.
 type LoadOptions struct {
-	baseDAG      string
-	params       string
-	paramsList   []string
-	noEval       bool
-	onlyMetadata bool
+	baseConfig   string   // Path to the base DAG configuration file.
+	params       string   // Parameters to override default parameters in the DAG.
+	paramsList   []string // List of parameters to override default parameters in the DAG.
+	noEval       bool     // Flag to disable evaluation of dynamic fields.
+	onlyMetadata bool     // Flag to load only metadata without full DAG details.
 }
 
+// LoadOption is a function type for setting LoadOptions.
 type LoadOption func(*LoadOptions)
 
+// WithBaseConfig sets the base DAG configuration file.
 func WithBaseConfig(baseDAG string) LoadOption {
 	return func(o *LoadOptions) {
-		o.baseDAG = baseDAG
+		o.baseConfig = baseDAG
 	}
 }
 
+// WithParams sets the parameters for the DAG.
 func WithParams(params any) LoadOption {
 	return func(o *LoadOptions) {
 		switch params := params.(type) {
@@ -50,26 +54,28 @@ func WithParams(params any) LoadOption {
 	}
 }
 
+// WithoutEval disables the evaluation of dynamic fields.
 func WithoutEval() LoadOption {
 	return func(o *LoadOptions) {
 		o.noEval = true
 	}
 }
 
+// OnlyMetadata sets the flag to load only metadata.
 func OnlyMetadata() LoadOption {
 	return func(o *LoadOptions) {
 		o.onlyMetadata = true
 	}
 }
 
-// Load loads the DAG from the given file.
+// Load loads the DAG from the given file with the specified options.
 func Load(ctx context.Context, dag string, opts ...LoadOption) (*DAG, error) {
 	var options LoadOptions
 	for _, opt := range opts {
 		opt(&options)
 	}
 	return loadDAG(ctx, dag, buildOpts{
-		base:           options.baseDAG,
+		base:           options.baseConfig,
 		parameters:     options.params,
 		parametersList: options.paramsList,
 		onlyMetadata:   options.onlyMetadata,
@@ -77,14 +83,14 @@ func Load(ctx context.Context, dag string, opts ...LoadOption) (*DAG, error) {
 	})
 }
 
-// LoadYAML loads the DAG from the given YAML data.
+// LoadYAML loads the DAG from the given YAML data with the specified options.
 func LoadYAML(ctx context.Context, data []byte, opts ...LoadOption) (*DAG, error) {
 	var options LoadOptions
 	for _, opt := range opts {
 		opt(&options)
 	}
 	return loadYAML(ctx, data, buildOpts{
-		base:           options.baseDAG,
+		base:           options.baseConfig,
 		parameters:     options.params,
 		parametersList: options.paramsList,
 		onlyMetadata:   options.onlyMetadata,
@@ -92,7 +98,7 @@ func LoadYAML(ctx context.Context, data []byte, opts ...LoadOption) (*DAG, error
 	})
 }
 
-// loadYAML loads config from YAML data.
+// loadYAML loads the DAG configuration from YAML data.
 func loadYAML(ctx context.Context, data []byte, opts buildOpts) (*DAG, error) {
 	raw, err := unmarshalData(data)
 	if err != nil {

--- a/internal/digraph/loader.go
+++ b/internal/digraph/loader.go
@@ -139,10 +139,7 @@ func loadBaseConfig(ctx context.Context, file string, opts buildOpts) (*DAG, err
 		return nil, err
 	}
 
-	// TODO: Consider removing the line below.
-	opts.onlyMetadata = false
-
-	return build(ctx, def, opts, nil)
+	return build(ctx, def, buildOpts{noEval: opts.noEval}, nil)
 }
 
 // loadDAG loads the DAG from the given file.

--- a/internal/digraph/loader.go
+++ b/internal/digraph/loader.go
@@ -62,7 +62,7 @@ func OnlyMetadata() LoadOption {
 	}
 }
 
-// Load load the DAG from the given file.
+// Load loads the DAG from the given file.
 func Load(ctx context.Context, dag string, opts ...LoadOption) (*DAG, error) {
 	var options LoadOptions
 	for _, opt := range opts {
@@ -77,7 +77,7 @@ func Load(ctx context.Context, dag string, opts ...LoadOption) (*DAG, error) {
 	})
 }
 
-// LoadYAML load the DAG from the given YAML data.
+// LoadYAML loads the DAG from the given YAML data.
 func LoadYAML(ctx context.Context, data []byte, opts ...LoadOption) (*DAG, error) {
 	var options LoadOptions
 	for _, opt := range opts {
@@ -92,7 +92,7 @@ func LoadYAML(ctx context.Context, data []byte, opts ...LoadOption) (*DAG, error
 	})
 }
 
-// LoadYAML loads config from YAML data.
+// loadYAML loads config from YAML data.
 func loadYAML(ctx context.Context, data []byte, opts buildOpts) (*DAG, error) {
 	raw, err := unmarshalData(data)
 	if err != nil {
@@ -185,6 +185,8 @@ func defaultName(file string) string {
 
 var errConfigFileRequired = errors.New("config file was not specified")
 
+// resolveYamlFilePath resolves the YAML file path.
+// If the file name does not have an extension, it appends ".yaml".
 func resolveYamlFilePath(file string) (string, error) {
 	if file == "" {
 		return "", errConfigFileRequired
@@ -198,8 +200,7 @@ func resolveYamlFilePath(file string) (string, error) {
 	return filepath.Abs(file)
 }
 
-// loadBaseConfigIfRequired loads the base config if needed, based on the
-// given options.
+// loadBaseConfigIfRequired loads the base config if needed, based on the given options.
 func loadBaseConfigIfRequired(ctx context.Context, baseConfig string, opts buildOpts) (*DAG, error) {
 	if !opts.onlyMetadata && baseConfig != "" {
 		dag, err := loadBaseConfig(ctx, baseConfig, opts)

--- a/internal/digraph/loader_test.go
+++ b/internal/digraph/loader_test.go
@@ -48,7 +48,7 @@ func Test_Load(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dag, err := Load(context.Background(), "", tt.file, "")
+			dag, err := Load(context.Background(), tt.file)
 			if tt.expectedError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedError)
@@ -82,7 +82,7 @@ func Test_loadBaseConfig(t *testing.T) {
 func Test_LoadDefaultConfig(t *testing.T) {
 	t.Run("DefaultConfigWithoutBaseConfig", func(t *testing.T) {
 		filePath := filepath.Join(testdataDir, "default.yaml")
-		dag, err := Load(context.Background(), "", filePath, "")
+		dag, err := Load(context.Background(), filePath)
 
 		require.NoError(t, err)
 

--- a/internal/digraph/loader_test.go
+++ b/internal/digraph/loader_test.go
@@ -74,7 +74,7 @@ func Test_LoadMetadata(t *testing.T) {
 
 func Test_loadBaseConfig(t *testing.T) {
 	t.Run("LoadBaseConfigFile", func(t *testing.T) {
-		dag, err := loadBaseConfig(context.Background(), filepath.Join(testdataDir, "base.yaml"), buildOpts{})
+		dag, err := loadBaseConfig(BuildContext{}, filepath.Join(testdataDir, "base.yaml"))
 		require.NotNil(t, dag)
 		require.NoError(t, err)
 	})

--- a/internal/digraph/loader_test.go
+++ b/internal/digraph/loader_test.go
@@ -62,7 +62,8 @@ func Test_Load(t *testing.T) {
 
 func Test_LoadMetadata(t *testing.T) {
 	t.Run("Metadata", func(t *testing.T) {
-		dag, err := LoadMetadata(context.Background(), filepath.Join(testdataDir, "default.yaml"))
+		filePath := filepath.Join(testdataDir, "default.yaml")
+		dag, err := Load(context.Background(), filePath, OnlyMetadata(), WithoutEval())
 		require.NoError(t, err)
 
 		require.Equal(t, dag.Name, "default")

--- a/internal/digraph/params.go
+++ b/internal/digraph/params.go
@@ -119,6 +119,10 @@ func parseParams(ctx BuildContext, value any, params *[]paramPair, envs *[]strin
 	}
 
 	for index, paramPair := range paramPairs {
+		if !ctx.opts.noEval {
+			paramPair.Value = os.ExpandEnv(paramPair.Value)
+		}
+
 		*params = append(*params, paramPair)
 
 		paramString := paramPair.String()

--- a/internal/digraph/params.go
+++ b/internal/digraph/params.go
@@ -79,15 +79,11 @@ func buildParams(ctx BuildContext, spec *definition, dag *DAG) error {
 		}
 	}
 
-	// Convert the parameters to a string in the form of "key=value"
-	var paramStrings []string
 	for _, paramPair := range paramPairs {
-		paramStrings = append(paramStrings, paramPair.String())
+		dag.Params = append(dag.Params, paramPair.String())
 	}
 
-	// Set the parameters as environment variables for the command
 	dag.Env = append(dag.Env, envs...)
-	dag.Params = append(dag.Params, paramStrings...)
 
 	return nil
 }

--- a/internal/digraph/params.go
+++ b/internal/digraph/params.go
@@ -98,7 +98,7 @@ func parseParams(ctx BuildContext, value any, params *[]paramPair, envs *[]strin
 
 	paramPairs, err := parseParamValue(ctx, value)
 	if err != nil {
-		return WrapError("params", value, fmt.Errorf("%w: %s", errInvalidParamValue, err))
+		return wrapError("params", value, fmt.Errorf("%w: %s", errInvalidParamValue, err))
 	}
 
 	for index, paramPair := range paramPairs {
@@ -113,13 +113,13 @@ func parseParams(ctx BuildContext, value any, params *[]paramPair, envs *[]strin
 		// Set the parameter as an environment variable for the command
 		// $1, $2, $3, ...
 		if err := os.Setenv(strconv.Itoa(index+1), paramString); err != nil {
-			return WrapError("params", paramString, fmt.Errorf("failed to set environment variable: %w", err))
+			return wrapError("params", paramString, fmt.Errorf("failed to set environment variable: %w", err))
 		}
 
 		if !ctx.opts.noEval && paramPair.Name != "" {
 			*envs = append(*envs, paramString)
 			if err := os.Setenv(paramPair.Name, paramPair.Value); err != nil {
-				return WrapError("params", paramString, fmt.Errorf("failed to set environment variable: %w", err))
+				return wrapError("params", paramString, fmt.Errorf("failed to set environment variable: %w", err))
 			}
 		}
 	}
@@ -140,7 +140,7 @@ func parseParamValue(ctx BuildContext, input any) ([]paramPair, error) {
 		return parseMapParams(ctx, v)
 
 	default:
-		return nil, WrapError("params", v, fmt.Errorf("%w: %T", errInvalidParamValue, v))
+		return nil, wrapError("params", v, fmt.Errorf("%w: %T", errInvalidParamValue, v))
 
 	}
 }
@@ -160,7 +160,7 @@ func parseMapParams(ctx BuildContext, input []any) ([]paramPair, error) {
 					valueStr = v
 
 				default:
-					return nil, WrapError("params", value, fmt.Errorf("%w: %T", errInvalidParamValue, v))
+					return nil, wrapError("params", value, fmt.Errorf("%w: %T", errInvalidParamValue, v))
 
 				}
 
@@ -169,14 +169,14 @@ func parseMapParams(ctx BuildContext, input []any) ([]paramPair, error) {
 					nameStr = n
 
 				default:
-					return nil, WrapError("params", name, fmt.Errorf("%w: %T", errInvalidParamValue, n))
+					return nil, wrapError("params", name, fmt.Errorf("%w: %T", errInvalidParamValue, n))
 
 				}
 
 				if !ctx.opts.noEval {
 					parsed, err := cmdutil.EvalString(valueStr)
 					if err != nil {
-						return nil, WrapError("params", valueStr, fmt.Errorf("%w: %s", errInvalidParamValue, err))
+						return nil, wrapError("params", valueStr, fmt.Errorf("%w: %s", errInvalidParamValue, err))
 					}
 					valueStr = parsed
 				}
@@ -186,7 +186,7 @@ func parseMapParams(ctx BuildContext, input []any) ([]paramPair, error) {
 			}
 
 		default:
-			return nil, WrapError("params", m, fmt.Errorf("%w: %T", errInvalidParamValue, m))
+			return nil, wrapError("params", m, fmt.Errorf("%w: %T", errInvalidParamValue, m))
 		}
 	}
 
@@ -234,7 +234,7 @@ func parseStringParams(ctx BuildContext, input string) ([]paramPair, error) {
 				)
 
 				if cmdErr != nil {
-					return nil, WrapError("params", value, fmt.Errorf("%w: %s", errInvalidParamValue, cmdErr))
+					return nil, wrapError("params", value, fmt.Errorf("%w: %s", errInvalidParamValue, cmdErr))
 				}
 			}
 		}

--- a/internal/digraph/params.go
+++ b/internal/digraph/params.go
@@ -98,7 +98,7 @@ func parseParams(ctx BuildContext, value any, params *[]paramPair, envs *[]strin
 
 	paramPairs, err := parseParamValue(ctx, value)
 	if err != nil {
-		return fmt.Errorf("%w: %s", errInvalidParamValue, err)
+		return WrapError("params", value, fmt.Errorf("%w: %s", errInvalidParamValue, err))
 	}
 
 	for index, paramPair := range paramPairs {
@@ -113,13 +113,13 @@ func parseParams(ctx BuildContext, value any, params *[]paramPair, envs *[]strin
 		// Set the parameter as an environment variable for the command
 		// $1, $2, $3, ...
 		if err := os.Setenv(strconv.Itoa(index+1), paramString); err != nil {
-			return fmt.Errorf("failed to set environment variable: %w", err)
+			return WrapError("params", paramString, fmt.Errorf("failed to set environment variable: %w", err))
 		}
 
 		if !ctx.opts.noEval && paramPair.Name != "" {
 			*envs = append(*envs, paramString)
 			if err := os.Setenv(paramPair.Name, paramPair.Value); err != nil {
-				return fmt.Errorf("failed to set environment variable: %w", err)
+				return WrapError("params", paramString, fmt.Errorf("failed to set environment variable: %w", err))
 			}
 		}
 	}
@@ -140,7 +140,7 @@ func parseParamValue(ctx BuildContext, input any) ([]paramPair, error) {
 		return parseMapParams(ctx, v)
 
 	default:
-		return nil, fmt.Errorf("%w: %T", errInvalidParamValue, v)
+		return nil, WrapError("params", v, fmt.Errorf("%w: %T", errInvalidParamValue, v))
 
 	}
 }
@@ -160,7 +160,7 @@ func parseMapParams(ctx BuildContext, input []any) ([]paramPair, error) {
 					valueStr = v
 
 				default:
-					return nil, fmt.Errorf("%w: %T", errInvalidParamValue, v)
+					return nil, WrapError("params", value, fmt.Errorf("%w: %T", errInvalidParamValue, v))
 
 				}
 
@@ -169,14 +169,14 @@ func parseMapParams(ctx BuildContext, input []any) ([]paramPair, error) {
 					nameStr = n
 
 				default:
-					return nil, fmt.Errorf("%w: %T", errInvalidParamValue, n)
+					return nil, WrapError("params", name, fmt.Errorf("%w: %T", errInvalidParamValue, n))
 
 				}
 
 				if !ctx.opts.noEval {
 					parsed, err := cmdutil.EvalString(valueStr)
 					if err != nil {
-						return nil, fmt.Errorf("%w: %s", errInvalidParamValue, err)
+						return nil, WrapError("params", valueStr, fmt.Errorf("%w: %s", errInvalidParamValue, err))
 					}
 					valueStr = parsed
 				}
@@ -186,7 +186,7 @@ func parseMapParams(ctx BuildContext, input []any) ([]paramPair, error) {
 			}
 
 		default:
-			return nil, fmt.Errorf("%w: %T", errInvalidParamValue, m)
+			return nil, WrapError("params", m, fmt.Errorf("%w: %T", errInvalidParamValue, m))
 		}
 	}
 
@@ -234,7 +234,7 @@ func parseStringParams(ctx BuildContext, input string) ([]paramPair, error) {
 				)
 
 				if cmdErr != nil {
-					return nil, fmt.Errorf("%w: %s", errInvalidParamValue, cmdErr)
+					return nil, WrapError("params", value, fmt.Errorf("%w: %s", errInvalidParamValue, cmdErr))
 				}
 			}
 		}

--- a/internal/digraph/schedule.go
+++ b/internal/digraph/schedule.go
@@ -21,7 +21,7 @@ func buildScheduler(values []string) ([]Schedule, error) {
 	for _, v := range values {
 		parsed, err := cronParser.Parse(v)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %s", errInvalidSchedule, err)
+			return nil, WrapError("schedule", v, err)
 		}
 		ret = append(ret, Schedule{Expression: v, Parsed: parsed})
 	}
@@ -54,7 +54,7 @@ func parseScheduleMap(
 		// Key must be a string.
 		key, ok := k.(string)
 		if !ok {
-			return errScheduleKeyMustBeString
+			return WrapError("schedule", k, errScheduleKeyMustBeString)
 		}
 		var values []string
 
@@ -69,7 +69,7 @@ func parseScheduleMap(
 			for _, s := range v {
 				s, ok := s.(string)
 				if !ok {
-					return errScheduleMustBeStringOrArray
+					return WrapError("schedule", s, errScheduleMustBeStringOrArray)
 				}
 				values = append(values, s)
 			}
@@ -92,7 +92,7 @@ func parseScheduleMap(
 
 		for _, v := range values {
 			if _, err := cronParser.Parse(v); err != nil {
-				return fmt.Errorf("%w: %s", errInvalidSchedule, err)
+				return WrapError("schedule", v, fmt.Errorf("%w: %s", errInvalidSchedule, err))
 			}
 			*targets = append(*targets, v)
 		}

--- a/internal/digraph/schedule.go
+++ b/internal/digraph/schedule.go
@@ -21,7 +21,7 @@ func buildScheduler(values []string) ([]Schedule, error) {
 	for _, v := range values {
 		parsed, err := cronParser.Parse(v)
 		if err != nil {
-			return nil, WrapError("schedule", v, err)
+			return nil, fmt.Errorf("%w: %s", errInvalidSchedule, err)
 		}
 		ret = append(ret, Schedule{Expression: v, Parsed: parsed})
 	}
@@ -54,7 +54,7 @@ func parseScheduleMap(
 		// Key must be a string.
 		key, ok := k.(string)
 		if !ok {
-			return WrapError("schedule", k, errScheduleKeyMustBeString)
+			return wrapError("schedule", k, errScheduleKeyMustBeString)
 		}
 		var values []string
 
@@ -69,7 +69,7 @@ func parseScheduleMap(
 			for _, s := range v {
 				s, ok := s.(string)
 				if !ok {
-					return WrapError("schedule", s, errScheduleMustBeStringOrArray)
+					return wrapError("schedule", s, errScheduleMustBeStringOrArray)
 				}
 				values = append(values, s)
 			}
@@ -92,7 +92,7 @@ func parseScheduleMap(
 
 		for _, v := range values {
 			if _, err := cronParser.Parse(v); err != nil {
-				return WrapError("schedule", v, fmt.Errorf("%w: %s", errInvalidSchedule, err))
+				return wrapError("schedule", v, fmt.Errorf("%w: %s", errInvalidSchedule, err))
 			}
 			*targets = append(*targets, v)
 		}

--- a/internal/digraph/spec.go
+++ b/internal/digraph/spec.go
@@ -13,6 +13,8 @@ type definition struct {
 	Group string
 	// Description is the description of the DAG.
 	Description string
+	// Dotenv is the path to the dotenv file (string or []string).
+	Dotenv any
 	// Schedule is the cron schedule to run the DAG.
 	Schedule any
 	// SkipIfSuccessful is the flag to skip the DAG on schedule when it is

--- a/internal/digraph/spec.go
+++ b/internal/digraph/spec.go
@@ -46,7 +46,7 @@ type definition struct {
 	RestartWaitSec int
 	// HistRetentionDays is the retention days of the history.
 	HistRetentionDays *int
-	// Precondition is the condition to run the DAG.
+	// Preconditions is the condition to run the DAG.
 	Preconditions []*conditionDef
 	// MaxActiveRuns is the maximum number of concurrent steps.
 	MaxActiveRuns int
@@ -60,18 +60,21 @@ type definition struct {
 	Tags any
 }
 
+// conditionDef defines a condition and its expected value.
 type conditionDef struct {
-	Condition string
-	Expected  string
+	Condition string // Condition to evaluate
+	Expected  string // Expected value
 }
 
+// handlerOnDef defines the steps to be executed on different events.
 type handlerOnDef struct {
-	Failure *stepDef
-	Success *stepDef
-	Cancel  *stepDef
-	Exit    *stepDef
+	Failure *stepDef // Step to execute on failure
+	Success *stepDef // Step to execute on success
+	Cancel  *stepDef // Step to execute on cancel
+	Exit    *stepDef // Step to execute on exit
 }
 
+// stepDef defines a step in the DAG.
 type stepDef struct {
 	// Name is the name of the step.
 	Name string
@@ -103,7 +106,7 @@ type stepDef struct {
 	RepeatPolicy *repeatPolicyDef
 	// MailOnError is the flag to send mail on error.
 	MailOnError bool
-	// Precondition is the condition to run the step.
+	// Preconditions is the condition to run the step.
 	Preconditions []*conditionDef
 	// SignalOnStop is the signal when the step is requested to stop.
 	// When it is empty, the same signal as the parent process is sent.
@@ -117,47 +120,55 @@ type stepDef struct {
 	Params string
 }
 
+// funcDef defines a function in the DAG.
 type funcDef struct {
-	Name    string
-	Params  string
-	Command string
+	Name    string // Name of the function
+	Params  string // Parameters for the function
+	Command string // Command to execute the function
 }
 
+// callFuncDef defines a function call in the DAG.
 type callFuncDef struct {
-	Function string
-	Args     map[string]any
+	Function string         // Name of the function to call
+	Args     map[string]any // Arguments for the function call
 }
 
+// continueOnDef defines the conditions to continue on failure or skipped.
 type continueOnDef struct {
-	Failure bool
-	Skipped bool
+	Failure bool // Continue on failure
+	Skipped bool // Continue on skipped
 }
 
+// repeatPolicyDef defines the repeat policy for a step.
 type repeatPolicyDef struct {
-	Repeat      bool
-	IntervalSec int
+	Repeat      bool // Flag to indicate if the step should be repeated
+	IntervalSec int  // Interval in seconds between repeats
 }
 
+// retryPolicyDef defines the retry policy for a step.
 type retryPolicyDef struct {
-	Limit       any
-	IntervalSec any
+	Limit       any // Limit on the number of retries
+	IntervalSec any // Interval in seconds between retries
 }
 
+// smtpConfigDef defines the SMTP configuration.
 type smtpConfigDef struct {
-	Host     string
-	Port     string
-	Username string
-	Password string
+	Host     string // SMTP host
+	Port     string // SMTP port
+	Username string // SMTP username
+	Password string // SMTP password
 }
 
+// mailConfigDef defines the mail configuration.
 type mailConfigDef struct {
-	From       string
-	To         string
-	Prefix     string
-	AttachLogs bool
+	From       string // Sender email address
+	To         string // Recipient email address
+	Prefix     string // Prefix for the email subject
+	AttachLogs bool   // Flag to attach logs to the email
 }
 
+// mailOnDef defines the conditions to send mail.
 type mailOnDef struct {
-	Failure bool
-	Success bool
+	Failure bool // Send mail on failure
+	Success bool // Send mail on success
 }

--- a/internal/digraph/step.go
+++ b/internal/digraph/step.go
@@ -11,16 +11,16 @@ import (
 
 // Step contains the runtime information for a step in a DAG.
 // A step is created from parsing a DAG file written in YAML.
-// It marshal/unmarshal to/from JSON when it is saved in the execution history.
+// It marshals/unmarshals to/from JSON when it is saved in the execution history.
 type Step struct {
 	// Name is the name of the step.
 	Name string `json:"Name"`
-	// Description is the description of the step.
+	// Description is the description of the step. This is optional.
 	Description string `json:"Description,omitempty"`
-	// Shell is the shell program to execute the command. optional.
+	// Shell is the shell program to execute the command. This is optional.
 	Shell string `json:"Shell,omitempty"`
-	// OutputVariables is a structure to store the output variables for the
-	// following steps. It only contains the local output variables.
+	// OutputVariables stores the output variables for the following steps.
+	// It only contains the local output variables.
 	OutputVariables *SyncMap `json:"OutputVariables,omitempty"`
 	// Dir is the working directory for the step.
 	Dir string `json:"Dir,omitempty"`
@@ -60,20 +60,20 @@ type Step struct {
 
 // setup sets the default values for the step.
 func (s *Step) setup(workDir string) {
-	// if the working directory is not set, use the directory of the DAG file.
+	// If the working directory is not set, use the directory of the DAG file.
 	if s.Dir == "" {
 		s.Dir = workDir
 	}
 }
 
 // String implements the Stringer interface.
-// TODO: Remove if not needed.
+// It returns the string representation of the step.
 func (s *Step) String() string {
 	values := []string{
 		fmt.Sprintf("Name: %s", s.Name),
 		fmt.Sprintf("Dir: %s", s.Dir),
 		fmt.Sprintf("Command: %s", s.Command),
-		fmt.Sprintf("Args: %s", s.Args),
+		fmt.Sprintf("Args: %v", s.Args),
 		fmt.Sprintf("Depends: [%s]", strings.Join(s.Depends, ", ")),
 	}
 
@@ -92,10 +92,10 @@ const ExecutorTypeSubWorkflow = "subworkflow"
 
 // ExecutorConfig contains the configuration for the executor.
 type ExecutorConfig struct {
-	// Type represents one of the registered executor.
+	// Type represents one of the registered executors.
 	// See `executor.Register` in `internal/executor/executor.go`.
 	Type   string
-	Config map[string]any // Config contains executor specific configuration.
+	Config map[string]any // Config contains executor-specific configuration.
 }
 
 // RetryPolicy contains the retry policy for a step.
@@ -112,8 +112,10 @@ type RetryPolicy struct {
 
 // RepeatPolicy contains the repeat policy for a step.
 type RepeatPolicy struct {
-	Repeat   bool          // Repeat determines if the step should be repeated.
-	Interval time.Duration // Interval is the time to wait between repeats.
+	// Repeat determines if the step should be repeated.
+	Repeat bool
+	// Interval is the time to wait between repeats.
+	Interval time.Duration
 }
 
 // ContinueOn contains the conditions to continue on failure or skipped.

--- a/internal/digraph/step.go
+++ b/internal/digraph/step.go
@@ -66,18 +66,25 @@ func (s *Step) setup(workDir string) {
 	}
 }
 
-// String implements the Stringer interface.
-// It returns the string representation of the step.
+// String returns a formatted string representation of the step
 func (s *Step) String() string {
-	values := []string{
-		fmt.Sprintf("Name: %s", s.Name),
-		fmt.Sprintf("Dir: %s", s.Dir),
-		fmt.Sprintf("Command: %s", s.Command),
-		fmt.Sprintf("Args: %v", s.Args),
-		fmt.Sprintf("Depends: [%s]", strings.Join(s.Depends, ", ")),
+	fields := []struct {
+		name  string
+		value string
+	}{
+		{"Name", s.Name},
+		{"Dir", s.Dir},
+		{"Command", s.Command},
+		{"Args", fmt.Sprintf("%v", s.Args)},
+		{"Depends", fmt.Sprintf("[%s]", strings.Join(s.Depends, ", "))},
 	}
 
-	return strings.Join(values, "\t")
+	var parts []string
+	for _, field := range fields {
+		parts = append(parts, fmt.Sprintf("%s: %s", field.name, field.value))
+	}
+
+	return strings.Join(parts, "\t")
 }
 
 // SubWorkflow contains information about a sub DAG to be executed.

--- a/internal/digraph/step_context.go
+++ b/internal/digraph/step_context.go
@@ -5,6 +5,8 @@ package digraph
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 
 	"github.com/dagu-org/dagu/internal/cmdutil"
 	"github.com/dagu-org/dagu/internal/mailer"
@@ -67,6 +69,21 @@ func (c StepContext) EvalString(s string) (string, error) {
 		cmdutil.WithVariables(c.envs),
 		cmdutil.WithVariables(c.outputVariables.Variables()),
 	)
+}
+
+func (c StepContext) EvalBool(value any) (bool, error) {
+	switch v := value.(type) {
+	case string:
+		s, err := c.EvalString(v)
+		if err != nil {
+			return false, err
+		}
+		return strconv.ParseBool(s)
+	case bool:
+		return v, nil
+	default:
+		return false, fmt.Errorf("unsupported type %T for bool (value: %+v)", value, value)
+	}
 }
 
 func (c StepContext) WithEnv(key, value string) StepContext {

--- a/internal/digraph/testdata/dotenv
+++ b/internal/digraph/testdata/dotenv
@@ -1,0 +1,1 @@
+TEST_ENV_FOO=BAR

--- a/internal/digraph/variables.go
+++ b/internal/digraph/variables.go
@@ -23,7 +23,7 @@ func loadVariables(ctx BuildContext, strVariables any) (
 	case map[any]any:
 		// Case 1. env is a map.
 		if err := parseKeyValue(a, &pairs); err != nil {
-			return nil, WrapError("env", a, err)
+			return nil, wrapError("env", a, err)
 		}
 
 	case []any:
@@ -31,7 +31,7 @@ func loadVariables(ctx BuildContext, strVariables any) (
 		for _, v := range a {
 			if aa, ok := v.(map[any]any); ok {
 				if err := parseKeyValue(aa, &pairs); err != nil {
-					return nil, WrapError("env", v, err)
+					return nil, wrapError("env", v, err)
 				}
 			}
 		}
@@ -49,11 +49,11 @@ func loadVariables(ctx BuildContext, strVariables any) (
 
 			value, err = cmdutil.SubstituteCommands(os.ExpandEnv(value))
 			if err != nil {
-				return nil, WrapError("env", pair.val, fmt.Errorf("%w: %s", errInvalidEnvValue, pair.val))
+				return nil, wrapError("env", pair.val, fmt.Errorf("%w: %s", errInvalidEnvValue, pair.val))
 			}
 
 			if err := os.Setenv(pair.key, value); err != nil {
-				return nil, WrapError("env", pair.key, err)
+				return nil, wrapError("env", pair.key, err)
 			}
 		}
 
@@ -74,7 +74,7 @@ func parseKeyValue(m map[any]any, pairs *[]pair) error {
 	for k, v := range m {
 		key, ok := k.(string)
 		if !ok {
-			return WrapError("env", k, errInvalidKeyType)
+			return wrapError("env", k, errInvalidKeyType)
 		}
 
 		var val string

--- a/internal/digraph/variables.go
+++ b/internal/digraph/variables.go
@@ -23,7 +23,7 @@ func loadVariables(ctx BuildContext, strVariables any) (
 	case map[any]any:
 		// Case 1. env is a map.
 		if err := parseKeyValue(a, &pairs); err != nil {
-			return nil, err
+			return nil, WrapError("env", a, err)
 		}
 
 	case []any:
@@ -31,7 +31,7 @@ func loadVariables(ctx BuildContext, strVariables any) (
 		for _, v := range a {
 			if aa, ok := v.(map[any]any); ok {
 				if err := parseKeyValue(aa, &pairs); err != nil {
-					return nil, err
+					return nil, WrapError("env", v, err)
 				}
 			}
 		}
@@ -49,11 +49,11 @@ func loadVariables(ctx BuildContext, strVariables any) (
 
 			value, err = cmdutil.SubstituteCommands(os.ExpandEnv(value))
 			if err != nil {
-				return nil, fmt.Errorf("%w: %s", errInvalidEnvValue, pair.val)
+				return nil, WrapError("env", pair.val, fmt.Errorf("%w: %s", errInvalidEnvValue, pair.val))
 			}
 
 			if err := os.Setenv(pair.key, value); err != nil {
-				return nil, err
+				return nil, WrapError("env", pair.key, err)
 			}
 		}
 
@@ -74,7 +74,7 @@ func parseKeyValue(m map[any]any, pairs *[]pair) error {
 	for k, v := range m {
 		key, ok := k.(string)
 		if !ok {
-			return errInvalidKeyType
+			return WrapError("env", k, errInvalidKeyType)
 		}
 
 		var val string

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"time"
 )
 
 var (
@@ -31,29 +30,13 @@ func MustGetwd() string {
 	return wd
 }
 
-const (
-	legacyTimeFormat = "2006-01-02 15:04:05"
-	timeEmpty        = "-"
-)
-
-// FormatTime returns formatted time.
-func FormatTime(t time.Time) string {
-	if t.IsZero() {
-		return timeEmpty
+// IsDir returns true if path is a directory.
+func IsDir(path string) bool {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false
 	}
-
-	return t.Format(time.RFC3339)
-}
-
-// ParseTime parses time string.
-func ParseTime(val string) (time.Time, error) {
-	if val == timeEmpty {
-		return time.Time{}, nil
-	}
-	if t, err := time.ParseInLocation(time.RFC3339, val, time.Local); err == nil {
-		return t, nil
-	}
-	return time.ParseInLocation(legacyTimeFormat, val, time.Local)
+	return stat.IsDir()
 }
 
 // FileExists returns true if file exists.

--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -28,46 +27,6 @@ func Test_MustGetwd(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		wd, _ := os.Getwd()
 		require.Equal(t, MustGetwd(), wd)
-	})
-}
-
-func Test_FormatTime(t *testing.T) {
-	t.Run("Valid", func(t *testing.T) {
-		tm := time.Date(2022, 2, 1, 2, 2, 2, 0, time.UTC)
-		formatted := FormatTime(tm)
-		require.Equal(t, "2022-02-01T02:02:02Z", formatted)
-
-		parsed, err := ParseTime(formatted)
-		require.NoError(t, err)
-		require.Equal(t, tm, parsed)
-
-		// Test empty time
-		require.Equal(t, "-", FormatTime(time.Time{}))
-		parsed, err = ParseTime("-")
-		require.NoError(t, err)
-		require.Equal(t, time.Time{}, parsed)
-	})
-	t.Run("Empty", func(t *testing.T) {
-		// Test empty time
-		require.Equal(t, "-", FormatTime(time.Time{}))
-	})
-}
-
-func Test_ParseTime(t *testing.T) {
-	t.Run("Valid", func(t *testing.T) {
-		parsed, err := ParseTime("2022-02-01T02:02:02Z")
-		require.NoError(t, err)
-		require.Equal(t, time.Date(2022, 2, 1, 2, 2, 2, 0, time.UTC), parsed)
-	})
-	t.Run("Valid_Legacy", func(t *testing.T) {
-		parsed, err := ParseTime("2022-02-01 02:02:02")
-		require.NoError(t, err)
-		require.Equal(t, time.Date(2022, 2, 1, 2, 2, 2, 0, time.Now().Location()), parsed)
-	})
-	t.Run("Empty", func(t *testing.T) {
-		parsed, err := ParseTime("-")
-		require.NoError(t, err)
-		require.Equal(t, time.Time{}, parsed)
 	})
 }
 

--- a/internal/fileutil/resolver.go
+++ b/internal/fileutil/resolver.go
@@ -1,0 +1,90 @@
+// Copyright (C) 2024 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package fileutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FileResolver handles file path resolution across multiple locations
+type FileResolver struct {
+	relativeTos []string
+}
+
+// NewFileResolver creates a new FileResolver instance
+func NewFileResolver(relativeTos []string) *FileResolver {
+	return &FileResolver{
+		relativeTos: relativeTos,
+	}
+}
+
+// ResolveFilePath attempts to find a file in multiple locations in the following order:
+// 1. As an absolute path
+// 2. Relative to the DAG directory
+// 3. Relative to the base config directory
+// 4. Relative to the user's home directory
+func (r *FileResolver) ResolveFilePath(file string) (string, error) {
+	// Check if it's an absolute path
+	if filepath.IsAbs(file) {
+		if FileExists(file) {
+			return file, nil
+		}
+		return "", &FileNotFoundError{Path: file}
+	}
+
+	// Get search locations
+	searchPaths, err := r.getSearchPaths(file)
+	if err != nil {
+		return "", fmt.Errorf("getting search paths: %w", err)
+	}
+
+	// Try each location
+	for _, path := range searchPaths {
+		if FileExists(path) {
+			return path, nil
+		}
+	}
+
+	return "", &FileNotFoundError{
+		Path:          file,
+		SearchedPaths: searchPaths,
+	}
+}
+
+// getSearchPaths returns a list of paths to search for the file
+func (r *FileResolver) getSearchPaths(file string) ([]string, error) {
+	var paths []string
+
+	for _, relativeTo := range r.relativeTos {
+		if IsDir(relativeTo) {
+			paths = append(paths, filepath.Join(relativeTo, file))
+		} else {
+			dir := filepath.Dir(relativeTo)
+			paths = append(paths, filepath.Join(dir, file))
+		}
+	}
+
+	// Add home directory path
+	homeDir, err := os.UserHomeDir()
+	if err == nil && homeDir != "" {
+		paths = append(paths, filepath.Join(homeDir, file))
+	}
+
+	return paths, nil
+}
+
+// FileNotFoundError provides detailed information about file search failure
+type FileNotFoundError struct {
+	Path          string
+	SearchedPaths []string
+}
+
+func (e *FileNotFoundError) Error() string {
+	if len(e.SearchedPaths) == 0 {
+		return fmt.Sprintf("file not found: %s", e.Path)
+	}
+	return fmt.Sprintf("file not found: %s (searched in: %v)", e.Path, e.SearchedPaths)
+}

--- a/internal/fileutil/resolver_test.go
+++ b/internal/fileutil/resolver_test.go
@@ -1,0 +1,155 @@
+// Copyright (C) 2024 Yota Hamada
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileResolver(t *testing.T) {
+	// Create temporary test directories
+	tempDir := t.TempDir()
+	dir1 := filepath.Join(tempDir, "dir1")
+	dir2 := filepath.Join(tempDir, "dir2")
+
+	// Create test directories
+	for _, dir := range []string{dir1, dir2} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create test directory: %v", err)
+		}
+	}
+
+	// Create test files
+	testFiles := map[string]string{
+		filepath.Join(dir1, "file1.txt"):            "content1",
+		filepath.Join(dir2, "file2.txt"):            "content2",
+		filepath.Join(dir1, "shared.txt"):           "content_dir1",
+		filepath.Join(dir2, "shared.txt"):           "content_dir2",
+		filepath.Join(tempDir, "absolute.txt"):      "absolute",
+		filepath.Join(os.TempDir(), "homefile.txt"): "home",
+	}
+
+	for path, content := range testFiles {
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name          string
+		relativeTos   []string
+		file          string
+		expectedPath  string
+		expectedError bool
+	}{
+		{
+			name:         "Find file in first relative path",
+			relativeTos:  []string{dir1, dir2},
+			file:         "file1.txt",
+			expectedPath: filepath.Join(dir1, "file1.txt"),
+		},
+		{
+			name:         "Find file in second relative path",
+			relativeTos:  []string{dir1, dir2},
+			file:         "file2.txt",
+			expectedPath: filepath.Join(dir2, "file2.txt"),
+		},
+		{
+			name:         "Find shared file (should use first match)",
+			relativeTos:  []string{dir1, dir2},
+			file:         "shared.txt",
+			expectedPath: filepath.Join(dir1, "shared.txt"),
+		},
+		{
+			name:         "Absolute path exists",
+			relativeTos:  []string{dir1, dir2},
+			file:         filepath.Join(tempDir, "absolute.txt"),
+			expectedPath: filepath.Join(tempDir, "absolute.txt"),
+		},
+		{
+			name:          "Absolute path does not exist",
+			relativeTos:   []string{dir1, dir2},
+			file:          filepath.Join(tempDir, "nonexistent.txt"),
+			expectedError: true,
+		},
+		{
+			name:          "File not found in any location",
+			relativeTos:   []string{dir1, dir2},
+			file:          "nonexistent.txt",
+			expectedError: true,
+		},
+		{
+			name:          "Empty relative paths",
+			relativeTos:   []string{},
+			file:          "file1.txt",
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := NewFileResolver(tt.relativeTos)
+			path, err := resolver.ResolveFilePath(tt.file)
+
+			// Check error cases
+			if tt.expectedError {
+				if err == nil {
+					t.Error("expected error but got none")
+					return
+				}
+				return
+			}
+
+			// Check success cases
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if path != tt.expectedPath {
+				t.Errorf("expected path %s but got %s", tt.expectedPath, path)
+			}
+
+			// Verify the file exists
+			if !FileExists(path) {
+				t.Errorf("resolved path %s does not exist", path)
+			}
+		})
+	}
+}
+
+func TestFileNotFoundError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         *FileNotFoundError
+		expectedMsg string
+	}{
+		{
+			name: "Error with no searched paths",
+			err: &FileNotFoundError{
+				Path: "test.txt",
+			},
+			expectedMsg: "file not found: test.txt",
+		},
+		{
+			name: "Error with searched paths",
+			err: &FileNotFoundError{
+				Path:          "test.txt",
+				SearchedPaths: []string{"/path1", "/path2"},
+			},
+			expectedMsg: "file not found: test.txt (searched in: [/path1 /path2])",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if msg != tt.expectedMsg {
+				t.Errorf("expected message %q but got %q", tt.expectedMsg, msg)
+			}
+		})
+	}
+}

--- a/internal/persistence/local/dag_store.go
+++ b/internal/persistence/local/dag_store.go
@@ -93,8 +93,8 @@ func (d *dagStoreImpl) GetSpec(_ context.Context, name string) (string, error) {
 const defaultPerm os.FileMode = 0744
 
 func (d *dagStoreImpl) UpdateSpec(ctx context.Context, name string, spec []byte) error {
-	// Load the DAG to validate the spec.
-	_, err := digraph.LoadYAML(ctx, spec)
+	// Validate the spec before saving it.
+	_, err := digraph.LoadYAML(ctx, spec, digraph.WithoutEval())
 	if err != nil {
 		return err
 	}

--- a/internal/persistence/local/dag_store.go
+++ b/internal/persistence/local/dag_store.go
@@ -58,10 +58,10 @@ func (d *dagStoreImpl) GetMetadata(ctx context.Context, name string) (*digraph.D
 		return nil, fmt.Errorf("failed to locate DAG %s: %w", name, err)
 	}
 	if d.fileCache == nil {
-		return digraph.LoadMetadata(ctx, filePath)
+		return digraph.Load(ctx, filePath, digraph.OnlyMetadata(), digraph.WithoutEval())
 	}
 	return d.fileCache.LoadLatest(filePath, func() (*digraph.DAG, error) {
-		return digraph.LoadMetadata(ctx, filePath)
+		return digraph.Load(ctx, filePath, digraph.OnlyMetadata(), digraph.WithoutEval())
 	})
 }
 
@@ -269,7 +269,7 @@ func (d *dagStoreImpl) Grep(ctx context.Context, pattern string) (
 				errs = append(errs, fmt.Sprintf("grep %s failed: %s", entry.Name(), err))
 				continue
 			}
-			dag, err := digraph.LoadMetadata(ctx, filePath)
+			dag, err := digraph.Load(ctx, filePath, digraph.OnlyMetadata(), digraph.WithoutEval())
 			if err != nil {
 				errs = append(errs, fmt.Sprintf("check %s failed: %s", entry.Name(), err))
 				continue

--- a/internal/persistence/local/dag_store.go
+++ b/internal/persistence/local/dag_store.go
@@ -70,7 +70,7 @@ func (d *dagStoreImpl) GetDetails(ctx context.Context, name string) (*digraph.DA
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate DAG %s: %w", name, err)
 	}
-	dat, err := digraph.LoadWithoutEval(ctx, filePath)
+	dat, err := digraph.Load(ctx, filePath, digraph.WithoutEval())
 	if err != nil {
 		return nil, fmt.Errorf("failed to load DAG %s: %w", name, err)
 	}

--- a/internal/persistence/model/status.go
+++ b/internal/persistence/model/status.go
@@ -33,7 +33,8 @@ func (f *StatusFactory) CreateDefault() Status {
 		OnSuccess:  nodeOrNil(f.dag.HandlerOn.Success),
 		OnFailure:  nodeOrNil(f.dag.HandlerOn.Failure),
 		OnCancel:   nodeOrNil(f.dag.HandlerOn.Cancel),
-		Params:     Params(f.dag.Params),
+		Params:     strings.Join(f.dag.Params, " "),
+		ParamsList: f.dag.Params,
 		StartedAt:  stringutil.FormatTime(time.Time{}),
 		FinishedAt: stringutil.FormatTime(time.Time{}),
 	}
@@ -144,7 +145,8 @@ type Status struct {
 	StartedAt  string           `json:"StartedAt"`
 	FinishedAt string           `json:"FinishedAt"`
 	Log        string           `json:"Log"`
-	Params     string           `json:"Params"`
+	Params     string           `json:"Params,omitempty"`
+	ParamsList []string         `json:"ParamsList,omitempty"`
 }
 
 func (st *Status) CorrectRunningStatus() {
@@ -163,10 +165,6 @@ func FormatTime(val time.Time) string {
 
 func Time(t time.Time) *time.Time {
 	return &t
-}
-
-func Params(params []string) string {
-	return strings.Join(params, " ")
 }
 
 type PID int

--- a/internal/scheduler/entryreader.go
+++ b/internal/scheduler/entryreader.go
@@ -99,7 +99,7 @@ func (er *entryReaderImpl) initDAGs(ctx context.Context) error {
 	var fileNames []string
 	for _, fi := range fis {
 		if fileutil.IsYAMLFile(fi.Name()) {
-			dag, err := digraph.LoadMetadata(ctx, filepath.Join(er.dagsDir, fi.Name()))
+			dag, err := digraph.Load(ctx, filepath.Join(er.dagsDir, fi.Name()), digraph.OnlyMetadata(), digraph.WithoutEval())
 			if err != nil {
 				logger.Error(ctx, "DAG load failed", "err", err, "DAG", fi.Name())
 				continue
@@ -138,7 +138,8 @@ func (er *entryReaderImpl) watchDags(ctx context.Context, done chan any) {
 			}
 			er.dagsLock.Lock()
 			if event.Op == fsnotify.Create || event.Op == fsnotify.Write {
-				dag, err := digraph.LoadMetadata(ctx, filepath.Join(er.dagsDir, filepath.Base(event.Name)))
+				filePath := filepath.Join(er.dagsDir, filepath.Base(event.Name))
+				dag, err := digraph.Load(ctx, filePath, digraph.OnlyMetadata(), digraph.WithoutEval())
 				if err != nil {
 					logger.Error(ctx, "DAG load failed", "err", err, "file", event.Name)
 				} else {

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -164,7 +164,7 @@ func (d *DAG) AssertCurrentStatus(t *testing.T, expected scheduler.Status) {
 
 type AgentOption func(*Agent)
 
-func WithAgentOptions(options *agent.Options) AgentOption {
+func WithAgentOptions(options agent.Options) AgentOption {
 	return func(a *Agent) {
 		a.opts = options
 	}
@@ -182,10 +182,6 @@ func (d *DAG) Agent(opts ...AgentOption) *Agent {
 
 	for _, opt := range opts {
 		opt(helper)
-	}
-
-	if helper.opts == nil {
-		helper.opts = &agent.Options{}
 	}
 
 	helper.Agent = agent.New(
@@ -214,7 +210,7 @@ type Agent struct {
 	*Helper
 	*digraph.DAG
 	*agent.Agent
-	opts *agent.Options
+	opts agent.Options
 }
 
 func (a *Agent) RunError(t *testing.T) {

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -115,7 +115,7 @@ func (h Helper) LoadDAGFile(t *testing.T, filename string) DAG {
 	t.Helper()
 
 	filePath := filepath.Join(fileutil.MustGetwd(), "testdata", filename)
-	dag, err := digraph.Load(h.Context, "", filePath, "")
+	dag, err := digraph.Load(h.Context, filePath)
 	require.NoError(t, err)
 
 	return DAG{


### PR DESCRIPTION
Resolves #763 

- Added support for DAG level field `dotenv`. User can specify candidate ``.env`` files to load environment variables from. By default, no env files are loaded unless explicitly specified.
- Files can be specified as:
  - Absolute paths
  - Relative to the DAG file directory
  - Relative to the base config directory
  - Relative to the user's home directory

Example:

```yaml
dotenv: .env # Specify a single file

# Or specify multiple candidate files
dotenv:
  - .env
  - .env.local
  - configs/.env.prod
```