### PR TITLE
Fixes itemized list in Contribution Guide

### DIFF
--- a/docs/source/contrib.rst
+++ b/docs/source/contrib.rst
@@ -49,6 +49,7 @@ Code Structure
 - ``docs``: Contains the documentation for the project.
 - ``examples``: Contains the example DAGs.
 - ``internal``: Contains the internal code for the project.
+
   - ``agent``: Contains the code for running the DAGs.
   - ``config``: Contains the code for loading the configuration.
   - ``dag``: Contains the code for parsing the DAG definition.


### PR DESCRIPTION
## Description

Fixes a rendering issue in the docs.

The Contribution Guide has an itemized list under the [Code Structure](https://dagu.readthedocs.io/en/latest/contrib.html#code-structure) heading. The final item (which covers `internal`) is rendering incorrectly.  This is due to the lack of an empty line between the item and the first sub-item, causing Docutils to parse the sub-items as part of the paragraph rather than as distinct block-level nodes.
