### PR TITLE
fix: show legacy path warnings

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -54,6 +54,11 @@ UI Customization
 
 Configuration File
 ----------------
+
+.. note::
+  
+  Storing Dagu configuration in ``$HOME/.dagu`` is deprecated.
+   
 Create ``config.yaml`` in ``$HOME/.config/dagu/`` to override default settings. Below is a complete example with all available options:
 
 .. code-block:: yaml

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -59,6 +60,7 @@ func (r *PathResolver) setXDGPaths() {
 }
 
 func (r *PathResolver) setLegacyPaths() {
+	fmt.Sprintf("Warning: Legacy path detected. Update configuration paths")
 	r.DataDir = filepath.Join(r.ConfigDir, "data")
 	r.LogsDir = filepath.Join(r.ConfigDir, "logs")
 	r.BaseConfigFile = filepath.Join(r.ConfigDir, "base.yaml")


### PR DESCRIPTION
Show a legacy configuration page warning if users are using ``.dagu``.

Adds a note in configuration docs.