### PR TITLE
[#926] fix: set basicauth flag correctly when legacy config key specified

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -322,7 +322,9 @@ func TestLoadLegacyFields_AllSet(t *testing.T) {
 	// Check that legacy fields are correctly assigned.
 	assert.Equal(t, "legacyUser", cfg.Server.Auth.Basic.Username, "BasicAuthUsername should be set")
 	assert.Equal(t, "legacyPass", cfg.Server.Auth.Basic.Password, "BasicAuthPassword should be set")
+	assert.True(t, cfg.Server.Auth.Basic.Enabled, "Basic auth should be enabled when BasicAuthUsername is set")
 	assert.True(t, cfg.Server.Auth.Token.Enabled, "Auth token should be enabled when IsAuthToken is true")
+	assert.True(t, cfg.Server.Auth.Token.Enabled, "Auth token should be enabled")
 	assert.Equal(t, "legacyToken", cfg.Server.Auth.Token.Value, "Auth token value should be set")
 	// When both DAGs and DAGsDir are provided, DAGsDir takes precedence.
 	assert.Equal(t, "/usr/user/dags", cfg.Paths.DAGsDir, "DAGsDir should be set from def.DAGsDir")

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -150,10 +150,16 @@ func (l *ConfigLoader) buildConfig(def Definition) (*Config, error) {
 			cfg.Server.Auth.Basic.Enabled = def.Auth.Basic.Enabled
 			cfg.Server.Auth.Basic.Username = def.Auth.Basic.Username
 			cfg.Server.Auth.Basic.Password = def.Auth.Basic.Password
+			if def.Auth.Basic.Username != "" || def.Auth.Basic.Password != "" {
+				cfg.Server.Auth.Basic.Enabled = true
+			}
 		}
 		if def.Auth.Token != nil {
 			cfg.Server.Auth.Token.Enabled = def.Auth.Token.Enabled
 			cfg.Server.Auth.Token.Value = def.Auth.Token.Value
+			if def.Auth.Token.Value != "" {
+				cfg.Server.Auth.Token.Enabled = true
+			}
 		}
 	}
 
@@ -204,6 +210,9 @@ func (l *ConfigLoader) LoadLegacyFields(cfg *Config, def Definition) {
 	}
 	if def.BasicAuthPassword != "" {
 		cfg.Server.Auth.Basic.Password = def.BasicAuthPassword
+	}
+	if def.BasicAuthUsername != "" || def.BasicAuthPassword != "" {
+		cfg.Server.Auth.Basic.Enabled = true
 	}
 	if def.APIBaseURL != "" {
 		cfg.Server.APIBasePath = def.APIBaseURL


### PR DESCRIPTION
Issue: #926 

Changes:
- Fixed a bug in config loader where basic auth is not enabled when legacy config field is used.