### PR TITLE
fix: snapshot deprecated warning (Fixes #869)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,7 +36,7 @@ checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc


### PR DESCRIPTION
Minor change to prevent warnings in goreleaser healthcheck
https://goreleaser.com/deprecations/#snapshotname_template

Fix #869