### PR TITLE
feat: run DAG retry async to avoid request timeouts

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -189,6 +189,14 @@ func (e *client) Retry(_ context.Context, dag *digraph.DAG, requestID string) er
 	return cmd.Wait()
 }
 
+func (e *client) RetryAsync(ctx context.Context, dag *digraph.DAG, requestID string) {
+	go func() {
+		if err := e.Retry(ctx, dag, requestID); err != nil {
+			logger.Error(ctx, "DAG retry operation failed", "err", err)
+		}
+	}()
+}
+
 func (*client) GetCurrentStatus(_ context.Context, dag *digraph.DAG) (*model.Status, error) {
 	client := sock.NewClient(dag.SockAddr())
 	ret, err := client.Request("GET", "/status")

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -148,6 +148,12 @@ func (e *client) Restart(_ context.Context, dag *digraph.DAG, opts RestartOption
 	if opts.Quiet {
 		args = append(args, "-q")
 	}
+	if configFile := config.UsedConfigFile.Load(); configFile != nil {
+		if configFile, ok := configFile.(string); ok {
+			args = append(args, "--config")
+			args = append(args, configFile)
+		}
+	}
 	args = append(args, dag.Location)
 	// nolint:gosec
 	cmd := exec.Command(e.executable, args...)
@@ -164,6 +170,12 @@ func (e *client) Restart(_ context.Context, dag *digraph.DAG, opts RestartOption
 func (e *client) Retry(_ context.Context, dag *digraph.DAG, requestID string) error {
 	args := []string{"retry"}
 	args = append(args, fmt.Sprintf("--request-id=%s", requestID))
+	if configFile := config.UsedConfigFile.Load(); configFile != nil {
+		if configFile, ok := configFile.(string); ok {
+			args = append(args, "--config")
+			args = append(args, configFile)
+		}
+	}
 	args = append(args, dag.Location)
 	// nolint:gosec
 	cmd := exec.Command(e.executable, args...)

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -20,6 +20,7 @@ type Client interface {
 	Start(ctx context.Context, dag *digraph.DAG, opts StartOptions) error
 	Restart(ctx context.Context, dag *digraph.DAG, opts RestartOptions) error
 	Retry(ctx context.Context, dag *digraph.DAG, requestID string) error
+	RetryAsync(ctx context.Context, dag *digraph.DAG, requestID string)
 	GetCurrentStatus(ctx context.Context, dag *digraph.DAG) (*model.Status, error)
 	GetStatusByRequestID(ctx context.Context, dag *digraph.DAG, requestID string) (*model.Status, error)
 	GetLatestStatus(ctx context.Context, dag *digraph.DAG) (model.Status, error)

--- a/internal/frontend/handlers/dag.go
+++ b/internal/frontend/handlers/dag.go
@@ -802,11 +802,7 @@ func (h *DAG) postAction(
 				fmt.Errorf("request-id is required"),
 			)
 		}
-		if err := h.client.Retry(ctx, dagStatus.DAG, params.Body.RequestID); err != nil {
-			return nil, newInternalError(
-				fmt.Errorf("error trying to retry the DAG: %w", err),
-			)
-		}
+		h.client.RetryAsync(ctx, dagStatus.DAG, params.Body.RequestID)
 		return &models.PostDAGActionResponse{}, nil
 
 	case "mark-success":


### PR DESCRIPTION
# What does this PR do?
This PR updates the "retry" action handling so that the POST request no longer blocks until the DAG retry operation completes. Instead, the retry is now triggered asynchronously, and the API responds immediately, preventing request timeouts for long-running jobs.

# Why is this needed?
Addresses issue #608.

# What changed?

- Add RetryAsync method to client interface and implementation
- Update DAG action handler to use RetryAsync for "retry" actions
- Prevent API request from hanging until DAG retry completes by running retry in the background
