### PR TITLE
[#992] feat: implement queue configuration

### DIFF
--- a/docs/source/base_config.rst
+++ b/docs/source/base_config.rst
@@ -5,9 +5,15 @@ Base Configuration for all DAGs
 
 Creating a base configuration (default path: ``~/.config/dagu/base.yaml``) is a convenient way to organize shared settings among all DAGs. The path to the base configuration file can be configured. See :ref:`Configuration Options` for more details.
 
+Any settings defined in the base configuration can be overridden by individual DAG files. This is particularly useful for queue management and other organizational defaults.
+
 Example:
 
 .. code-block:: yaml
+
+    # Queue management settings - shared by all DAGs
+    queue: "global-queue"      # Assign all DAGs to the same queue
+    maxActiveRuns: 2           # Default concurrent runs per DAG
 
     # directory path to save logs from standard output
     logDir: /path/to/stdout-logs/

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -31,6 +31,12 @@ The following commands are available for interacting with Dagu:
   # Dry-runs the DAG
   dagu dry <file> [-- <key>=<value> ...]
   
+  # Enqueues a DAG-run to the queue
+  dagu enqueue <file> [--run-id=<run-id>] [-- <key>=<value> ...]
+  
+  # Dequeues a DAG-run from the queue
+  dagu dequeue --dag-run=<dag-name>:<run-id>
+  
   # Launches both the web UI server and scheduler process
   dagu start-all [--host=<host>] [--port=<port>] [--dags=<path to directory>]
   

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -47,6 +47,10 @@ Authentication
 - ``DAGU_AUTH_BASIC_PASSWORD`` (``""``): Basic auth password
 - ``DAGU_AUTH_TOKEN`` (``""``): API token value
 
+Queue System
+~~~~~~~~~~~
+- ``DAGU_QUEUE_ENABLED`` (``true``): Enable/disable the queue system
+
 UI Customization
 ~~~~~~~~~~~~~~
 - ``DAGU_UI_NAVBAR_COLOR`` (``""``): Navigation bar color (e.g., ``red`` or ``#ff0000``)
@@ -75,6 +79,17 @@ Create ``config.yaml`` in ``~/.config/dagu/`` to override default settings. Belo
     dataDir: "~/.local/share/dagu/history"    # Application data location
     suspendFlagsDir: "~/.config/dagu/suspend" # DAG suspend flags location
     adminLogsDir: "~/.local/share/admin"      # Admin logs location
+
+    # Queue Configuration
+    queues:
+      enabled: true    # Enable/disable the queue system (default: true)
+      config:          # Named queue configurations
+        - name: "critical"
+          maxConcurrency: 3
+        - name: "batch"
+          maxConcurrency: 1
+        - name: "default"
+          maxConcurrency: 2
 
     # Common Configuration for all DAGs
     baseConfig: "~/.config/dagu/base.yaml"  # Base DAG config

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -377,3 +377,73 @@ Process multiple items with object parameters:
         fi
 
 For more details on parallel execution, see :ref:`Parallel Execution`.
+
+Queue Management
+---------------
+
+Control concurrent execution of DAGs using queue configuration:
+
+**Basic Queue Assignment:**
+
+.. code-block:: yaml
+
+  name: data-processing
+  queue: "batch"          # Assign to "batch" queue
+  maxActiveRuns: 2        # Allow max 2 concurrent runs
+  schedule: "*/10 * * * *"  # Run every 10 minutes
+  
+  steps:
+    - name: process
+      command: process_data.sh
+
+**Disable Queueing for Critical Jobs:**
+
+.. code-block:: yaml
+
+  name: critical-alert
+  maxActiveRuns: -1       # Disable queueing - always run immediately
+  
+  steps:
+    - name: check-alerts
+      command: check_alerts.sh
+    - name: notify
+      command: send_notifications.sh
+
+**Unified Queue Management via Base Configuration:**
+
+.. code-block:: yaml
+
+  # ~/.config/dagu/base.yaml
+  # All DAGs will use these settings by default
+  queue: "global-queue"
+  maxActiveRuns: 2
+
+**Global Queue Configuration (config.yaml):**
+
+.. code-block:: yaml
+
+  # Global queue settings
+  queues:
+    enabled: true
+    config:
+      - name: "critical"
+        maxConcurrency: 5    # Critical jobs can run 5 at a time
+      - name: "batch"
+        maxConcurrency: 1    # Batch jobs run one at a time
+      - name: "reporting"
+        maxConcurrency: 3    # Reporting can run 3 at a time
+      - name: "global-queue"
+        maxConcurrency: 10   # Shared queue for all DAGs by default
+
+**Manual Queue Management:**
+
+.. code-block:: sh
+
+  # Enqueue a DAG run with custom run ID
+  dagu enqueue batch-job.yaml --run-id=batch-2024-01-15
+  
+  # Enqueue with parameters
+  dagu enqueue process.yaml -- INPUT=/data/file.csv OUTPUT=/results/
+  
+  # Remove from queue
+  dagu dequeue --dag-run=batch-job:batch-2024-01-15

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -30,6 +30,9 @@ Dagu was born out of a desire to make workflow orchestration feasible in any env
 4. **Keep it Simple**  
    Workflows are defined in clear, human-readable YAML with ease of development and fast onboarding. Dagu is designed to be simple to understand and use, even for non-developers.
 
-5. **Community-Driven** 
+5. **Intelligent Queue Management**
+   Built-in queue system provides flexible concurrency control, allowing you to manage resource utilization and prevent overwhelming systems without external dependencies.
+
+6. **Community-Driven** 
    As an open-source project, developers can contribute new executors, integrate emerging technologies, or propose enhancements via GitHub. This encourages rapid iteration and keeps Dagu aligned with real-world use cases.
 

--- a/docs/source/scheduler.rst
+++ b/docs/source/scheduler.rst
@@ -90,6 +90,32 @@ The wait time after the job is stopped before restart can be configured in the D
       - name: step1
         command: python some_app.py
 
+Queue Processing
+---------------
+
+The scheduler also manages the DAG execution queue. When a DAG is scheduled or manually enqueued, it's added to a queue system that controls concurrent execution based on configured limits.
+
+**Queue Behavior:**
+
+- DAGs are processed based on their queue assignment and concurrency limits
+- Each DAG can be assigned to a named queue (defaults to the DAG name)
+- Concurrent execution is controlled by ``maxActiveRuns`` settings
+- The queue system can be disabled globally or per-DAG
+
+**Example with Queue Control:**
+
+.. code-block:: yaml
+
+    name: batch-processor
+    schedule: "0 * * * *"   # Run every hour
+    queue: "batch"          # Use the "batch" queue
+    maxActiveRuns: 2        # Allow max 2 concurrent runs
+    steps:
+      - name: process
+        command: process_batch.sh
+
+If the queue system is disabled (``DAGU_QUEUE_ENABLED=false`` or in config), scheduled DAGs will run immediately without queue control.
+
 Run Scheduler as a Daemon
 -------------------------
 

--- a/docs/source/schema.rst
+++ b/docs/source/schema.rst
@@ -136,7 +136,11 @@ These fields apply to the entire DAG. They appear at the root of the YAML file.
 
 ``maxActiveRuns``
 ~~~~~~~~~~~~~~~~~~
-  Limit on how many active DAG-runs can exist at the same time. If this limit is reached, new runs will be queued until existing ones finish.
+  Limit on how many active DAG-runs can exist at the same time. If this limit is reached, new runs will be queued until existing ones finish. Defaults to 1. Set to -1 to disable queueing for this DAG.
+
+``queue``
+~~~~~~~~~
+  Name of the queue to assign this DAG to. If not specified, defaults to the DAG name. Used with global queue configuration to control concurrent execution across multiple DAGs.
 
 ``params``
 ~~~~~~~~~

--- a/internal/cmd/dequeue.go
+++ b/internal/cmd/dequeue.go
@@ -37,6 +37,10 @@ func runDequeue(ctx *Context, _ []string) error {
 
 // dequeueDAGRun dequeues a dag-run from the queue.
 func dequeueDAGRun(ctx *Context, dagRun digraph.DAGRunRef) error {
+	// Check if queues are enabled
+	if !ctx.Config.Queues.Enabled {
+		return fmt.Errorf("queues are disabled in configuration")
+	}
 	attempt, err := ctx.DAGRunStore.FindAttempt(ctx, dagRun)
 	if err != nil {
 		return fmt.Errorf("failed to find the record for dag-run ID %s: %w", dagRun.ID, err)

--- a/internal/cmd/enqueue.go
+++ b/internal/cmd/enqueue.go
@@ -57,6 +57,10 @@ func runEnqueue(ctx *Context, args []string) error {
 
 // enqueueDAGRun enqueues a dag-run to the queue.
 func enqueueDAGRun(ctx *Context, dag *digraph.DAG, dagRunID string) error {
+	// Check if queues are enabled
+	if !ctx.Config.Queues.Enabled {
+		return fmt.Errorf("queues are disabled in configuration")
+	}
 	logFile, err := ctx.GenLogFileName(dag, dagRunID)
 	if err != nil {
 		return fmt.Errorf("failed to generate log file name: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	// UI contains settings specific to the application's user interface.
 	UI UI
 
+	// Queues contains global queue configuration settings.
+	Queues Queues
+
 	// Warnings contains a list of warnings generated during the configuration loading process.
 	Warnings []string
 }
@@ -210,4 +213,16 @@ type RemoteNode struct {
 type TLSConfig struct {
 	CertFile string
 	KeyFile  string
+}
+
+// Queues represents the global queue configuration
+type Queues struct {
+	Enabled bool
+	Config  []QueueConfig
+}
+
+// QueueConfig represents individual queue configuration
+type QueueConfig struct {
+	Name          string
+	MaxActiveRuns int
 }

--- a/internal/config/definition.go
+++ b/internal/config/definition.go
@@ -62,6 +62,9 @@ type Definition struct {
 	// such as certificate and key file paths.
 	TLS *tlsConfigDef `mapstructure:"tls"`
 
+	// Queues contains global queue configuration settings.
+	Queues *queuesDef `mapstructure:"queues"`
+
 	// ----------------------------------------------------------------------------
 	// Legacy fields for backward compatibility - Start
 	// These fields are maintained for compatibility with older configuration formats.
@@ -205,4 +208,16 @@ type remoteNodeDef struct {
 type tlsConfigDef struct {
 	CertFile string `mapstructure:"certFile"`
 	KeyFile  string `mapstructure:"keyFile"`
+}
+
+// queuesDef represents the global queue configuration
+type queuesDef struct {
+	Enabled bool               `mapstructure:"enabled"`
+	Config  []queueConfigDef   `mapstructure:"config"`
+}
+
+// queueConfigDef represents individual queue configuration
+type queueConfigDef struct {
+	Name           string `mapstructure:"name"`
+	MaxActiveRuns  int    `mapstructure:"maxActiveRuns"`
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -211,6 +211,18 @@ func (l *ConfigLoader) buildConfig(def Definition) (*Config, error) {
 		cfg.UI.LogEncodingCharset = def.UI.LogEncodingCharset
 	}
 
+	// Set queue configuration if provided, with default enabled=true.
+	cfg.Queues.Enabled = true // Default to enabled
+	if def.Queues != nil {
+		cfg.Queues.Enabled = def.Queues.Enabled
+		for _, queueDef := range def.Queues.Config {
+			cfg.Queues.Config = append(cfg.Queues.Config, QueueConfig{
+				Name:          queueDef.Name,
+				MaxActiveRuns: queueDef.MaxActiveRuns,
+			})
+		}
+	}
+
 	// Incorporate legacy field values, which may override existing settings.
 	l.LoadLegacyFields(&cfg, def)
 	// Load legacy environment variable overrides.
@@ -375,6 +387,9 @@ func (l *ConfigLoader) setDefaultValues(resolver PathResolver) {
 
 	// Logging settings
 	viper.SetDefault("logFormat", "text")
+
+	// Queue settings
+	viper.SetDefault("queues.enabled", true)
 }
 
 // bindEnvironmentVariables binds various configuration keys to environment variables.
@@ -433,6 +448,9 @@ func (l *ConfigLoader) bindEnvironmentVariables() {
 
 	// UI customization
 	l.bindEnv("latestStatusToday", "LATEST_STATUS_TODAY")
+
+	// Queue configuration
+	l.bindEnv("queues.enabled", "QUEUE_ENABLED")
 }
 
 // bindEnv constructs the full environment variable name using the app prefix and binds it to the given key.

--- a/internal/digraph/builder.go
+++ b/internal/digraph/builder.go
@@ -76,6 +76,7 @@ var builderRegistry = []builderEntry{
 	{name: "infoMailConfig", fn: buildInfoMailConfig},
 	{name: "maxHistoryRetentionDays", fn: maxHistoryRetentionDays},
 	{name: "maxCleanUpTime", fn: maxCleanUpTime},
+	{name: "maxActiveRuns", fn: buildMaxActiveRuns},
 	{name: "preconditions", fn: buildPrecondition},
 }
 
@@ -120,7 +121,6 @@ func build(ctx BuildContext, spec *definition) (*DAG, error) {
 		Delay:          time.Second * time.Duration(spec.DelaySec),
 		RestartWait:    time.Second * time.Duration(spec.RestartWaitSec),
 		Tags:           parseTags(spec.Tags),
-		MaxActiveRuns:  spec.MaxActiveRuns,
 		MaxActiveSteps: spec.MaxActiveSteps,
 		Queue:          spec.Queue,
 	}
@@ -497,6 +497,18 @@ func parsePrecondition(ctx BuildContext, precondition any) ([]*Condition, error)
 func maxCleanUpTime(_ BuildContext, spec *definition, dag *DAG) error {
 	if spec.MaxCleanUpTimeSec != nil {
 		dag.MaxCleanUpTime = time.Second * time.Duration(*spec.MaxCleanUpTimeSec)
+	}
+	return nil
+}
+
+func buildMaxActiveRuns(_ BuildContext, spec *definition, dag *DAG) error {
+	if spec.MaxActiveRuns != 0 {
+		// Preserve the value if it's set (including negative values)
+		// MaxActiveRuns < 0 means queueing is disabled for this DAG
+		dag.MaxActiveRuns = spec.MaxActiveRuns
+	} else {
+		// Default to 1 only when not specified (0)
+		dag.MaxActiveRuns = 1
 	}
 	return nil
 }

--- a/internal/digraph/builder.go
+++ b/internal/digraph/builder.go
@@ -122,6 +122,7 @@ func build(ctx BuildContext, spec *definition) (*DAG, error) {
 		Tags:           parseTags(spec.Tags),
 		MaxActiveRuns:  spec.MaxActiveRuns,
 		MaxActiveSteps: spec.MaxActiveSteps,
+		Queue:          spec.Queue,
 	}
 
 	// For backward compatibility, set MaxActiveSteps to MaxActiveRuns

--- a/internal/digraph/builder.go
+++ b/internal/digraph/builder.go
@@ -125,11 +125,6 @@ func build(ctx BuildContext, spec *definition) (*DAG, error) {
 		Queue:          spec.Queue,
 	}
 
-	// For backward compatibility, set MaxActiveSteps to MaxActiveRuns
-	if spec.MaxActiveRuns > 0 {
-		dag.MaxActiveSteps = spec.MaxActiveRuns
-	}
-
 	var errs ErrorList
 	for _, builder := range builderRegistry {
 		if !builder.metadata && ctx.opts.OnlyMetadata {

--- a/internal/digraph/builder_test.go
+++ b/internal/digraph/builder_test.go
@@ -529,15 +529,24 @@ func testLoad(t *testing.T, file string, opts ...testOption) DAG {
 }
 
 func TestBuild_QueueConfiguration(t *testing.T) {
-	t.Run("ExplicitQueueAssignment", func(t *testing.T) {
-		th := testLoad(t, "queue_config.yaml")
-		assert.Equal(t, "customQueue", th.Queue)
-		assert.Equal(t, 5, th.MaxActiveRuns)
+	t.Run("MaxActiveRunsDefaultsToOne", func(t *testing.T) {
+		// Test that when maxActiveRuns is not specified, it defaults to 1
+		th := testLoad(t, "valid_command.yaml") // Using a simple DAG without maxActiveRuns
+		assert.Equal(t, 1, th.MaxActiveRuns, "maxActiveRuns should default to 1 when not specified")
 	})
-
-	t.Run("DefaultQueueAssignment", func(t *testing.T) {
-		th := testLoad(t, "queue_default.yaml")
-		assert.Equal(t, "", th.Queue) // Should be empty in DAG struct, will be resolved at runtime
-		assert.Equal(t, 3, th.MaxActiveRuns)
+	
+	t.Run("MaxActiveRunsNegativeValuePreserved", func(t *testing.T) {
+		// Test that negative values are preserved (they mean queueing is disabled)
+		// Create a simple DAG YAML with negative maxActiveRuns
+		data := []byte(`
+name: test-negative-max-active-runs
+maxActiveRuns: -1
+steps:
+  - name: step1
+    command: echo test
+`)
+		dag, err := digraph.LoadYAML(context.Background(), data)
+		require.NoError(t, err)
+		assert.Equal(t, -1, dag.MaxActiveRuns, "negative maxActiveRuns should be preserved")
 	})
 }

--- a/internal/digraph/builder_test.go
+++ b/internal/digraph/builder_test.go
@@ -527,3 +527,17 @@ func testLoad(t *testing.T, file string, opts ...testOption) DAG {
 
 	return DAG{t: t, DAG: dag}
 }
+
+func TestBuild_QueueConfiguration(t *testing.T) {
+	t.Run("ExplicitQueueAssignment", func(t *testing.T) {
+		th := testLoad(t, "queue_config.yaml")
+		assert.Equal(t, "customQueue", th.Queue)
+		assert.Equal(t, 5, th.MaxActiveRuns)
+	})
+
+	t.Run("DefaultQueueAssignment", func(t *testing.T) {
+		th := testLoad(t, "queue_default.yaml")
+		assert.Equal(t, "", th.Queue) // Should be empty in DAG struct, will be resolved at runtime
+		assert.Equal(t, 3, th.MaxActiveRuns)
+	})
+}

--- a/internal/digraph/dag.go
+++ b/internal/digraph/dag.go
@@ -90,6 +90,8 @@ type DAG struct {
 	MaxCleanUpTime time.Duration `json:"maxCleanUpTime,omitempty"`
 	// HistRetentionDays is the number of days to keep the history of dag-runs.
 	HistRetentionDays int `json:"histRetentionDays,omitempty"`
+	// Queue is the name of the queue to assign this DAG to.
+	Queue string `json:"queue,omitempty"`
 	// BuildErrors contains any errors encountered while building the DAG.
 	BuildErrors []error
 }

--- a/internal/digraph/dag.go
+++ b/internal/digraph/dag.go
@@ -306,6 +306,12 @@ func (d *DAG) initializeDefaults() {
 		d.MaxCleanUpTime = defaultMaxCleanUpTime
 	}
 
+	// Set default max active runs to 1 only when not specified (0).
+	// MaxActiveRuns < 0 means queueing is disabled for this DAG.
+	if d.MaxActiveRuns == 0 {
+		d.MaxActiveRuns = 1
+	}
+
 	// Ensure we have a valid working directory
 	var workDir = "."
 	if d.Location != "" {

--- a/internal/digraph/definition.go
+++ b/internal/digraph/definition.go
@@ -62,6 +62,8 @@ type definition struct {
 	MaxCleanUpTimeSec *int
 	// Tags is the tags for the DAG.
 	Tags any
+	// Queue is the name of the queue to assign this DAG to.
+	Queue string
 }
 
 // handlerOnDef defines the steps to be executed on different events.

--- a/internal/scheduler/queue_test.go
+++ b/internal/scheduler/queue_test.go
@@ -1,0 +1,153 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/dagu-org/dagu/internal/config"
+	"github.com/dagu-org/dagu/internal/digraph"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScheduler_QueueMethods(t *testing.T) {
+	t.Parallel()
+
+	t.Run("getQueueNameForDAG_WithExplicitQueue", func(t *testing.T) {
+		cfg := &config.Config{
+			Queues: config.Queues{
+				Enabled: true,
+				Config:  []config.QueueConfig{},
+			},
+		}
+
+		s := &Scheduler{config: cfg}
+
+		dag := &digraph.DAG{
+			Name:  "test-dag",
+			Queue: "customQueue",
+		}
+
+		queueName := s.getQueueNameForDAG(dag)
+		assert.Equal(t, "customQueue", queueName)
+	})
+
+	t.Run("getQueueNameForDAG_DefaultsToDAGName", func(t *testing.T) {
+		cfg := &config.Config{
+			Queues: config.Queues{
+				Enabled: true,
+				Config:  []config.QueueConfig{},
+			},
+		}
+
+		s := &Scheduler{config: cfg}
+
+		dag := &digraph.DAG{
+			Name:  "my-pipeline",
+			Queue: "", // Empty queue should default to DAG name
+		}
+
+		queueName := s.getQueueNameForDAG(dag)
+		assert.Equal(t, "my-pipeline", queueName)
+	})
+
+	t.Run("getQueueConfigByName_GlobalConfigExists", func(t *testing.T) {
+		cfg := &config.Config{
+			Queues: config.Queues{
+				Enabled: true,
+				Config: []config.QueueConfig{
+					{Name: "highPriority", MaxActiveRuns: 2},
+					{Name: "lowPriority", MaxActiveRuns: 10},
+				},
+			},
+		}
+
+		s := &Scheduler{config: cfg}
+
+		dag := &digraph.DAG{
+			Name:          "test-dag",
+			MaxActiveRuns: 5, // Should be ignored since global config exists
+		}
+
+		queueCfg := s.getQueueConfigByName("highPriority", dag)
+		assert.Equal(t, 2, queueCfg.MaxConcurrency)
+	})
+
+	t.Run("getQueueConfigByName_FallbackToDAGMaxActiveRuns", func(t *testing.T) {
+		cfg := &config.Config{
+			Queues: config.Queues{
+				Enabled: true,
+				Config:  []config.QueueConfig{}, // No global queue configuration
+			},
+		}
+
+		s := &Scheduler{config: cfg}
+
+		dag := &digraph.DAG{
+			Name:          "test-dag",
+			MaxActiveRuns: 7,
+		}
+
+		queueCfg := s.getQueueConfigByName("unknownQueue", dag)
+		assert.Equal(t, 7, queueCfg.MaxConcurrency)
+	})
+
+	t.Run("getQueueConfigByName_DefaultToOne", func(t *testing.T) {
+		cfg := &config.Config{
+			Queues: config.Queues{
+				Enabled: true,
+				Config:  []config.QueueConfig{}, // No global queue configuration
+			},
+		}
+
+		s := &Scheduler{config: cfg}
+
+		dag := &digraph.DAG{
+			Name:          "test-dag",
+			MaxActiveRuns: 0, // No DAG max active runs
+		}
+
+		queueCfg := s.getQueueConfigByName("unknownQueue", dag)
+		assert.Equal(t, 1, queueCfg.MaxConcurrency)
+	})
+
+	t.Run("getQueueConfigByName_GlobalConfigPriority", func(t *testing.T) {
+		cfg := &config.Config{
+			Queues: config.Queues{
+				Enabled: true,
+				Config: []config.QueueConfig{
+					{Name: "testQueue", MaxActiveRuns: 3},
+				},
+			},
+		}
+
+		s := &Scheduler{config: cfg}
+
+		dag := &digraph.DAG{
+			Name:          "test-dag",
+			MaxActiveRuns: 10, // Should be ignored since global config exists for testQueue
+		}
+
+		queueCfg := s.getQueueConfigByName("testQueue", dag)
+		assert.Equal(t, 3, queueCfg.MaxConcurrency) // Global config takes priority
+	})
+
+	t.Run("getQueueConfigByName_MinimumOne", func(t *testing.T) {
+		cfg := &config.Config{
+			Queues: config.Queues{
+				Enabled: true,
+				Config: []config.QueueConfig{
+					{Name: "testQueue", MaxActiveRuns: 0}, // Zero should be converted to 1
+				},
+			},
+		}
+
+		s := &Scheduler{config: cfg}
+
+		dag := &digraph.DAG{
+			Name:          "test-dag",
+			MaxActiveRuns: 5,
+		}
+
+		queueCfg := s.getQueueConfigByName("testQueue", dag)
+		assert.Equal(t, 1, queueCfg.MaxConcurrency) // Should be at least 1
+	})
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -211,3 +211,31 @@ func TestPrevExecTime(t *testing.T) {
 		})
 	}
 }
+
+func TestScheduler_QueueDisabled(t *testing.T) {
+	t.Parallel()
+
+	t.Run("QueueDisabled_SkipsQueueProcessing", func(t *testing.T) {
+		th := setupTest(t)
+		// Disable queues
+		th.Config.Queues.Enabled = false
+		
+		entryReader := &mockJobManager{
+			Entries: []*scheduler.ScheduledJob{},
+		}
+
+		sc := scheduler.New(th.Config, entryReader, th.DAGRunMgr, th.DAGRunStore, th.QueueStore, th.ProcStore)
+
+		ctx := context.Background()
+		go func() {
+			_ = sc.Start(ctx)
+		}()
+
+		// Give it a moment to start
+		time.Sleep(time.Millisecond * 100)
+		sc.Stop(ctx)
+
+		// Test passes if no panics occur when queues are disabled
+		require.True(t, true)
+	})
+}

--- a/schemas/dag.schema.json
+++ b/schemas/dag.schema.json
@@ -162,7 +162,12 @@
     },
     "maxActiveRuns": {
       "type": "integer",
-      "description": "Maximum number of concurrent DAG runs allowed. Useful for limiting resource usage and preventing overload. If exceeded, new runs will be queued until existing ones complete."
+      "default": 1,
+      "description": "Maximum number of concurrent DAG runs allowed. Useful for limiting resource usage and preventing overload. If exceeded, new runs will be queued until existing ones complete. Defaults to 1. Set to -1 to disable queueing for this DAG."
+    },
+    "queue": {
+      "type": "string",
+      "description": "Name of the queue to assign this DAG to. If not specified, defaults to the DAG name. Used with global queue configuration to control concurrent execution across multiple DAGs."
     },
     "maxActiveSteps": {
       "type": "integer",


### PR DESCRIPTION
Resolves #992 

**Overview:**
- Added global queue config settings
  ```yaml
  queues:
    enabled: true # default is true
    config:
      - name: some_queue
        maxActiveRuns: 3
  ```

- Added `queue` field as a DAG level field
  ```yaml
  queue: global-queue
  maxActiveRuns: 3
  ```
  You can set it in the base DAG file to use same queue across all DAGs.
  
- Fixed a bug: default value (1) was not set for `maxActiveRuns` in DAG loading process