### PR TITLE
Add git tags to dagu version (Fixes #816)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,9 @@ CONFIG_DIR=$(SCRIPT_DIR)/config
 
 # Local build settings
 BIN_DIR=$(SCRIPT_DIR)/.local/bin
-BUILD_VERSION=$(shell date +'%y%m%d%H%M%S')
-LDFLAGS=-X 'main.version=$(BUILD_VERSION)'
+BUILD_VERSION=$(shell git describe --tags)
+DATE=$(shell date +'%y%m%d%H%M%S')
+LDFLAGS=-X 'main.version=$(BUILD_VERSION)-$(DATE)'
 
 # Application name
 APP_NAME=dagu


### PR DESCRIPTION
Fetch git tag and appended to LDFLAGS in Makefile. 

Improve dagu version command line output with github tags.

Fixes #816