### PR TITLE
doc: improve contribution guide, add commit standards

### DIFF
--- a/docs/source/contrib.rst
+++ b/docs/source/contrib.rst
@@ -1,7 +1,63 @@
 Contribution Guide
 ===================
 
-We welcome any contributions to the `Dagu` project. If you have an idea for a new feature or have found a bug, please open an issue on the GitHub repository.
+We welcome contributions to the `Dagu` project. If you have an idea for a new feature or find a bug, open an issue on the GitHub repository.
+
+The `Dagu` community and maintainers are active and helpful. If you're unsure whether something is a bug, start by asking a question in the `community <https://discord.gg/gpahPUjGRk>`_.
+
+Asking Support Questions
+------------------------
+
+We have an active `community <https://discord.gg/gpahPUjGRk>`_ where `Dagu` community members and maintainers ask and answer questions.
+
+Reporting Issues
+----------------
+
+If you find a technical problem in `Dagu` or its documentation, use the GitHub issue tracker to report it. If you're unsure whether it's a bug, start by asking in the `community <https://discord.gg/gpahPUjGRk>`_.
+
+Code Contribution Guidelines
+----------------------------
+
+Using conventional commit standards makes commit messages clearer. Format each commit message as follows:
+
+.. code-block:: sh
+   
+   TYPE(SCOPE): MESSAGE
+
+`SCOPE` describes the area of the changes, `MESSAGE` concisely summarizes them, and `TYPE` is a short label from the following list:
+
+* `feat`: Introduces a new feature
+* `fix`: Fixes a bug
+* `docs`: Changes in documentation only
+* `style`: Code changes that do not impact functionality (e.g., running `go fmt`)
+* `refactor`: Code changes to improving code readability or structure
+* `perf`: Code changes that improve performance
+* `test`: Addition of missing tests or corrections to existing tests
+* `chore`: Changes that do not modify source code or test files 
+* `build`: Changes affecting the build system or external dependencies 
+* `ci`: Changes to Continuous Integration configuration files and scripts
+* `revert`: Reverts a previously made commit
+
+Conventional Commit Message Examples
+-------------------------------------
+.. code-block:: sh
+   
+   feat: add user notifications on dag runs
+
+.. code-block:: sh
+
+   test : add unit tests for docker
+
+.. code-block:: sh
+
+   fix(cmd): add checks for missing parameters
+
+.. code-block:: sh
+
+   docs: add new dag scheme page
+
+Please refer to `Conventional Commits <https://www.conventionalcommits.org>`_ for more information.
+
 
 Prerequisite
 -------------


### PR DESCRIPTION
This commit improves the contribution guide by adding sections for support questions, reporting issues and additional documentation code contribution guidelines.