### PR TITLE
docs: note block in execute the DAG of QuickStart

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -55,6 +55,9 @@ Go to the ``SPEC`` Tab and hit the ``Edit`` button. Copy & Paste the following Y
 4. Execute the DAG
 -------------------
 
+.. note::
+   In the `examples <https://github.com/dagu-org/dagu/tree/main/examples>`_ folder, there is a ``docker-compose.yaml`` which can be used to test out DAGs, and get up to speed with examples like the above.
+
 You can execute the example by pressing the `Start` button.
 
 5. Next Steps


### PR DESCRIPTION
See https://github.com/dagu-org/dagu/issues/841

Just a note-block for now.

I noticed the other `note:` was not a note block, but managed to find an example in rest.rst of how this project was setup.

When testing I did use python 3.11.9 instead of 3.7.16 (which I think was old in 2018 😄 )

I can add changing the python version to this, but it might be better to have in it's own PR and issue so others can discuss.
