### PR TITLE
executor/mail: fix: line breaks in email body are not properly converted to `<br />`

### DIFF
--- a/internal/digraph/builder.go
+++ b/internal/digraph/builder.go
@@ -85,6 +85,7 @@ var stepBuilderRegistry = []stepBuilderEntry{
 	{name: "repeatPolicy", fn: buildRepeatPolicy},
 	{name: "signalOnStop", fn: buildSignalOnStop},
 	{name: "precondition", fn: buildStepPrecondition},
+	{name: "output", fn: buildOutput},
 }
 
 type stepBuilderEntry struct {
@@ -550,7 +551,6 @@ func buildStep(ctx BuildContext, def stepDef, fns []*funcDef) (*Step, error) {
 		Script:         def.Script,
 		Stdout:         def.Stdout,
 		Stderr:         def.Stderr,
-		Output:         def.Output,
 		Dir:            def.Dir,
 		MailOnError:    def.MailOnError,
 		ExecutorConfig: ExecutorConfig{Config: make(map[string]any)},
@@ -622,6 +622,20 @@ func buildRepeatPolicy(_ BuildContext, def stepDef, step *Step) error {
 		step.RepeatPolicy.Repeat = def.RepeatPolicy.Repeat
 		step.RepeatPolicy.Interval = time.Second * time.Duration(def.RepeatPolicy.IntervalSec)
 	}
+	return nil
+}
+
+func buildOutput(_ BuildContext, def stepDef, step *Step) error {
+	if def.Output == "" {
+		return nil
+	}
+
+	if strings.HasPrefix(def.Output, "$") {
+		step.Output = strings.TrimPrefix(def.Output, "$")
+		return nil
+	}
+
+	step.Output = def.Output
 	return nil
 }
 

--- a/internal/digraph/scheduler/node.go
+++ b/internal/digraph/scheduler/node.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -699,5 +700,5 @@ func (oc *OutputCoordinator) capturedOutput(ctx context.Context) (string, error)
 	if _, err := io.Copy(&buf, oc.outputReader); err != nil {
 		return "", fmt.Errorf("io: failed to read output: %w", err)
 	}
-	return buf.String(), nil
+	return strings.TrimSpace(buf.String()), nil
 }

--- a/internal/digraph/scheduler/node.go
+++ b/internal/digraph/scheduler/node.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -700,5 +699,5 @@ func (oc *OutputCoordinator) capturedOutput(ctx context.Context) (string, error)
 	if _, err := io.Copy(&buf, oc.outputReader); err != nil {
 		return "", fmt.Errorf("io: failed to read output: %w", err)
 	}
-	return strings.TrimSpace(buf.String()), nil
+	return buf.String(), nil
 }

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -157,7 +157,7 @@ func joinBytes(s ...[]byte) []byte {
 
 func newlineToBrTag(body string) string {
 	return strings.NewReplacer(
-		`\r\n`, "<br />", `\r`, "<br />", `\n`, "<br />",
+		`\r\n`, "<br />", `\r`, "<br />", `\n`, "<br />", "\r\n", "<br />", "\r", "<br />", "\n", "<br />",
 	).Replace(body)
 }
 

--- a/schemas/dag.schema.json
+++ b/schemas/dag.schema.json
@@ -34,7 +34,6 @@
     },
     "schedule": {
       "type": "string",
-      "pattern": "(\\*|[0-5]?[0-9]|\\*/[0-9]+)\\s+(\\*|1?[0-9]|2[0-3]|\\*/[0-9]+)\\s+(\\*|[1-2]?[0-9]|3[0-1]|\\*/[0-9]+)\\s+(\\*|[0-9]|1[0-2]|\\*/[0-9]+|jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\\s+(\\*/[0-9]+|\\*|[0-7]|sun|mon|tue|wed|thu|fri|sat)\\s*(\\*/[0-9]+|\\*|[0-9]+)?",
       "description": "Cron expression that determines how often the DAG runs (e.g., '5 4 * * *' runs daily at 04:05). If omitted, the DAG will only run manually."
     },
     "skipIfSuccessful": {


### PR DESCRIPTION
**Changes:**
- Convert line breaks of email contents to `<br />`
- Fix json schema
- Handle `$` prefix in output name in DAG spec