### PR TITLE
digraph: fix: Do not expand env before command evaluation

### DIFF
--- a/internal/digraph/condition.go
+++ b/internal/digraph/condition.go
@@ -56,19 +56,19 @@ func (c Condition) eval(ctx context.Context) (bool, error) {
 func (c Condition) evalCommand(ctx context.Context) (bool, error) {
 	var commandToRun string
 	if IsStepContext(ctx) {
-		command, err := GetStepContext(ctx).EvalString(c.Command)
+		command, err := GetStepContext(ctx).EvalString(c.Command, cmdutil.OnlyReplaceVars())
 		if err != nil {
 			return false, err
 		}
 		commandToRun = command
 	} else if IsContext(ctx) {
-		command, err := GetContext(ctx).EvalString(c.Command)
+		command, err := GetContext(ctx).EvalString(c.Command, cmdutil.OnlyReplaceVars())
 		if err != nil {
 			return false, err
 		}
 		commandToRun = command
 	} else {
-		command, err := cmdutil.EvalString(c.Command)
+		command, err := cmdutil.EvalString(c.Command, cmdutil.OnlyReplaceVars())
 		if err != nil {
 			return false, err
 		}

--- a/internal/digraph/condition_test.go
+++ b/internal/digraph/condition_test.go
@@ -67,6 +67,22 @@ func TestCondition_Eval(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "ComplexCommand",
+			condition: []Condition{
+				{
+					Command: "test 1 -eq 1",
+				},
+			},
+		},
+		{
+			name: "EvenMoreComplexCommand",
+			condition: []Condition{
+				{
+					Command: "df / | awk 'NR==2 {exit $4 > 5000 ? 0 : 1}'",
+				},
+			},
+		},
+		{
 			name: "CommandResultTest",
 			condition: []Condition{
 				{

--- a/internal/digraph/context.go
+++ b/internal/digraph/context.go
@@ -45,8 +45,9 @@ func (c Context) WithEnv(key, value string) Context {
 	return c
 }
 
-func (c Context) EvalString(s string) (string, error) {
-	return cmdutil.EvalString(s, cmdutil.WithVariables(c.envs))
+func (c Context) EvalString(s string, opts ...cmdutil.EvalOption) (string, error) {
+	opts = append(opts, cmdutil.WithVariables(c.envs))
+	return cmdutil.EvalString(s, opts...)
 }
 
 func NewContext(ctx context.Context, dag *DAG, client DBClient, requestID, logFile string) context.Context {

--- a/internal/digraph/step_context.go
+++ b/internal/digraph/step_context.go
@@ -61,11 +61,10 @@ func (c StepContext) MailerConfig() (mailer.Config, error) {
 	})
 }
 
-func (c StepContext) EvalString(s string) (string, error) {
-	return cmdutil.EvalString(s,
-		cmdutil.WithVariables(c.envs),
-		cmdutil.WithVariables(c.outputVariables.Variables()),
-	)
+func (c StepContext) EvalString(s string, opts ...cmdutil.EvalOption) (string, error) {
+	opts = append(opts, cmdutil.WithVariables(c.envs))
+	opts = append(opts, cmdutil.WithVariables(c.outputVariables.Variables()))
+	return cmdutil.EvalString(s, opts...)
 }
 
 func (c StepContext) EvalBool(value any) (bool, error) {


### PR DESCRIPTION
- Resolved an issue where `precondition.command` execution occurred after the expansion of environment variables, leading to incorrect outcomes.