### PR TITLE
Improve security by updating file and directory permissions

### DIFF
--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -431,10 +431,10 @@ func BuildLogFilename(config LogFileSettings) string {
 }
 
 // OpenOrCreateLogFile opens (or creates) the log file with flags for creation, write-only access,
-// appending, and synchronous I/O. It sets file permissions to 0640.
+// appending, and synchronous I/O. It sets file permissions to 0600.
 func OpenOrCreateLogFile(filepath string) (*os.File, error) {
 	flags := os.O_CREATE | os.O_WRONLY | os.O_APPEND | os.O_SYNC
-	file, err := os.OpenFile(filepath, flags, 0640)
+	file, err := os.OpenFile(filepath, flags, 0600) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to create/open log file %s: %w", filepath, err)
 	}

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -431,12 +431,10 @@ func BuildLogFilename(config LogFileSettings) string {
 }
 
 // OpenOrCreateLogFile opens (or creates) the log file with flags for creation, write-only access,
-// appending, and synchronous I/O. It sets file permissions to 0644.
+// appending, and synchronous I/O. It sets file permissions to 0640.
 func OpenOrCreateLogFile(filepath string) (*os.File, error) {
 	flags := os.O_CREATE | os.O_WRONLY | os.O_APPEND | os.O_SYNC
-	permissions := os.FileMode(0644)
-
-	file, err := os.OpenFile(filepath, flags, permissions) //nolint:gosec
+	file, err := os.OpenFile(filepath, flags, 0640)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create/open log file %s: %w", filepath, err)
 	}

