### PR TITLE
ci: add docker-next workflow and docs for next preview image

### DIFF
--- a/.github/workflows/docker-next.yaml
+++ b/.github/workflows/docker-next.yaml
@@ -1,0 +1,52 @@
+name: DockerImage (next)
+
+on:
+  push:
+    branches:
+      - next
+
+concurrency:
+  group: docker-next-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set short SHA
+        id: vars
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.DAGU_GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:next
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:next-${{ env.SHORT_SHA }}

--- a/.github/workflows/docker-next.yaml
+++ b/.github/workflows/docker-next.yaml
@@ -1,6 +1,12 @@
 name: DockerImage (next)
 
 on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or tag to build"
+        required: false
+        default: next
   push:
     branches:
       - next
@@ -23,6 +29,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set short SHA
         id: vars

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Dagu’s design emphasizes minimal external dependencies: it operates solely as 
   - [Via Bash script](#via-bash-script)
   - [Via GitHub Releases Page](#via-github-releases-page)
   - [Via Homebrew (macOS)](#via-homebrew-macos)
-  - [Via Docker](#via-docker)
+  - [Via Docker (stable)](#via-docker-stable)
+  - [Via Docker (next preview)](#via-docker-next-preview)
   - [Quick Start](#quick-start)
 - [Building from Source](#building-from-source)
   - [Prerequisites](#prerequisites)
@@ -132,7 +133,7 @@ Upgrade to the latest version:
 brew upgrade dagu-org/brew/dagu
 ```
 
-### Via Docker
+### Via Docker (stable)
 
 ```sh
 docker run \
@@ -146,6 +147,28 @@ ghcr.io/dagu-org/dagu:latest dagu start-all
 Note: The environment variable `DAGU_TZ` is the timezone for the scheduler and server. You can set it to your local timezone (e.g. `America/New_York`).
 
 See [Environment variables](https://dagu.readthedocs.io/en/latest/config.html#environment-variables) to configure those default directories.
+
+### Via Docker (next preview)
+
+The `next` branch is published continuously as a preview image. Use this to test the upcoming version without waiting for a formal release.
+
+```sh
+docker run \
+--rm \
+-p 8080:8080 \
+-v ~/.config/dagu:/config \
+-e DAGU_TZ=`ls -l /etc/localtime | awk -F'/zoneinfo/' '{print $2}'` \
+ghcr.io/dagu-org/dagu:next dagu start-all
+```
+
+Two tags are pushed on every commit to `next`:
+
+| Tag          | Description                                                    |
+| ------------ | -------------------------------------------------------------- |
+| `next`       | Moving pointer to the latest commit on the `next` branch       |
+| `next-<sha>` | Immutable image for the specific commit (first 7 chars of SHA) |
+
+> **Heads‑up**: preview images may contain breaking changes and are **not** guaranteed to be backward‑compatible. Pin to `next-<sha>` if you need a reproducible environment.
 
 ### Quick Start
 


### PR DESCRIPTION
This PR:
- Adds `.github/workflows/docker-next.yaml` to build and publish Docker images from the `next` branch
- Updates README with a “Via Docker (next preview)” section showing how to pull `ghcr.io/dagu-org/dagu:next` and `next-<sha>` tags
- Does not add a new badge

**Note:** Preview images may contain breaking changes; pin to `next-<sha>` for a reproducible build.