### PR TITLE
docs: fixed incorrect command syntax in slack notification example

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,8 +584,8 @@ handlerOn:
   failure:
     command: |
       curl -X POST -H 'Content-type: application/json' \
-      --data '{"text":"DAG Failed ($DAG_NAME")}' \
-      ${SLACK_WEBHOOK_URL}
+      --data '{ "text": "DAG Failure ('${DAG_NAME}')" }' \
+      ${SLACK_WEBHOOK_URL} 
 
 steps:
   - name: critical process


### PR DESCRIPTION
Closes https://github.com/dagu-org/dagu/issues/873#issuecomment-2708754362