--- a/internal/cmd/setup_test.go
+++ b/internal/cmd/setup_test.go
@@ -130,7 +130,7 @@ func TestCreateLogFile(t *testing.T) {
 
 		info, err := file.Stat()
 		require.NoError(t, err)
-		assert.Equal(t, os.FileMode(0644), info.Mode().Perm())
+		assert.Equal(t, os.FileMode(0640), info.Mode().Perm())
 	})
 
 	t.Run("invalid path", func(t *testing.T) {

--- a/internal/cmd/setup_test.go
+++ b/internal/cmd/setup_test.go
@@ -130,7 +130,7 @@ func TestCreateLogFile(t *testing.T) {
 
 		info, err := file.Stat()
 		require.NoError(t, err)
-		assert.Equal(t, os.FileMode(0640), info.Mode().Perm())
+		assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
 	})
 
 	t.Run("invalid path", func(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,7 +54,7 @@ tls:
   certFile: "/path/to/cert.pem"
   keyFile: "/path/to/key.pem"
 `
-	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	err := os.WriteFile(configFile, []byte(configContent), 0640)
 	require.NoError(t, err)
 
 	// Load the configuration using the provided config file option.
@@ -138,7 +138,7 @@ auth:
     username: ""
     password: "secret"
 `
-	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	err := os.WriteFile(configFile, []byte(configContent), 0640)
 	require.NoError(t, err)
 
 	_, err = config.Load(config.WithConfigFile(configFile))
@@ -156,7 +156,7 @@ tls:
   certFile: "/path/to/cert.pem"
   keyFile: ""
 `
-	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	err := os.WriteFile(configFile, []byte(configContent), 0640)
 	require.NoError(t, err)
 
 	_, err = config.Load(config.WithConfigFile(configFile))
@@ -252,7 +252,7 @@ func TestSetExecutable(t *testing.T) {
 paths:
   executable: ""
 `
-	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	err := os.WriteFile(configFile, []byte(configContent), 0640)
 	require.NoError(t, err)
 
 	cfg, err := config.Load(config.WithConfigFile(configFile))
@@ -270,7 +270,7 @@ func TestCleanBasePath(t *testing.T) {
 	configContent := `
 basePath: "////dagu//"
 `
-	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	err := os.WriteFile(configFile, []byte(configContent), 0640)
 	require.NoError(t, err)
 
 	cfg, err := config.Load(config.WithConfigFile(configFile))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,7 +54,7 @@ tls:
   certFile: "/path/to/cert.pem"
   keyFile: "/path/to/key.pem"
 `
-	err := os.WriteFile(configFile, []byte(configContent), 0640)
+	err := os.WriteFile(configFile, []byte(configContent), 0600)
 	require.NoError(t, err)
 
 	// Load the configuration using the provided config file option.
@@ -138,7 +138,7 @@ auth:
     username: ""
     password: "secret"
 `
-	err := os.WriteFile(configFile, []byte(configContent), 0640)
+	err := os.WriteFile(configFile, []byte(configContent), 0600)
 	require.NoError(t, err)
 
 	_, err = config.Load(config.WithConfigFile(configFile))
@@ -156,7 +156,7 @@ tls:
   certFile: "/path/to/cert.pem"
   keyFile: ""
 `
-	err := os.WriteFile(configFile, []byte(configContent), 0640)
+	err := os.WriteFile(configFile, []byte(configContent), 0600)
 	require.NoError(t, err)
 
 	_, err = config.Load(config.WithConfigFile(configFile))
@@ -252,7 +252,7 @@ func TestSetExecutable(t *testing.T) {
 paths:
   executable: ""
 `
-	err := os.WriteFile(configFile, []byte(configContent), 0640)
+	err := os.WriteFile(configFile, []byte(configContent), 0600)
 	require.NoError(t, err)
 
 	cfg, err := config.Load(config.WithConfigFile(configFile))
@@ -270,7 +270,7 @@ func TestCleanBasePath(t *testing.T) {
 	configContent := `
 basePath: "////dagu//"
 `
-	err := os.WriteFile(configFile, []byte(configContent), 0640)
+	err := os.WriteFile(configFile, []byte(configContent), 0600)
 	require.NoError(t, err)
 
 	cfg, err := config.Load(config.WithConfigFile(configFile))

--- a/internal/digraph/executor/mail_test.go
+++ b/internal/digraph/executor/mail_test.go
@@ -27,7 +27,7 @@ func TestMail(t *testing.T) {
 	content := []byte("Test email")
 
 	_ = os.Setenv("MAIL_SUBJECT", "Test Subject")
-	err = os.WriteFile(attachFile, content, 0640)
+	err = os.WriteFile(attachFile, content, 0600)
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}

--- a/internal/digraph/executor/mail_test.go
+++ b/internal/digraph/executor/mail_test.go
@@ -27,7 +27,7 @@ func TestMail(t *testing.T) {
 	content := []byte("Test email")
 
 	_ = os.Setenv("MAIL_SUBJECT", "Test Subject")
-	err = os.WriteFile(attachFile, content, 0644)
+	err = os.WriteFile(attachFile, content, 0640)
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -54,7 +54,7 @@ func OpenOrCreateFile(file string) (*os.File, error) {
 
 // openFile opens file.
 func openFile(file string) (*os.File, error) {
-	outfile, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0600)
+	outfile, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0600) //nolint:gosec
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func openFile(file string) (*os.File, error) {
 
 // createFile creates file.
 func createFile(file string) (*os.File, error) {
-	outfile, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	outfile, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600) //nolint:gosec
 	if err != nil {
 		return nil, err
 	}

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -54,7 +54,7 @@ func OpenOrCreateFile(file string) (*os.File, error) {
 
 // openFile opens file.
 func openFile(file string) (*os.File, error) {
-	outfile, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0640)
+	outfile, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func openFile(file string) (*os.File, error) {
 
 // createFile creates file.
 func createFile(file string) (*os.File, error) {
-	outfile, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0640)
+	outfile, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -54,7 +54,7 @@ func OpenOrCreateFile(file string) (*os.File, error) {
 
 // openFile opens file.
 func openFile(file string) (*os.File, error) {
-	outfile, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0750) //nolint:gosec
+	outfile, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0640)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func openFile(file string) (*os.File, error) {
 
 // createFile creates file.
 func createFile(file string) (*os.File, error) {
-	outfile, err := os.Create(file) //nolint:gosec
+	outfile, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0640)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/fileutil/resolver_test.go
+++ b/internal/fileutil/resolver_test.go
@@ -14,7 +14,7 @@ func TestFileResolver(t *testing.T) {
 
 	// Create test directories
 	for _, dir := range []string{dir1, dir2} {
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0750); err != nil {
 			t.Fatalf("Failed to create test directory: %v", err)
 		}
 	}
@@ -30,7 +30,7 @@ func TestFileResolver(t *testing.T) {
 	}
 
 	for path, content := range testFiles {
-		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(content), 0640); err != nil {
 			t.Fatalf("Failed to create test file: %v", err)
 		}
 	}

--- a/internal/fileutil/resolver_test.go
+++ b/internal/fileutil/resolver_test.go
@@ -30,7 +30,7 @@ func TestFileResolver(t *testing.T) {
 	}
 
 	for path, content := range testFiles {
-		if err := os.WriteFile(path, []byte(content), 0640); err != nil {
+		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 			t.Fatalf("Failed to create test file: %v", err)
 		}
 	}

--- a/internal/integration/servercmd_test.go
+++ b/internal/integration/servercmd_test.go
@@ -33,7 +33,7 @@ func TestServer_BasePath(t *testing.T) {
 port: %s
 basePath: "/dagu"
 `, port)
-	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0640))
 
 	// Use the provided test helper to set up context and cancellation.
 	th := test.SetupCommand(t)
@@ -103,7 +103,7 @@ remoteNodes:
   - name: "dev"
     apiBaseUrl: "http://127.0.0.1:%s%s/api/v2"
 `, port, tc.basePath, port, tc.basePath)
-			require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+			require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0640))
 
 			// Use the provided test helper to set up context and cancellation.
 			th := test.SetupCommand(t)

--- a/internal/integration/servercmd_test.go
+++ b/internal/integration/servercmd_test.go
@@ -33,7 +33,7 @@ func TestServer_BasePath(t *testing.T) {
 port: %s
 basePath: "/dagu"
 `, port)
-	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0640))
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0600))
 
 	// Use the provided test helper to set up context and cancellation.
 	th := test.SetupCommand(t)
@@ -103,7 +103,7 @@ remoteNodes:
   - name: "dev"
     apiBaseUrl: "http://127.0.0.1:%s%s/api/v2"
 `, port, tc.basePath, port, tc.basePath)
-			require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0640))
+			require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0600))
 
 			// Use the provided test helper to set up context and cancellation.
 			th := test.SetupCommand(t)

--- a/internal/integration/startcmd_test.go
+++ b/internal/integration/startcmd_test.go
@@ -30,7 +30,7 @@ func TestServer_StartWithConfig(t *testing.T) {
 				tempDir := t.TempDir()
 				configFile := filepath.Join(tempDir, "config.yaml")
 				configContent := `logDir: ${TMP_LOGS_DIR}/logs`
-				require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+				require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0640))
 				return configFile, tempDir
 			},
 			dagPath: func(t *testing.T, _ string) string {
@@ -49,7 +49,7 @@ steps:
   - name: step1
     command: echo "Hello, world!"
 `
-				require.NoError(t, os.WriteFile(dagFile, []byte(dagContent), 0644))
+				require.NoError(t, os.WriteFile(dagFile, []byte(dagContent), 0640))
 				return dagFile, tempDir
 			},
 			dagPath: func(_ *testing.T, tempDir string) string {
@@ -95,10 +95,10 @@ func TestServer_RetrySubDAG(t *testing.T) {
 		// Create temporary DAG file
 		dagFile := filepath.Join(th.Config.Paths.DAGsDir, name)
 		// Create the directory if it doesn't exist
-		err := os.MkdirAll(filepath.Dir(dagFile), 0755)
+		err := os.MkdirAll(filepath.Dir(dagFile), 0750)
 		require.NoError(t, err)
 		// Write the DAG file
-		err = os.WriteFile(dagFile, []byte(content), 0644)
+		err = os.WriteFile(dagFile, []byte(content), 0640)
 		require.NoError(t, err)
 	}
 

--- a/internal/integration/startcmd_test.go
+++ b/internal/integration/startcmd_test.go
@@ -30,7 +30,7 @@ func TestServer_StartWithConfig(t *testing.T) {
 				tempDir := t.TempDir()
 				configFile := filepath.Join(tempDir, "config.yaml")
 				configContent := `logDir: ${TMP_LOGS_DIR}/logs`
-				require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0640))
+				require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0600))
 				return configFile, tempDir
 			},
 			dagPath: func(t *testing.T, _ string) string {
@@ -49,7 +49,7 @@ steps:
   - name: step1
     command: echo "Hello, world!"
 `
-				require.NoError(t, os.WriteFile(dagFile, []byte(dagContent), 0640))
+				require.NoError(t, os.WriteFile(dagFile, []byte(dagContent), 0600))
 				return dagFile, tempDir
 			},
 			dagPath: func(_ *testing.T, tempDir string) string {
@@ -98,7 +98,7 @@ func TestServer_RetrySubDAG(t *testing.T) {
 		err := os.MkdirAll(filepath.Dir(dagFile), 0750)
 		require.NoError(t, err)
 		// Write the DAG file
-		err = os.WriteFile(dagFile, []byte(content), 0640)
+		err = os.WriteFile(dagFile, []byte(content), 0600)
 		require.NoError(t, err)
 	}
 

--- a/internal/persistence/jsondb/record.go
+++ b/internal/persistence/jsondb/record.go
@@ -108,7 +108,7 @@ func (r *Record) Open(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to marshal DAG metadata: %w", err)
 		}
-		if err := os.WriteFile(filepath.Join(dir, "dag.json"), dagJSON, 0640); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "dag.json"), dagJSON, 0600); err != nil {
 			return fmt.Errorf("failed to write DAG metadata: %w", err)
 		}
 	}

