### PR TITLE
docs: update quickstart to include messy output example

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -44,6 +44,8 @@ Go to the ``SPEC`` Tab and hit the ``Edit`` button. Copy & Paste the following Y
         command: |
           echo "$raw_output" | grep '^DATA:' | sed 's/^DATA: //'
         output: cleaned_data
+        depends:
+          - pass 'Simulate unclean Command Output'
 
       - name: Done
         command: echo Done!

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -45,7 +45,7 @@ Go to the ``SPEC`` Tab and hit the ``Edit`` button. Copy & Paste the following Y
           echo "$raw_output" | grep '^DATA:' | sed 's/^DATA: //'
         output: cleaned_data
         depends:
-          - pass 'Simulate unclean Command Output'
+          - Simulate unclean Command Output
 
       - name: Done
         command: echo Done!

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -58,6 +58,6 @@ You can execute the example by pressing the `Start` button.
 5. Next Steps
 --------------
 
-Check out the [examples](https://github.com/dagu-org/dagu/tree/main/examples) to learn more
+Check out the `Examples provided by Dagu team <https://github.com/dagu-org/dagu/tree/main/examples>`_ to learn more
 
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -29,6 +29,22 @@ Go to the ``SPEC`` Tab and hit the ``Edit`` button. Copy & Paste the following Y
     steps:
       - name: Hello world
         command: echo Hello $NAME
+
+      - name: Simulate unclean Command Output
+        command: |
+          cat <<EOF
+          INFO: Starting process...
+          DEBUG: Initializing variables...
+          DATA: User count is 42
+          INFO: Process completed successfully.
+          EOF
+        output: raw_output
+    
+      - name: Extract Relevant Data
+        command: |
+          echo "$raw_output" | grep '^DATA:' | sed 's/^DATA: //'
+        output: cleaned_data
+
       - name: Done
         command: echo Done!
         depends:
@@ -38,3 +54,10 @@ Go to the ``SPEC`` Tab and hit the ``Edit`` button. Copy & Paste the following Y
 -------------------
 
 You can execute the example by pressing the `Start` button.
+
+5. Next Steps
+--------------
+
+Check out the [examples](https://github.com/dagu-org/dagu/tree/main/examples) to learn more
+
+


### PR DESCRIPTION
See: https://github.com/dagu-org/dagu/issues/841#issuecomment-2668916859

This I hope is a tiny edit, which would have answered some questions I had about output.

I might ask if this is successful to also add some docs to the output command, documenting some alternative patterns.

This is the kind of thing I encounter at work all the time. Some third party component that has noise in it's output, but maybe isn't OpenSource or is retrieving data from somewhere that means I need to make a tool to clean the data.