### PR TITLE
system version fix

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -38,9 +38,12 @@ esac
 TMPDIR=$(mktemp -d)
 export TAR_FILE="${TMPDIR}/${FILE_BASENAME}_$(uname -s)_${ARCHITECTURE}.tar.gz"
 
+# Get system type (Linux | Freebsd | Darwin ) as lowercase
+SYSTEM=$(uname -s | awk '{print tolower($0)}')
+
 # Download the binary
 echo "Downloading Dagu $VERSION..."
-curl -sfLo "$TAR_FILE" "$RELEASES_URL/download/$VERSION/${FILE_BASENAME}_${VERSION:1}_$(uname -s)_${ARCHITECTURE}.tar.gz" || {
+curl -sfLo "$TAR_FILE" "$RELEASES_URL/download/$VERSION/${FILE_BASENAME}_${VERSION#v}_${SYSTEM}_${ARCHITECTURE}.tar.gz" || {
     echo "Failed to download the file. Check your internet connection and the URL." >&2
     exit 1
 }


### PR DESCRIPTION
Checking out dagu  and tried using the `scripts/installer.sh` to download latest release from [Dagu Releases](https://github.com/dagu-org/dagu/releases)

Ran into a few bugs. First, a syntax error, then issues getting the correct URL to download the release file. 

Debugging/tested on an Ubuntu 24.10 system.

Syntax issue:

```
./installer.sh
Downloading the latest binary to the current directory...
Downloading Dagu v1.16.1...
./installer.sh: 43: Bad substitution
```

Current URL build method
```
"$RELEASES_URL/download/$VERSION/${FILE_BASENAME}_${VERSION:1}_$(uname -s)_${ARCHITECTURE}.tar.gz" 
```

The tweaks to get rid of syntax issue & the correct URL for the file on the releases page:
- `$(uname -s)` is giving `Linux` but we need `linux` _(lowercase)_
- `${VERSION:1} is cause of `Bad substitution` error.
- The second VERSION in the file name, not folder, needs to be just the version number without v prefixed, like so: `v1.16.1`  for folder, but `1.16.1` for the filename.


So, the tweaks are summarized as follows:
```
SYSTEM=$(uname -s | awk '{print tolower($0)}')
"$RELEASES_URL/download/$VERSION/${FILE_BASENAME}_${VERSION#v}_${SYSTEM}_${ARCHITECTURE}.tar.gz"
```
