### PR TITLE
[#946] fix: scheduler does not pass config file to DAG executions

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/dagu-org/dagu/internal/config"
 	"github.com/dagu-org/dagu/internal/digraph"
 	"github.com/dagu-org/dagu/internal/digraph/scheduler"
 	"github.com/dagu-org/dagu/internal/fileutil"
@@ -119,6 +120,12 @@ func (e *client) Start(_ context.Context, dag *digraph.DAG, opts StartOptions) e
 	}
 	if opts.Quiet {
 		args = append(args, "-q")
+	}
+	if configFile := config.UsedConfigFile.Load(); configFile != nil {
+		if configFile, ok := configFile.(string); ok {
+			args = append(args, "--config")
+			args = append(args, configFile)
+		}
 	}
 	args = append(args, dag.Location)
 	// nolint:gosec

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -8,12 +8,16 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/adrg/xdg"
 	"github.com/dagu-org/dagu/internal/build"
 	"github.com/dagu-org/dagu/internal/fileutil"
 	"github.com/spf13/viper"
 )
+
+// UsedConfigFile is a global variable that stores the path to the configuration file
+var UsedConfigFile = atomic.Value{}
 
 // Load creates a new configuration by instantiating a ConfigLoader with the provided options
 // and then invoking its Load method.
@@ -70,6 +74,11 @@ func (l *ConfigLoader) Load() (*Config, error) {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			return nil, fmt.Errorf("failed to read config: %w", err)
 		}
+	}
+
+	// Store the path of the used configuration file for later reference.
+	if configFile := viper.ConfigFileUsed(); configFile != "" {
+		UsedConfigFile.Store(configFile)
 	}
 
 	// For backward compatibility, try merging in the "admin.yaml" config.

--- a/internal/digraph/loader_test.go
+++ b/internal/digraph/loader_test.go
@@ -113,6 +113,18 @@ func TestLoadBaseConfig(t *testing.T) {
 		require.NotNil(t, dag)
 		require.NoError(t, err)
 	})
+	t.Run("InheritBaseConfig", func(t *testing.T) {
+		t.Parallel()
+
+		baseDAG := test.TestdataPath(t, filepath.Join("digraph", "inherit_base.yaml"))
+		testDAG := test.TestdataPath(t, filepath.Join("digraph", "inherit_child.yaml"))
+		dag, err := digraph.Load(context.Background(), testDAG, digraph.WithBaseConfig(baseDAG))
+		require.NotNil(t, dag)
+		require.NoError(t, err)
+
+		// Check if fields are inherited correctly
+		assert.Equal(t, "/base/logs", dag.LogDir)
+	})
 }
 
 func TestLoadYAML(t *testing.T) {

--- a/internal/frontend/server/routes.go
+++ b/internal/frontend/server/routes.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/dagu-org/dagu/internal/logger"
 	"github.com/go-chi/chi/v5"
@@ -28,8 +29,14 @@ func (svr *Server) defaultRoutes(ctx context.Context, r *chi.Mux) *chi.Mux {
 
 func (svr *Server) handleRequest(ctx context.Context) http.HandlerFunc {
 	renderFunc := svr.useTemplate(ctx, "index.gohtml", "index")
-	return func(w http.ResponseWriter, _ *http.Request) {
-		renderFunc(w, nil)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ".js") {
+			// Insert "/assets" to the URL path for JavaScript files
+			r.URL.Path = "/assets" + r.URL.Path
+			svr.handleGetAssets()(w, r)
+		} else {
+			renderFunc(w, nil)
+		}
 	}
 }
 

--- a/internal/testdata/digraph/inherit_base.yaml
+++ b/internal/testdata/digraph/inherit_base.yaml
@@ -1,0 +1,1 @@
+logDir: "/base/logs"

--- a/internal/testdata/digraph/inherit_child.yaml
+++ b/internal/testdata/digraph/inherit_child.yaml
@@ -1,0 +1,3 @@
+steps:
+  - name: "step1"
+    command: echo "step1"


### PR DESCRIPTION
Address the issue reported in #946 

Changes:
- Updated the server and scheduler to ensure the same config file is passed down to DAG executions.