### PR TITLE
Optimize Docker image size and split into three base-line image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -8,8 +8,8 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-*"
 
 jobs:
-  # Build and push Docker image
-  docker:
+  # Build and push ubuntu-based latest image
+  docker-latest:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,8 +41,87 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ env.VERSION }}
+  # Build and push ubuntu-based dev image
+  docker-dev:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          # Remove 'v' prefix from tag
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.DAGU_GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.dev
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:dev
+            ghcr.io/${{ github.repository }}:${{ env.VERSION }}-dev
+  # Build and push ubuntu-based dev image
+  docker-alpine:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          # Remove 'v' prefix from tag
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.DAGU_GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.alpine
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:alpine
+            ghcr.io/${{ github.repository }}:${{ env.VERSION }}-alpine

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -47,7 +47,7 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ env.VERSION }}
-  # Build and push ubuntu-based dev image
+  # Build and push alpine-based dev image
   docker-dev:
     runs-on: ubuntu-latest
     permissions:

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -19,20 +19,15 @@ COPY --from=ui-builder /app/dist/ ./internal/frontend/assets/
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="${LDFLAGS}" -o ./bin/dagu ./cmd
 
 # Stage 3: Final Image
-FROM --platform=$TARGETPLATFORM ubuntu:24.04
+FROM --platform=$TARGETPLATFORM alpine:3.21.3
 ARG USER="dagu"
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
 # Install common tools
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
-    apt-get install -y \
-    sudo \
-    tzdata \
-    jq \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk update && \
+    apk add jq tzdata sudo shadow bash && \
+    rm -rf /var/cache/apk/*
 
 COPY --from=go-builder /app/bin/dagu /usr/local/bin/
 COPY ./entrypoint.sh /entrypoint.sh

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -29,8 +29,20 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
     sudo \
+    git \
+    curl \
+    wget \
+    zip \
+    unzip \
+    sudo \
     tzdata \
+    build-essential \
     jq \
+    python3 \
+    python3-pip \
+    openjdk-11-jdk \
+    nodejs \
+    npm \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hi, I'm back with my work update! As discussed in issue #891, I've migrated the `dagu:latest` image to a `dagu:dev` version (which includes various development tools that are unnecessary in production), and created a new Alpine-based image `dagu:alpine`.

After setting up GitHub Actions in my forked repository and building the three images, pulling them to my server resulted in significant size reduction and build time improvements:
```
jerry@docker:~$ docker images | grep dagu
ghcr.io/jerry-yuan/dagu   dev               097d153d8388   27 minutes ago   1.39GB
ghcr.io/jerry-yuan/dagu   latest            9af316925576   29 minutes ago   126MB
ghcr.io/jerry-yuan/dagu   alpine            73a5aa5de41f   30 minutes ago   58MB
jerry@docker:~$ 
```
![image](https://github.com/user-attachments/assets/2f6e4c84-3372-482e-8629-111ba97a2b36)

Additionally, I've tested most sample workflows. The smaller alpine image performs well except for environment-dependent DAGs:
![image](https://github.com/user-attachments/assets/1c4fa2c4-219f-4766-9c19-a71ed504a353)
 