--- a/internal/persistence/jsondb/record.go
+++ b/internal/persistence/jsondb/record.go
@@ -108,8 +108,7 @@ func (r *Record) Open(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to marshal DAG metadata: %w", err)
 		}
-		// TODO: use 0600 // nolint: gosec
-		if err := os.WriteFile(filepath.Join(dir, "dag.json"), dagJSON, 0744); err != nil { //nolint:gosec
+		if err := os.WriteFile(filepath.Join(dir, "dag.json"), dagJSON, 0640); err != nil {
 			return fmt.Errorf("failed to write DAG metadata: %w", err)
 		}
 	}

--- a/internal/persistence/jsondb/record_test.go
+++ b/internal/persistence/jsondb/record_test.go
@@ -131,7 +131,7 @@ func TestHistoryRecord_Compact(t *testing.T) {
 			data, err := json.Marshal(status)
 			require.NoError(t, err)
 
-			f, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0644)
+			f, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0640)
 			require.NoError(t, err)
 
 			_, err = f.Write(append(data, '\n'))
@@ -245,7 +245,7 @@ func TestHistoryRecord_InvalidJSON(t *testing.T) {
 	writeJSONToFile(t, file, validStatus)
 
 	// Append invalid JSON
-	f, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0640)
 	require.NoError(t, err)
 	_, err = f.Write([]byte("invalid json\n"))
 	require.NoError(t, err)
