### PR TITLE
[fb-1.17.0-beta] Start command should DAG-run without queueing when no other process

### DIFF
--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -103,6 +103,12 @@ func runStart(ctx *Context, args []string) error {
 		return executeDAGRun(ctx, dag, digraph.DAGRunRef{}, dagRunID, root)
 	}
 
+	runningCount, err := ctx.ProcStore.CountAlive(ctx, dag.Name)
+	if err == nil && runningCount == 0 {
+		// If there are no running processes, we can execute the DAG-run directly
+		return executeDAGRun(ctx, dag, digraph.DAGRunRef{}, dagRunID, root)
+	}
+
 	dag.Location = "" // Queued dag-runs must not have a location
 
 	// Enqueue the DAG-run for execution

--- a/internal/persistence/filedagrun/store.go
+++ b/internal/persistence/filedagrun/store.go
@@ -226,7 +226,10 @@ func (store *Store) collectStatusesFromRoots(
 	wg.Wait()
 
 	sort.Slice(results, func(i, j int) bool {
-		return results[i].CreatedAt > results[j].CreatedAt
+		if results[i].CreatedAt != results[j].CreatedAt {
+			return results[i].CreatedAt > results[j].CreatedAt
+		}
+		return results[i].DAGRunID < results[j].DAGRunID
 	})
 	if len(results) > opts.Limit {
 		results = results[:opts.Limit]


### PR DESCRIPTION
- Skip queueing if no other process is running
- Fixed a minor issue where DAG-run list items order was not stable