@@ -264,7 +264,7 @@ func TestReadLineFrom(t *testing.T) {
 
 	// Create a test file with multiple lines
 	content := "line1\nline2\nline3\n"
-	err := os.WriteFile(file, []byte(content), 0644)
+	err := os.WriteFile(file, []byte(content), 0640)
 	require.NoError(t, err)
 
 	f, err := os.Open(file)
@@ -302,7 +302,7 @@ func TestSafeRename(t *testing.T) {
 	targetFile := filepath.Join(dir, "target.txt")
 
 	// Create source file
-	err := os.WriteFile(sourceFile, []byte("test content"), 0644)
+	err := os.WriteFile(sourceFile, []byte("test content"), 0640)
 	require.NoError(t, err)
 
 	// Test rename when target doesn't exist
@@ -312,7 +312,7 @@ func TestSafeRename(t *testing.T) {
 	assert.NoFileExists(t, sourceFile)
 
 	// Create source again
-	err = os.WriteFile(sourceFile, []byte("new content"), 0644)
+	err = os.WriteFile(sourceFile, []byte("new content"), 0640)
 	require.NoError(t, err)
 
 	// Test rename when target exists
@@ -390,6 +390,6 @@ func writeJSONToFile(t *testing.T, file string, obj any) {
 	data, err := json.Marshal(obj)
 	require.NoError(t, err)
 
-	err = os.WriteFile(file, append(data, '\n'), 0644)
+	err = os.WriteFile(file, append(data, '\n'), 0640)
 	require.NoError(t, err)
 }

--- a/internal/persistence/jsondb/record_test.go
+++ b/internal/persistence/jsondb/record_test.go
@@ -131,7 +131,7 @@ func TestHistoryRecord_Compact(t *testing.T) {
 			data, err := json.Marshal(status)
 			require.NoError(t, err)
 
-			f, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0640)
+			f, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0600)
 			require.NoError(t, err)
 
 			_, err = f.Write(append(data, '\n'))
@@ -245,7 +245,7 @@ func TestHistoryRecord_InvalidJSON(t *testing.T) {
 	writeJSONToFile(t, file, validStatus)
 
 	// Append invalid JSON
-	f, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0640)
+	f, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0600)
 	require.NoError(t, err)
 	_, err = f.Write([]byte("invalid json\n"))
 	require.NoError(t, err)
@@ -264,7 +264,7 @@ func TestReadLineFrom(t *testing.T) {
 
 	// Create a test file with multiple lines
 	content := "line1\nline2\nline3\n"
-	err := os.WriteFile(file, []byte(content), 0640)
+	err := os.WriteFile(file, []byte(content), 0600)
 	require.NoError(t, err)
 
 	f, err := os.Open(file)
@@ -302,7 +302,7 @@ func TestSafeRename(t *testing.T) {
 	targetFile := filepath.Join(dir, "target.txt")
 
 	// Create source file
-	err := os.WriteFile(sourceFile, []byte("test content"), 0640)
+	err := os.WriteFile(sourceFile, []byte("test content"), 0600)
 	require.NoError(t, err)
 
 	// Test rename when target doesn't exist
@@ -312,7 +312,7 @@ func TestSafeRename(t *testing.T) {
 	assert.NoFileExists(t, sourceFile)
 
 	// Create source again
-	err = os.WriteFile(sourceFile, []byte("new content"), 0640)
+	err = os.WriteFile(sourceFile, []byte("new content"), 0600)
 	require.NoError(t, err)
 
 	// Test rename when target exists
@@ -390,6 +390,6 @@ func writeJSONToFile(t *testing.T, file string, obj any) {
 	data, err := json.Marshal(obj)
 	require.NoError(t, err)
 
-	err = os.WriteFile(file, append(data, '\n'), 0640)
+	err = os.WriteFile(file, append(data, '\n'), 0600)
 	require.NoError(t, err)
 }

--- a/internal/persistence/local/dagstore.go
+++ b/internal/persistence/local/dagstore.go
@@ -96,8 +96,7 @@ func (d *dagStoreImpl) GetSpec(_ context.Context, name string) (string, error) {
 }
 
 // FileMode used for newly created DAG files
-// TODO: Consider using more restrictive permissions (0600) for security
-const defaultPerm os.FileMode = 0744
+const defaultPerm os.FileMode = 0640
 
 func (d *dagStoreImpl) LoadSpec(ctx context.Context, spec []byte, opts ...digraph.LoadOption) (*digraph.DAG, error) {
 	// Validate the spec before saving it.

--- a/internal/persistence/local/dagstore.go
+++ b/internal/persistence/local/dagstore.go
@@ -96,7 +96,7 @@ func (d *dagStoreImpl) GetSpec(_ context.Context, name string) (string, error) {
 }
 
 // FileMode used for newly created DAG files
-const defaultPerm os.FileMode = 0640
+const defaultPerm os.FileMode = 0600
 
 func (d *dagStoreImpl) LoadSpec(ctx context.Context, spec []byte, opts ...digraph.LoadOption) (*digraph.DAG, error) {
 	// Validate the spec before saving it.

--- a/internal/persistence/local/storage/storage.go
+++ b/internal/persistence/local/storage/storage.go
@@ -10,10 +10,8 @@ type Storage struct {
 	Dir string
 }
 
-var (
-	// TODO: use 0600 // nolint: gosec
-	defaultPermission os.FileMode = 0744
-)
+// defaultPermission is the default permission for the directory.
+var defaultPermission os.FileMode = 0750
 
 // NewStorage creates a new storage.
 func NewStorage(dir string) *Storage {


### PR DESCRIPTION
This PR improves the security posture of the Dagu project by implementing more restrictive file and directory permissions throughout the codebase. The main changes include:

- Changed file permissions from 0644 (rw-r--r--) to 0600 (rw-r-----) across all file operations
- Changed directory permissions from 0755 (rwxr-xr-x) to 0750 (rwxr-x---)