### PR TITLE
feat: add Partial Success status to DAG runs

### DIFF
--- a/api/v1/api.gen.go
+++ b/api/v1/api.gen.go
@@ -94,15 +94,17 @@ const (
 	RunStatusN2 RunStatus = 2
 	RunStatusN3 RunStatus = 3
 	RunStatusN4 RunStatus = 4
+	RunStatusN6 RunStatus = 6
 )
 
 // Defines values for RunStatusText.
 const (
-	RunStatusTextCancelled  RunStatusText = "cancelled"
-	RunStatusTextFailed     RunStatusText = "failed"
-	RunStatusTextFinished   RunStatusText = "finished"
-	RunStatusTextNotStarted RunStatusText = "not started"
-	RunStatusTextRunning    RunStatusText = "running"
+	RunStatusTextCancelled      RunStatusText = "cancelled"
+	RunStatusTextFailed         RunStatusText = "failed"
+	RunStatusTextFinished       RunStatusText = "finished"
+	RunStatusTextNotStarted     RunStatusText = "not started"
+	RunStatusTextPartialSuccess RunStatusText = "partial success"
+	RunStatusTextRunning        RunStatusText = "running"
 )
 
 // DAG Core DAG configuration containing dag-run definition and metadata
@@ -250,6 +252,7 @@ type DAGStatus struct {
 	// 2: "Failed"
 	// 3: "Cancelled"
 	// 4: "Success"
+	// 6: "Partial Success"
 	Status RunStatus `json:"Status"`
 
 	// StatusText Human-readable status description for the dag-run
@@ -300,6 +303,7 @@ type DAGStatusDetails struct {
 	// 2: "Failed"
 	// 3: "Cancelled"
 	// 4: "Success"
+	// 6: "Partial Success"
 	Status RunStatus `json:"Status"`
 
 	// StatusText Human-readable status description for the dag-run
@@ -477,6 +481,7 @@ type RepeatPolicy struct {
 // 2: "Failed"
 // 3: "Cancelled"
 // 4: "Success"
+// 6: "Partial Success"
 type RunStatus int
 
 // RunStatusText Human-readable status description for the dag-run
@@ -1777,82 +1782,82 @@ func (sh *strictHandler) ListTags(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xc62/ctrL/VwjdC5wW2MRJk364+83HThxfuIlhu6e4aIJgVpqVeCKRCkmtvQ38v18M",
-	"H3qsqH04TZoU55N3VyI5HM7jNw/6U5LKqpYChdHJ/FOi0wIrsB9Pj8/oT4Y6Vbw2XIpknpxIhez0+Iyl",
-	"Uix53iigB/TNABdc5CyD/JFqBMtwyQW3T0FkrEIDGRhIZkmtZI3KcHTL4BKa0lyCgkqPF/SPWU3P0aBi",
-	"Kygb1IwL9r/Xb16zpVQVGMaXTEjDdI0pX3LMGBimGmF4hcksMesak3mijeIiT+5nyWl/kc01XzUViEcK",
-	"IYNFiaz3kMklM4XlwD80qxtVS412fwssYMWlii12pmRTj5e5kDlPoWQ5PSbWySVTWILBjBbQtDUmVQ6C",
-	"/2HZDGVYUseWeQ0Vjlf5VfCPDTKeoTDEGWWn9Ztgt9wUXDButCMjNu/U0VxwbYjm7mgEVKiZKcCwFARb",
-	"IKtBa8yYke2Kg3PhBt3Mo0X9D6AUrOn7dVpg1pQ4TYZ2bxAj8a5WqDWXQns5FDm7LVC0VOhCNmVGlPSp",
-	"+G+Fy2Se/NdRpxRHXiOOWgIixN1AvoU/BnJ3likYzKXifxA5JDRLXhqkHdvzPoAf97NE4ceGK8yS+e/u",
-	"5N+1L8nFvzE1VsyPz47TuJC73+lk6JhQkR5hxmTLo8fsUmrNSQNalUvLJsP5W/GIaQPKzNk1/Qkj7O+N",
-	"rlFkc3btPgyeGVnTEFn3f1Vo1HrOruiP/b0EbWWEHlagPjzSTZqi1nP2C6gPg1cYaOafLpuyHbAEXmI2",
-	"8b57aOmBFc7ZNazQvpQ2SqEwtDWDPU13RJJsE5X0t3uSzBIUTUWHYDmSzBLPAfpkJCmU3WAyS/p7CV8d",
-	"MfQurNC+K4Zn2TNZx2enaICXN7AYH+e5yDjJl2a3BU8LUkrT2wOdM9HB0S7To9k0RAzZzWSWFFwbaYkt",
-	"ZU4/e6FXj+j7VqqittvY7UUcBhfObtOL34pHKGE9Xu2GV0gza0ylyDTx8Ra4YQtckiu0h04K7PnczcyF",
-	"wRzVV3c2L8Rq2hShWHElRUVivgLFaUm7J43tlvAO04b2dJB9/ko+7hWIrET1Ruwy192LNIprc4WGPKAU",
-	"p7COSNXrplqgIvIyWGuvLsAFcyphN1HKXEcP+EKmED/dSzBF3/steRmVvguZn3IVEXauMCWVZDXNRNyy",
-	"5IicqLHTRfn0C9yRgV/hVSMiu/0F7njVVEy0u06l6Owf1o4D1juOt/u3BhqXymq6Ra46BoDDM7d81WjS",
-	"HMK3QYECAURZcAp7QYz+0t8dBromqdlCWRAqZ16sTe1s5n6rG6y/N/T1yjnUU4p8xqa/My02YgIDllLw",
-	"XBm6xTPFs/g89KQbveK6gdKb0315e3p8diFzmujcYBXj8oXMt7l4hyT6ft0Sg5AWh0iYo+PaTvaSxyRt",
-	"g/ktVzyFE+fQ31ycf0SeJZns6iYPhycRt3/0a3DZJO0xC/cviOEkt93+WCZVhgoztlizTQu2jX2vZYZu",
-	"tv2k1lM0zbTeScR8ezh28kNbMV18hr53DO4sxja/pd2y414MgHRzyy/d9H62iU13a20Y/l504A4LQq4j",
-	"slvBdYHZsRnPc/XyhD179ux/7LlqA1XdWeWQO1n68RNI4eGM3C255BgW6ByINdTZIZ76yjnczlPriGMe",
-	"4vTo9DyL7FFJipzY+WmgtWP/GKNc4ccGtTnPDgEqgf/KDZ4QRWUefrLaDX+4kF81olNw9+kG78zew+zL",
-	"m4rRMWsW7MJ1iAx7w/q7n/WFfKsq7Q4PIyrlcw0kh2nBy4wJmVmke5Cifdt6Fh1ot7nFQ3CR8RXPGig9",
-	"pPLA+kAsRevEvPwbcQIixXLf8W/Eiztu9n/7JfCyUbj/gGufL9lzwJRhuuwM0rdrfj7L9PzNLQ+dSVCP",
-	"STvktHarNYoDkRCaW22yQeoYz47zVK5AsgOS2JyMUjIS3NufWYVaQ46MLxmIdex8doOnbamFA8GTHeJS",
-	"mBiR3t8KNAV2cT3XIeXbl62FlCWCmEJgzlB1B91OsPPo9nYmm4EIeOihDdm3B55lCyy/ryPtkf1NnewE",
-	"D89QoOIpQ8tLhbqWQiPz4zZPLiXLv4MTdqET7yKyKRE6zlzqBUq/dHgzQro/4YinLqQyfnx4aXSCG7yz",
-	"W+jmnGTVid9qTORoDgsOUmjz0TSLzfpaPndZ/6VUC55lSCZtAdn7zucIad4vZWOrF+TNlIDyfRjeCGhM",
-	"IRX/wwoEjczB4C2sbeGikgbfE0xrB0CpELL1e9UI4fLJNH/3LTzHO66NjpYXBvneUSauV1CwyYYVBWiF",
-	"G2IdfTyTsh/ECemmfQBOeHdPeBNe3xPcuNfvI2LxCqE0xZVXkQguGCpPizQKO46lBaYfGIqsllyMVUtP",
-	"hMJvVqigLMMsepi+QLXCvrS5t9ZWgMLn2FG32GVL7G3nZlMlnKa2T8Y66Ya5x71iThS5rVDpaCo/EOFf",
-	"GO13u463lbYwf0tuf+cx1b/g2txAftghl1xbM0DHZCAfR07WamxJm1od1gxFKhsyBJixrFHBsnQWY//E",
-	"+vY0beNQsaf1gZnYGzfa7y3GzNdRE9qFVyA2I6wQYE1ne06lwBPi0raqUlelZqThJboawtJ6uBqd0bYR",
-	"XVQq94UbbQKxLSxHoMeDYmY360MDZhr9yJdi062hs+0D2MlOW1NnYAxWtdGsggy9cSPYMsi+9rj4sAjK",
-	"7vyzw6dhanb/+Kkb5wIoV2nZ22X01ePa8eXClvYnQ6h4/NU7lllP4qd0bCqL+rqpLLbzPmMTtYQSJMEI",
-	"14cxfyuezNnb5LU04QzeJm/FU/rtyiEJ+v4TfX/pOjuSt+IZfXVu3v/ynH7x/pa+/2y/f+B17Z53DuvJ",
-	"7Onsp9mz2fPZz++i1c/hgewq6Pud9uv6wQsLh/uCoxTdFglQtTCpVeXUbsh+7CmidpuI+tRLqU3bA3SY",
-	"B6ml9yCCQdsqFMdTr/F2IuGFtzaUEFDhLJgnP5tC3ZQGMwfThHsz6kZHAjaok0YSNd3TYY1Wg+HatoL4",
-	"Sq3nMYNQdInDxem1XrRFVhrs4JSRDFdQNmCi9u3FXY2piQVg4YlnTQAY3Wb8tA497MGnK+tYLmXJ0/U+",
-	"+NkywVnWXofJkBnnBAZWUB7SKWNuEcWGyZ7ImhHB20NTZ41d6XqBvqnJ9q0tPfiOxqpj5rTprIcaKZ9V",
-	"+3I2KmKTohZpmGL7DIPUIZwDbdKGUYqZounmhfBko0WMiJqCXJ3eReRakaoMFDO0sbGaxE+JnWi9N3/M",
-	"wwWKVRTzXMh8lH6ykhtGxSyMwRjgoalS/zAOuXYnktplt8Cuje2HeWctZVEuIKi0OD0+07+ASYt4bd3n",
-	"nlxxR9sRrKLXO1wds7kXXGCsbcmkhe194gK3MoYLdGAxFnEIDI1PtwUqDPQAwXGX+5iAjnGqXA+sJcn2",
-	"mRBZdyYyyyaXabYBrf1ltnP8yrqIOMvPewGMY7h3KG2LQ5zn++ez7Tmg3nraPdaiZrf0pc0s7dXtE5Gu",
-	"SFS5u9JWBaGZwheRrgj3athm9Cg8CJ9kvQH9YSDjDov4TmtN2hDCITqEeInhWG2LmUHlTUVMI1WvQeug",
-	"8qmsKhiyemd4flJlv3FTxFc8cSFrOzNz8/SqtANafOtATDNPPGmjJf4Jupu+1ydGLJSN6RaIN+/WKLId",
-	"7Wf9rkELCdOwq7ZxzweP8da9nSz8jD7fWyKqhTeZjHd1RltEf5Pqg71407aK2lxo6OJtZ/2H7slFpGGU",
-	"l2/ERJqhxV+SaRQZwwp4yYQ0JL7gMhlSdImHOAo7vHG0n3/ZUjR/05i6iXjPf/kOZ+Z69qVtncU+Q6Qb",
-	"eUCHS6+QvKF0ulns297yp7SYTgvq5/SYbsYMW0u7/XcdDo14R8+WzX7iPjKkt2O4kD4HNz/IbnnjYK2o",
-	"e2u6VJahiog04ZuupzqF2rjspjYgMlBZWzSJzShj0rZzxilh27edlFzO3oCz5158OuwrQs7tvXy7s1eu",
-	"m2Mye7UTm97PEo1po7hZE1Sv3Jah5jfyA1oZXSAoVC+dis4TWcPHBv2Fl8paLftCt4HCGFuyWYDm6XFj",
-	"iva2pH2bft18mcigY3FVSmEgtey2F3zmyf9JA+wVVJBBMksaVfpxen50lHNTNIvHqayO1tIYKKrMVS4H",
-	"5crL8xZvKlmWoa25koL7KwKnkDe+QPE4mSUlT9HnfzwRZ5cXj549frKNgAzy5pFUuf1wtCjl4qgCLo4u",
-	"zk9evL5+8diRZrghoUhoxV6RY548ffzk8RN6Q9YooObJPHlmf5olpCv2YGhq+yHHWGYWTaMEqXrpnbm9",
-	"OGI7NWQd7oxAzgW0t0097nUd3uRKW4h1nnlU4Hu+u07FZP77WKbzNlT4wSbF2mV+tBXSZJ58bNBemPIc",
-	"rV3B10my24y9rpTMn8YCgukMt7Xm/h5KowQBR+Ynj61b8oqb+MI/Pdln5ZeWV463i7V1mRNLOeZ6pNyt",
-	"N7JqO1YwkG9d4AbyrfO/I/Pg8pZWeH568iRomjdsUNelxydH/9YOlHXzjYKfLfCxkzhTIFchh7JxsXnf",
-	"Dvdt7e2zv6Ay9wr0DuAHYh3WtZFcb/Eo0CPFmajh3EgDZe/iEcm0ZrACXhJW2x02e8Vtie6vFnEFY7vZ",
-	"r8UFCSKinx8oQDs7TmKrn4sVlDwbdEgrueIZehPvlfZL0xFvsnGus6kqUOsgclCW4YKMrc7Of0+svX53",
-	"P0tqqU0sA4fgwJlP6/f+GcDIFruXHbL3wvtPma0/Q5Vh541nH4SzppaCpUQAPfjBtWv9GEMt9oppZEqt",
-	"ZcrtbUb7Rhu5eBp2Yb32NTd/XHy7AUY1eD8ye08/x+xBfn66PX8i8LZcOy65S5s7d+Um/X500YsdW5Dc",
-	"fXNK6BRkWCMb6uH9zEGoo0/kQO/dcZZoYo2u9nftM1KLte119b5+qJfuTZ8n3AaSbgofYA86261fJ4TX",
-	"uXW/zFCcD/Pwz+Otu50QlWvmtp45KXr+5Q/RFjil8dnNb0583Dm2Kd+RCd+KubN+9v70+GzWy/jZu8cz",
-	"eyl65kB3aBwYCtIZml7r7F8mTCM4eh3i4+3/KiEGUA0sBtB0r7bhG1g4MmIz+mj5EPJDRjNyAySGqV30",
-	"/OXg9O6OghyNTUhuCtUDCxHjpnCbgm2BRtRSDIDIuDb/1aH3hczDnd4d2+3fJHYDf1WRKvyvVxe2UcMa",
-	"RKucPjFcruO5N59R2ufaty13DhNRu3qQ/Igblx4YtwyYslX1y31apd1EoUAz2eh3ENL4j484Q+Nhetvw",
-	"vh/SvxxVszALDT4/4OP88cxlp2f2f//8GP67UM5XKLzqD53FoGHpL0YeD4tFNu1gBy0Pbavq4pgdpsFz",
-	"696za/vVhl7gOQxW9ihcqJ232gKUPj/dGQrNnE+aTzu2YcOYAZWj0ZHM9r7R2puQLcQ7o+CzIraHRWp/",
-	"XkwTb+w7xO59WxbIG5KeWkgxhVkp3HEXCXbmjHt3HWK3FCxspQgos/VjFCnHKIB19yySL3igGzc5Inz0",
-	"txi4ZuEWxf0s+fnJs7+EhO4qx9cUpV8Fhh5J9O/0hejVxK2WID96rQ1WXoJcknlSglz7CToj6VLWoF2f",
-	"ITCLrX0PxEhcusaVXf7rONQpNuaL4fePnxk5/9lg3lHe++c5+10vebEVQfszOQRAu0YoPXWAvvVJd11A",
-	"tE7g7YGNSL2mq103UQJZfw5G/bZstedsPCdMqmUOK+eFO0qs0RY9Kql1mH1ct/N3fL6YId68bvX9nlOb",
-	"vfeXqjZPqlclt8apq4///u5+9qlf6rY/kFVxfjNmzGyt+fjyvLsQ50rKn9xm7udHR58Kqc39EdT8aPXU",
-	"Jr39fyAkPhRtgOF5mJQyhdL+vLn9V1KbAfL3a95H65+uHN+7kOi+2lq35cO7ljdjxOjFz/mBCgTkoc7e",
-	"dVhZ9/CD+1d9mLHjdJ2WPGVnCupC/9jZcMv4SCbHuqWuC9Cv1ZXxbZkxLG0Dna6u38vwOO92/+7+/wMA",
-	"AP//+YNrk9VZAAA=",
+	"H4sIAAAAAAAC/+xce2/cOJL/KoTugJ0BOnEyySxw/Z/XThwfPIlhe3ZwmARBtVQtcSORCkm13RP4ux+K",
+	"Dz1aVD+cSSZZ7F9uSXwUi8WqXz3oT0kqq1oKFEYn80+JTguswP48PT6jPxnqVPHacCmSeXIiFbLT4zOW",
+	"SrHkeaOAPtCTAS64yFkG+SPVCJbhkgtuv4LIWIUGMjCQzJJayRqV4eimwSU0pbkEBZUeT+g/s5q+o0HF",
+	"VlA2qBkX7H+v37xmS6kqMIwvmZCG6RpTvuSYMTBMNcLwCpNZYtY1JvNEG8VFntzPktP+JJtzvmoqEI8U",
+	"QgaLElnvI5NLZgrLgb9pVjeqlhrt+hZYwIpLFZvsTMmmHk9zIXOeQsly+kysk0umsASDGU2gaWlMqhwE",
+	"/8OyGcowpY5N8xoqHM/yq+AfG2Q8Q2GIM8oO6xfBbrkpuGDcaEdGbNyprbng2hDN3dYIqFAzU4BhKQi2",
+	"QFaD1pgxI9sZB/vCDbqRR5P6F6AUrOn5Oi0wa0qcJkO7FsRIvKsVas2l0F4ORc5uCxQtFbqQTZkRJX0q",
+	"/lvhMpkn/3XUHYojfyKOWgIixN1AvoU/BnK3lykYzKXifxA5JDRLXhqkFdv9PoAf97NE4ceGK8yS+e9u",
+	"59+1jeTiX5gaK+bHZ8dpXMjde9oZ2iZUdI4wY7Ll0WN2KbXmdALaI5eWTYbzt+IR0waUmbNr+hN62PeN",
+	"rlFkc3btfgy+GVlTF1n33yo0aj1nV/THvi9BWxmhjxWoD490k6ao9Zz9AurDoAkDzfzXZVO2HZbAS8wm",
+	"2ruPlh5Y4Zxdwwpto7RRCoWhpRnsnXRHJMk2UUl/uy/JLEHRVLQJliPJLPEcoF9G0oGyC0xmSX8t4dER",
+	"Q21hhbatGO5lT2Udn52iAV7ewGK8neci4yRfmt0WPC3oUJreGmifiQ6OdpoezaYhYkhvJrOk4NpIS2wp",
+	"c3rthV49ouetVEV1t7HLixgMLpzepobfikUoYT2e7YZXSCNrTKXINPHxFrhhC1ySKbSbTgfY87kbmQuD",
+	"OaqvbmxeiNW0KkKx4kqKisR8BYrTlHZNGtsl4R2mDa3pIP38lWzcKxBZieqN2KWuu4bUi2tzhYYsoBSn",
+	"sI5I1eumWqAi8jJYa39cgAvmjoRdRClzHd3gC5lCfHcvwRR967fkZVT6LmR+ylVE2LnClI4kq2kk4pYl",
+	"R+REjR0uyqdf4I4U/AqvGhFZ7S9wx6umYqJddSpFp/+wdhyw1nG83H9roHGp7Em3yFXHAHD45qavGk0n",
+	"h/BtOECBAKIsGIW9IEZ/6u8OA12T1GyhLAiVUy9Wp3Y6c7/ZDdbfG/p65QzqKXk+Y9XfqRbrMYEBSyl4",
+	"rgzN4pniWXwc+tL1XnHdQOnV6b68PT0+u5A5DXRusIpx+ULm20y8QxJ9u26JQUiLQyTM0XFtB3vJY5K2",
+	"wfyWK57CiX3oLy7OPyLPkkx6dZOHw52I6z96G0w2SXtMw/0TYjjJLbffl0mVocKMLdZsU4NtY99rmaEb",
+	"bT+p9RRNM623EzHbHrad7NBWTBcfoW8dgzmLsc0vabfsuIYBkG4u+aUb3o82sehurg3F3/MO3GZBiHVE",
+	"Viu4LjA7NuNxrl6esGfPnv2P3VdtoKo7rRxiJ0vffwIpPJyRuyWXDMMCnQGxijo7xFJfOYPbWWodMcxD",
+	"nB4dnmeRNSpJnhM7Pw20duwfY5Qr/NigNufZIUAl8F+5zhOiqMzDd1a77g8X8qtGdAfc/brBO7N3N9t4",
+	"82B0zJoFvXAdPMNet/7qZ30h33qUdruHkSPlYw0kh2nBy4wJmVmke9BB+7bPWbSjXeYWC8FFxlc8a6D0",
+	"kMoD6wOxFM0Ts/JvxAmIFMt9+78RL+642b/1S+Blo3D/Dtc+XrJnhynFdNkppG9X/XyW6vk31zy0J+F4",
+	"TOohd2q3aqM4EAmuuT1N1kkd49lxnMolSHZAEhuTUUpGnHv7mlWoNeTI+JKBWMf2Zzd42hZaOBA82S4u",
+	"hIkR6f2tQFNg59dzHUK+fdlaSFkiiCkE5hRVt9HtADu3bm9jsumIgIce2pB+e+BetsDy+9rSHtnf1M5O",
+	"8PAMBSqeMrS8VKhrKTQy329z51LS/Ds4YSc68SYimxKh48yFXqD0U4eWEdL9DkcsdSGV8f1Do9EObvDO",
+	"LqEbc5JVJ36pMZGjMSw4SKGNR9MoNupr+dxF/ZdSLXiWIam0BWTvO5sjpHm/lI3NXpA1UwLK96F7I6Ax",
+	"hVT8DysQ1DMHg7ewtomLShp8TzCt7QClQsjW71UjhIsn0/jdU/iOd1wbHU0vDOK9o0hcL6Fggw0rctAK",
+	"18Ua+ngkZT+IE8JN+wCc0HZPeBOa7wluXPP7iFi8QihNceWPSAQXDA9PizQK24+lBaYfGIqsllyMj5ae",
+	"cIXfrFBBWYZR9DB8gWqFfWlzrdZWgMLv2Fa32GWL723HZlMpnKa2X8Zn0nVzn3vJnChyW6HS0VB+IMI3",
+	"GK13+xlvM21h/Jbc/spjR/+Ca3MD+WGbXHJt1QBtk4F87DlZrbElbGrPsGYoUtmQIsCMZY0KmqXTGPsH",
+	"1reHaRuHij2tD4zE3rjefm0xZr6OqtDOvQKx6WEFB2s62nMqBZ4Ql7ZllbosNaMTXqLLISythavRKW3r",
+	"0UWlcl+40QYQ28RyBHo8yGd2oz7UYabej3wqNt3qOts6gJ3stDl1BsZgVRvNKsjQKzeCLYPoa4+LD/Og",
+	"7Mo/230ahmb395+6fs6BcpmWvU1G/3hcO75c2NT+pAsV97962zLrSfzUGZuKor5uKovtvM3YRC0hBUkw",
+	"wtVhzN+KJ3P2NnktTdiDt8lb8ZTeXTkkQc8/0fNLV9mRvBXP6NGZef/mOb3x9paef7bPH3hdu++dwXoy",
+	"ezr7afZs9nz287to9nO4IbsS+n6l/bx+sMLC4b5gKEW3RAJULUxqj3JqF2R/9g6idouI2tRLqU1bA3SY",
+	"BamltyCCQVsqFMdTr/F2IuCFt9aVEFDhLKgnP5pC3ZQGMwfThGsZNaMjARvkSSOBmu7rMEerwXBtS0F8",
+	"ptbzmEFIusTh4vRcL9okK3V2cMpIhisoGzBR/fbirsbUxByw8MWzJgCMbjF+WIce9uDTlTUsl7Lk6Xof",
+	"/GyZ4DRrr8JkyIxzAgMrKA+plDG3iGJDZU9EzYjg7a6p08Yudb1AX9Rk69aWHnxHfdUxc9pw1kOVlI+q",
+	"fTkd9Xd6vgRlOJSs9z6mq/4e1VXD4NtnqKoO+xyorUbqqvbrCYVwMbU1XegQvmyUkxGZU/CsO6ORM6Do",
+	"WA0OcSh5YzWJqhI7kX1v/Jg1DBSrKD66kPkoVGWlPPSKaSODMXBEQ6X+Yxye7Q46tdNugWgbyw/jzlrK",
+	"olxAUGlxenymfwGTFvE8vI9TuUSQtj1YRc07DB7TzxdcYKzEyaSFrZPiArcyhgt0wDLmnQgMRVK3BSoM",
+	"9ABBdxcnmYCZcapcvawlydakEFl3JjLKJpdptAGt/Wm2c/zKmpM4y897zo5juDc+bTlEnOf7x77tPqDe",
+	"uts91qJmt/TQRqH2qgyKSFfEA92dlauC0ExhkUgFhWsalhndCg/YJ1lvQH8YyLjDLb4qW9NpCK4TbUI8",
+	"HXGstvnXoPKmIqbRUa9B63DkU1lVMGT1Tlf+pMp+46aIz3ji3Nt2ZObG6WV0B7T4MoPYyTzxpI2m+Afo",
+	"bvheTRmxUDammyBe6FujyHaUqvUrDC18TMOq2iI/72jGy/x2svAzaoJviagWCmUyXgEaLSf9TaoP9pJO",
+	"W1Zq46ah4rcd9W+6JxeR4lJevhETIYkWq0mmUWQMK+AlE9KQ+IKLekjRBSniiO3wItN+rGZLgv1NY+om",
+	"Yj3/6auhmavvl7bMFvsMka7nAdUwvaTzxqHTzWLfUpg/pRx1WlA/px5107/Ymgbut3XINGIdPVs2a4/7",
+	"yJBax3Ah/Q5mfhAJ88rBalHXajqtlqGKiDThm67+OoXauEioNiAyUFmbYImNKGPStnPEKWHbt/SUTM7e",
+	"gLNnXnzo7CtCzu11f7sjXa7yYzLStROb3s8SjWmjuFkTVK/ckqHmN/IDWhldIChUL90RnSeyho8N+ssx",
+	"ldVatkG3gMIYm95ZgObpcWOK9malbU1vNxsTGbQtLqMpDKSW3fYy0Dz5P2mAvYIKMkhmSaNK30/Pj45y",
+	"bopm8TiV1dFaGgNFlbks5yC1eXne4k0lyzKUQFdScH+d4BTyxiczHiezpOQp+liRJ+Ls8uLRs8dPthGQ",
+	"Qd48kiq3P44WpVwcVcDF0cX5yYvX1y8eO9IMNyQUCc3YS4jMk6ePnzx+Qi1kjQJqnsyTZ/YVeY2msBtD",
+	"Q9sfOcaiuGgaJeiol96Y20smtqpD1uF+CeRcQHsz1eNeVw1OprSFWOeZRwW+Pryrakzmv49lOm9dhR9s",
+	"AK2d5kebTU3myccG7eUqz9HaJYedJLvF2KtNyfxpzCGYjoZbbe7vrDRKEHBkfvDYvCWvuIlP/NOTfWZ+",
+	"aXnleLtYW5M5MZVjrkfK3XwjrbZjBgP51gluIN86/jtSDy7GaYXnpydPwknzig3quvT45Ohf2oGybryR",
+	"87MFPnYSZwrkKkRVNi5B71sNv60UfvYXZPFegd4B/ECsw7zWk+tNHgV6dHAm8j030kDZu6REMq0ZrICX",
+	"hNV2u83+4LZE92eLmIKx3uzn7YIEEdHPDxSgndUpsdnPxQpKng2qqZVc8Qy9iveH9kvTES/IcaazqSpQ",
+	"6yByUJbhMo3N5M5/T6y+fnc/S2qpTSwCh+DAmU8B9P5xwEgXu8YO2Xvh/YfM1p9xlGHn7WjvhLOmloKl",
+	"RAB9+MGVdv0YQy32OmpkSK1lyu3NR9ui9Vw8DbuwXtvMjR8X366DUQ3ej9Te089Re5Cfn26Pnwi8LdeO",
+	"S+6C585VuUG/n7PoxY4tSO6+uUPoDsgwnzY8h/czB6GOPpEBvXfbWaKJFcXa99pHpBZrWxfrbf3wXLqW",
+	"Pk64DSTdFN7BHlTBW7tOCK8z636aoTgfZuGfx8t8OyEq18wtPXNS9PzLb6JNhkrjo5vfnPi4fWxDviMV",
+	"vhVzZ/3o/enx2awX8bP3lGf2AvXMge5QZDAUpDM0vTLbv0yYRnD0OvjH2/+tQgygGlgMoOleJcY3sHBk",
+	"xEb03vIh5IeIZuS2SAxTO+/5y8Hp3dUHORobkNwUqgcmIsYF5DYE2wKNqKYYAJFxHv+rQ+8LmYf7vzuW",
+	"27917Dr+qiIZ+1+vLmxRh1WI9nD6wHC5jsfefERpnyviNt05DETtqlfyPW5ceGBcXmDK9qhf7lNW7QYK",
+	"CZrJosCDkMZ/bMQZGg/T2+L4/ZD+5SibhVkoBvoBH+ePZy46PbP/J+jH8J+Icr5C4Y/+0FgMipv+YuTx",
+	"MF9kUw920PLQEqzOj9mhGjy37j27tl+D6DmeQ2dlj8SF2nkDLkDp89OdrtDM2aT5tGEbFpcZUDkaHYls",
+	"7+utvQnRQrwzCj7LY3uYp/bn+TTxIsBD9N63pYG8IukdCymmMCu5O+7Swc6Yce9eROxGg4Wt5AFlNn+M",
+	"IuUYBbDuTkbyBTd049ZHhI/+xgPXLNy4uJ8lPz959peQ0F37+Jqi9KvAUE+Jvk1fiF5N3IAJ8qPX2mDl",
+	"JcgFmSclyJWfoFOSLmQN2tUkArPY2tdAjMSlK1zZZb+OQ55iY7wYfv/4mZ7znw3mHeW9f7Sz31WUF1sR",
+	"tN+TQwC0K4TSUxvoS590VwVE8wTeHliI1Cu62nVrJZD152DUb0tXe87GY8J0tMxh6bxwn4k12qJHJbUO",
+	"o4/zdv4+0BdTxJtXs77ffWqj9/4C1uZO9bLkVjl1+fHf393PPvVT3fYFaRVnN2PKzOaajy/Pu8tzLqX8",
+	"yS3mfn509KmQ2twfQc2PVk9t0Nv/t0LiQ9E6GJ6HSSlTKO3rzeW/ktoMkL+f8z6a/3Tp+N7lRfdoc92W",
+	"D+9a3owRoxc/ZwcqEJCHPHtXYWXNww/u3/phxo7TdVrylJ0pqAv9Y6fDLeMjkRxrlroqQD9Xl8a3acYw",
+	"tXV0urx+L8LjrNv9u/v/DwAA//9cMj2TAVoAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/v1/api.yaml
+++ b/api/v1/api.yaml
@@ -609,7 +609,7 @@ components:
 
     RunStatus:
       type: integer
-      enum: [0, 1, 2, 3, 4]
+      enum: [0, 1, 2, 3, 4, 6]
       description: |
         Numeric status code indicating current run state:
         0: "Not started"
@@ -617,6 +617,7 @@ components:
         2: "Failed"
         3: "Cancelled"
         4: "Success"
+        6: "Partial Success"
 
     RunStatusText:
       type: string
@@ -627,6 +628,7 @@ components:
         - "failed"
         - "cancelled"
         - "finished"
+        - "partial success"
 
     NodeStatus:
       type: integer

--- a/api/v2/api.gen.go
+++ b/api/v2/api.gen.go
@@ -68,22 +68,24 @@ const (
 
 // Defines values for Status.
 const (
-	StatusCancelled  Status = 3
-	StatusFailed     Status = 2
-	StatusNotStarted Status = 0
-	StatusQueued     Status = 5
-	StatusRunning    Status = 1
-	StatusSuccess    Status = 4
+	StatusCancelled      Status = 3
+	StatusFailed         Status = 2
+	StatusNotStarted     Status = 0
+	StatusPartialSuccess Status = 6
+	StatusQueued         Status = 5
+	StatusRunning        Status = 1
+	StatusSuccess        Status = 4
 )
 
 // Defines values for StatusLabel.
 const (
-	StatusLabelCancelled  StatusLabel = "cancelled"
-	StatusLabelFailed     StatusLabel = "failed"
-	StatusLabelFinished   StatusLabel = "finished"
-	StatusLabelNotStarted StatusLabel = "not started"
-	StatusLabelQueued     StatusLabel = "queued"
-	StatusLabelRunning    StatusLabel = "running"
+	StatusLabelCancelled      StatusLabel = "cancelled"
+	StatusLabelFailed         StatusLabel = "failed"
+	StatusLabelFinished       StatusLabel = "finished"
+	StatusLabelNotStarted     StatusLabel = "not started"
+	StatusLabelPartialSuccess StatusLabel = "partial success"
+	StatusLabelQueued         StatusLabel = "queued"
+	StatusLabelRunning        StatusLabel = "running"
 )
 
 // Defines values for Stream.
@@ -284,6 +286,7 @@ type DAGRunDetails struct {
 	// 3: "Cancelled"
 	// 4: "Success"
 	// 5: "Queued"
+	// 6: "Partial Success"
 	Status Status `json:"status"`
 
 	// StatusLabel Human-readable status description for the DAG-run
@@ -335,6 +338,7 @@ type DAGRunSummary struct {
 	// 3: "Cancelled"
 	// 4: "Success"
 	// 5: "Queued"
+	// 6: "Partial Success"
 	Status Status `json:"status"`
 
 	// StatusLabel Human-readable status description for the DAG-run
@@ -546,6 +550,7 @@ type SearchResultItem struct {
 // 3: "Cancelled"
 // 4: "Success"
 // 5: "Queued"
+// 6: "Partial Success"
 type Status int
 
 // StatusLabel Human-readable status description for the DAG-run
@@ -5176,114 +5181,115 @@ func (sh *strictHandler) GetMetrics(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+w9aVPkOLJ/RVGzEbMvXtEUfczuEDEfGOiDF3Q3D3rexOzAI1R2VpW2bcktyQU1BP99",
-	"Q5ct2/JRXA0E3ygsp9KpvJVSXo4ilmaMApVitH05yjDHKUjg+tfezvt3JIFPOAX1MwYRcZJJwuhoeyQX",
-	"gChOAbEZUn/v7bxHM5LAaDwi6nmG5WI0HlH98mjm4IxHHL7lhEM82pY8h/FIRAtIsZrgbxxmo+3RD5sl",
-	"Upvmqdj0cbm6GivcwnjVcAqjQ2+Iio/GUU734yYe+3seFhs8p4hx9GOCJQj5I5IMzUHqxykTEnGIgEo3",
-	"NIx0jOdmrhsgbgD4mB8D5tHibvD/lgNfBT/g2ggPWvR2GvYuvFxlapyQnNC5mRdL+EJSeMdZ2pxZSMwl",
-	"irEESVJAM8aVFEhQrztUBCIU7R9/Rv/8abKlhqRYonMiF0i98xej0EKwGWepmn4wwX6j5ELhKiROswr2",
-	"X1gTd6DxXWEu2Q3x/gA4IFSf8nQKXK10QigIxYYcZM4pUqTSyz+FOaFUfYPlB18p1bBcqEl8HFNCSZqn",
-	"o+2tseMEQiXMgWukDkhKZBOrj/hCvYVoG3Yt0ycaXGV+A2m0vTWZTCbjPnw+z2YCAggdEAoOG8mQ4VEO",
-	"OFZk0ZT6+9bGFAuI/6sFNWYgr0GbQzwPCGaG5+DRhUhINV1mIKMF+nsMM5wnEhGBttpQUSAqiNiXNCJ9",
-	"SAEP41VHKQOONK4+Sq8mY5TiC43dZNKKn50jiOIbtYj+ovaifAQpk/CJxT1qjutxiKqBYcR4CSmI2yhh",
-	"EU5G44DOO5ZY5iKo7WQuWjRtbXozdrAKsFOa2SHr1/NCQhZW8sK9v56iP5YccEDF/74AuTCSZJWNkDHL",
-	"pTKIQsbAOUrYXLSSQUMdTgY9XOHzBZPkWipQ6fV+5ScV+MECfuVGaq7YXZAkNgY5oA5B4hhLrE0KRpEa",
-	"6/FKxlkGXBIw/OV8gsGuwNh4qQHuPCy8V5RhISBWxFFUqKCgTNr/HH/+ZM1ZkP9LtvnT91rsxKfFK2z6",
-	"b4ikwmmX0ZgYPBpocYjcUyQXWKI0FxJNAQksiZgRiNEUZowD4rkxXVhzt2KwNrpF7fO9vcg4CKFmYxxF",
-	"C4i+KkLAEie5Mcq1Dx6PgHPGA5DUv1EKQijVSAxLld9CBKJMohRkEOZFBpGEOIigfoI4CKVqWR2wRVWN",
-	"DgBOsYwWIbiFoFaAnWNRRXHKWAKYNha6JGlogVUs0ZhxVy2ainwiRmdknnONtPolMdErGcOMUIMIprFC",
-	"RMtGUw6MVj5sYe09a5WKAA0pEoGoMbNaI7UkIoOIaMbChVOOIg6tNK3MVp/8Q55iuqH8BzxNAHkPPUvw",
-	"o0BZzjMmQH/oFBZ4SRgPTTbnLM8CXgubkwgnSD+2DhwHFXFo2RVanzA+x5T8pT8EJ25KEZqGBk2Im6UZ",
-	"JzYAtOmZAyI005aLoYAJI9sRpkq0SwVUuNKa/hA7PU2Ei0+VBxIwSQVGmHO8GlkNHOcJtKNkRyjqQaEG",
-	"hOVCOkfnC6AlRmLB8kStVT9unTbLoRVAWeJ5BwXVU72sEZYwZ5z8pbUfjauhiFiDSjWh1kzQIs97oGxg",
-	"UNrUA8N2NdEm1EiakaMHJsMJXjWnVXGVmkJoK6QdhnNMpDM5OjgwNqe0NXXzf88KAuiynWeALglnNAUq",
-	"0RJzoqbUXyWg+Ci4gChvfNVwQbsnDbXANE6Af6Z9EvahGKjeIkIegQSqZtjDK9HlJMZ45XxETChS7zKu",
-	"P8L6rM2lTth8jwS8gT3CIZKMr5Byt/W3amB0rmBpV1OE7fXFTiTJEowPJ4YE0BGjUc65l1MSCCcJOw/o",
-	"qOYXFDOqSOIe5gtbmt8o+ZYDIrFaqRkBrknmcqXnRC4IRUQKw06PwgBlnisrQu6Qe1b1c9NSMnGpyjA1",
-	"ymeomSld7KdhGkWYOQt81WPtuGtlpnX48KXsjjEhe2y2+h0Jra3bdDA5SSVLNkPRaabxfEC0WYRFHSQx",
-	"zxHQiOVUAocYxbkmhMnQfMtByLUEbNa636IIgCpJeRfcN4CaJH0ZnvfH1cd5mmJuuDIXGdC4L75S8xOB",
-	"ytG94ZW3BaRWoIamP3FB+A5eCBPpU3hDykb62yMOc7jQgbyUwNUb//8n3vhrZ+Nfk42fzzZO//tvIXru",
-	"7bx/z0m8LyGQHVJPdBJRy8aSiBwnRjScorPOCHPWd9XgSPf/BvDjSr7N5gRizWjTlc7BD5X5TywGl2Jr",
-	"sh3tpabNtnWnSuzuivucluUbtHS3smpHOfV8fJwkn2ej7T/XE4jW2KCpaQr7blS3tfCFxXvRWHfKYhBd",
-	"q05oTJYkznFShVnLvg5lgNDSM7qLaQTJ0PcZfXthNkGGjX6HSZJzGP7CcR5FIAZ/T49LUrhK/rBW78Tf",
-	"7rxN/6QuJ3rdm+JxOu5hNjbzHChCoyTXWzrV/KaBHpa9ls3qTlfVchlc4DRL9L6VVtzXFEgnWU3n0frf",
-	"gU+9layxcvPEAuKdwIbZ0btd9OrVq5+1StWbkMYd9PnBvR+0uGweSkfLhctAuwCpK081qOagPSg4yqne",
-	"yM3asuBD8996CqBySG2DGdnMHIRh9Wv+fnjfcsivv4jnWCADIQSbMzboq9W4LhxLOP1f3AdLq6Drf7B9",
-	"vQWy3eQbsi/nxh/gab+xOPaG1pVfjTg1qo/9/RbrT5Q7iR5YnzIV4TbSGPI93oZ3Od4DBU4i480jDiJj",
-	"VACy7zU3XuJeadUT7VoDFbdlGXdiYy5wYqd2IwOo2z2YgK+wYFza992gPjctMlvCbngrqXaDm9BmU0jB",
-	"0O5JhKULeBSUIixSFoPmqfb8GZ+SOAbF31Mcn5WBEWXybMZyGus9SmVLcHLmXs8pzuVCBZqaf9Wbcyzh",
-	"HK/0xm7KJJwpW1e8gBMOOF6d2V00C7/85Z7DBRHSt7+lTHzwM3KN5IaXB1b2EZZKV9kknk7jtlusaJCT",
-	"5SJzGOBiubGzYQ6WGy6GuVdm+FWANT4ATuTiyIpJQCtVBajwJBb6PbsfCTTOGKFN8RItlQefl8Bxkjgo",
-	"1UIEAXwJPseZUSvNRO7v0HIXirPDHdGwXazVgJBn+klTLs1r5rGXfg/mD5fARTCx7pCwAxrf2y3nhd50",
-	"8At0/S8Pib/ymr/g+XqLnBBhUu5JopNFjbW9/3RKd0YrN16vxfWaSSv7dkfG4oBFONkzSafrZKJcCHu9",
-	"hNT5giSAMs6U1Dta6sqftbO//VkCH+6gVEEn2ebBHZhgxF3kWEKFEhKoDINyD4N7M+Ij49CZBeOAMAeU",
-	"qtDRVOPgJSYJnvqOfpEPG4+IeCskSbHsBqthIb2EiAiEKQL3WgiqGr2rBvcXC5lKId8d9LSQZBInB2pc",
-	"YBNRPWsUONpMRDO48QvaaiUWmt6h9Q6XvJW5EEzr6ZBGhqW5+Cow5kDbJaYSOguEhWAR0al1U+a6IKKo",
-	"NBuUBPAqowIiFLMBa2VN9CxPkJohAZO0mGnvNAPjcJndg9A6rlPMo8k40zmGkBD0xMxtwYeB2hEvc5B8",
-	"1UsHPQphKSHNpEApjsEKfLkozc/vDpg6Ub5xsFTNsq4RMJUv2qBJvR0D591pBSExjTGPbQDgBLGNSv7n",
-	"xCyXA4GzXGa5XAs6ZIMdzKrHogFa7AoadMR6LbGhx2C+0LXpnbZ61095qkND627Wgx63ZayiED0Gtk/o",
-	"ZBudjD4x6bjpZHRCt9T/jkwgon6/VL/fabFTP1+pnyYNa//zWv3HZkLV7zf691eSZeZ56etOxlvjl+NX",
-	"49fjN6cNcRiPLjbUuI0l5nqLWBH5E5PHBaMfFdHRO6cFCkRGY4eC+stMPjqtkKxg7s6CEEs+vy7EGW5b",
-	"v+wcd1rSTa1igVyhokwcpf/0FIxwyAWY8RDPCcWucKVmH8wChmvE3ep6Nezh3X+4aIGgnvS+nnFYthTP",
-	"c1gSloteENpyKxgBFpY1y53pYa1QjiBiPB4Ah9uBvTa/AnZcIXkFc4+QHlFCEnukjeAhS0i0GhKna91u",
-	"jIlXdVTlBJ19WOJknfopeQ5Aa1YqSFljtbt9PmOAiqoDBZVAjNQn2AA/uMPaIM5xayGEe1KraJuVVcZ+",
-	"eVktdCsqJgIE54x6JRW6LN5N5XYI+sIBD35oxc0htb2d9+IjltEivBNr4ySzcyD0G0jXClf8RK8it/GV",
-	"yqsNVQvJaKGrnIxb3hoyqOfGe+k+knOuIweLGlaOncmAtfgyB0GstAo3KOmiDIXWhewXR/2NFVz9adqJ",
-	"f6RrtcOU3/f8ckN3W9ld7ItjGxRetxLD1HyLzkX3yAoCnasfRW5xUFlMgMmuFQWnjmHWCIRNSYT7zOAy",
-	"3MxH8TYE7thN+V+9v/J9vBQzt3ZSbslB8TZA1/NRGk6K3XcK+SjH1mFuFSuJxVf/LIHewM6AzxhPhVJ3",
-	"plg4Qkq8XKVyR2CMeVdiDPN5nirZUMYuw0IUB2lYmuKqRPVmjaI0/p3IxU5wxl0T3xaQkYHj7W1XcLGl",
-	"cCHl61BrTPErFiV4r5xOGQWWy3KCcE11BjTuqdLzqy91UUHkvqooK7DBUriooJeENyi+PldIFf5FzMIl",
-	"unGo3vd3xr/qIyxF3a/e9ChKqx3UH4XHF4HqX5J8pi1bb97ROgE0RqBGI8qk4mVs0h6MllmKsBu0fgGu",
-	"nz2qCnkDfxP8NoH/ny09NwdJ9ClbV0FiiWLfXKOu1zvAVhe8tU6w3UahbkGm263T5TXfvQtQxc+/0qo2",
-	"4J4H7qGQDCkyYRE4fthMVmhgIXdZ/e38vUrCzKoQrXjNqLbajrYkjq7mLMroI5xJs9FRTeisk7nphdjG",
-	"jkOLcMvjsc4Q1tM0p17NnoUe+IDqWf+Q0F54CbrKzllRgrT10z9evnm1tfXzz96UhMqfXocdYAFRzolc",
-	"qRAotRYwI1/YV5MangLmwN85QCzD3/Li0LRWNXpACXshpd5MnWJBop1c6vszytHqv/XBCg1CZ8ztSeBI",
-	"L6I9jPsHkxh9wCmO8Wg8ynli3xPbm5tzIhf59EXE0s0VkxIv0rhhFEY7h/tFHMBZkrja7JRRYg9p7OF5",
-	"brcOX+gIIAK7t2eReH94sPHqxaQLgRjP8w3G5/qPzWnCppspJnTzYH/37afjty8MapJIXSimZvS2H7dH",
-	"L19MXky0Vs2A4oyMtkev9L90LdlCL4wCrZPx6sc8dL3BkY6Nl1r+EueyJEmZxdepe5bZ4oqyPH26MqrC",
-	"OBo2cVh4TPuxtevunMq4ch9OS91oOaQslekdWblTZI3xX9ig0dWrXQa84V060Kx4fafpV1LXUrHlWLmr",
-	"2Wk9aH+q9I3ZPdZL/HIyqe3T4SxLrPnf/LcwPk8JL1QJ2OGgVZlCLoBw5+7XDuQOMm6NevnOzWGHXVOf",
-	"XjUl2N/3cRQygm4vbFiDSL3VSSEMwoVQRoG6qk1DV1/aRm6bXX+u+depeqcQ5M1LxRRX31uef13ZgrPH",
-	"LNW2CvSOdcCzjD4tGTWE9dIEVksPE9zNS1eT2S7D78Ck3eKO4xF4quPtEovSK68K7XuQ1dMb68pszZ71",
-	"y8q6YnU3IuIdVunn76IsKMjP7umNuPr15PXdc7T5Gn3k3aRrH5w4OfvUYO7aGYW1pWnT1adsXkZl3cit",
-	"i1k9BG4Im1e08oAlbtxekF9Nj5jj7v6S6eKZ8GVRFcKvdWPUswa4JSHcrR1feqSKoJFpujV1sGnPF3Wq",
-	"hKISj/Fardw68n/A5g9U9nvG6tvSBozTF0sOGGfvVhww0twKeT315C3aQ1NPXWKkuOTBqZEDV5/2GDRI",
-	"IantZvoW9YcuFt28dBcj3lSh6CS43l9cR7UcS8ie1csN1EtvosJcHfnQFNEQzO2Fnc9K67EprXZVcJfq",
-	"q6zGzrAM3V6+u8B0bnWY76NV8S7qwrrV2G9ZjCXUNNmxyzc+6jgp159WqYBXtHoIWkCf9vqVxasbBFXr",
-	"V+2Hj9CFY6jqx1+FVddgZTO5e2nfp0uckLg4SnfPKR5XivuAVd1HTHOcJCsnGNgVc5SX+BQZl1vReTHo",
-	"srBWZ2zPPPeu/Sgx0aUbRLgSv2RVXm1QVWAWSHHV0mNJpj6nKdfh3ZJVDBvciC+HBgglN5bOQW9a/zkK",
-	"uG4U8OwfP2T/eJYnSU0ibrxFoI+XaM+GCRk6fAHYVKJROC9shO7tgZgyUcUhIv+IdFUuFf6rB24cbsMb",
-	"9G+N6mt2ZGPj1fD2AHfvIz48rl81vZJrMfmd5ad6TdGjTkqVEdOTSmA9G7lHmwS6iaW78yxPd37nkaR2",
-	"npMoz0mUp5JEuaaaYFm7P/yO8QiUH75CaqByjF1Tpcoh58Dd6VWl8AV4SmihF55e1uRh8UxB7uaCdXLJ",
-	"kFMC1VPfw8qJ7bVewWLi9U2DvspgwNq6foW3V7J/43L9PthSH1wON5ib3+9BgO4K4yYL3Eahse5LEDjn",
-	"dv933WWVe0660PZuRAlEs95tdhWgT7E+uriuzXWu8BSN0KfIh2RdIM3kClV7UWiXtOjgZKWsqk0MkE9w",
-	"bq9GuLZ5uTVPb62bqIedGxzi4m3dAsrttzFQOE9WhdEffCXDE2J3w2hlirB6BUqN5Z1d3RRFY/CgeT0s",
-	"Lx9Q7taGhAvpbv/AEWdCuBMIvuJtCEF56cZNPazG0hhctFFCxXHUkKH6dq91df0XqRrMvX46w65Rfdtp",
-	"UuxyrmNRzCUuoQYV/iUvorzvRM3jaLvGlSve1TJ9h3UcSh03hz5aMbVUDVuiQizlMJ9XyZ53vy3KBcRO",
-	"Lvtk8j3InSTZ23n/xd7iezPLdFeZvNodxU/NHXEhSBsjXLqGSleGDxIIXSt7CDzF1FQHcEiZOWVZ5YCy",
-	"c7RYCSWFzfoBBfymbsqg0Lbo7RTgndfhBmDlGicrZOgQ32dW5mHXBOh7aDBF+tJ771KquqM77LhR33G+",
-	"qmsR2nO5twNGXZx02xZ7DlKabs/eFXTXv/HsZjd+3zCOXL97nIduYu8678C4uCPc3j2DuW77YtuAr9fJ",
-	"sLhaPdRe8a4a2XX0rSs//yk6KMUWkILMYQFUkKWlYKXfYr/J6r/kw6ke20yuckw8mMEdoHr0kn0om/A9",
-	"FgW05nF6r8nv7TQMbYh5s18yifewxC3tEWMscaU9omOUobMX7ReHHub3UHqKAthoKelbnDWkb8jJ/jKm",
-	"6DhrrBQ4ifIE8zW3WXzJ/A6uwfc+8X8bB32fEoe/Bxk+XBu4M2IAnwMtqqv7ErlFmz8XC9ViJExjhONY",
-	"ICLdpXym3Na7FDFged5SV3p9X/uINbNzt4Vzn90u2v5e/cbUMSIzHRplnC1JDLFNQDIK6JwkCZoCmiue",
-	"wC0tF9a/JXHo/YhX169EuMPSQy9FHb6rcL3Kw0cp/1Zc6vI42LBxcBsCLfLuVQzNmh21O1zIIw35e+RA",
-	"bmVnB847umbDuS0/wyn4Yty/U+KBfS7vecqJJCM45Sbn/t4wgVR2e1Al7x87Hw8KK4/d9cV4WGR3rGZ5",
-	"zAHdnSSF7OXGwhBneAbIrVnzol2dbs0gUqD1gnVY2EoFoEHhCadEHGUK7g0WE4Qu7v3IYjIjN5OCooL1",
-	"uwjCrRSZtvKc27S+Nt+d3ru3d6fyWe+c8uRkyjBzseYD7Yy+ofyW4jwNTEV6fslqtWrQk7BGyGduB3+s",
-	"ruJzsPcc7N1vXRKNi6Yc14377CZMhwIw96ILdO733LJtqrhrvGVWpcyaVzcYcBQxrpuSSKaVg1YboF5j",
-	"tADWYZw1koIweixNM9dHaKdLQtdqgswDl7TTHT1kOJhs21hzsO8jknyO6L6w+dxWmoiCMU17qLDMmUbq",
-	"XfsEOafCdWhv7hJoPih7EIRCOdNbvjh/dWe1Q7Ue9tdUofXGFXCRQaSUOtiFqQbQEH113eQrXew9atv6",
-	"G0PvVMUWkegl+CFnqdJpudhQn4olmSa6lYt6W0tgvQlEQfdg7ddHO28v/SVcyM0swaRG+aJNx+gH9OHt",
-	"wSGK8Tw/Uwxhpp/mJKmUkpzQH9CXPw7fegPnOJ/DCS3+cWmbSPxyMtp6sfX6xeRkNNZwzpRy/eVk9HLy",
-	"8vXGZGtjsvVl6+X2ZLI9mfzrZDSeszP/zZdbJ6MrtHWipyxxM23xz1yLR93yURAauVb7xiOsoll7x0e4",
-	"9ujVT5NJfcYYz8+UiTkrLm85c8deygbI5cUu3pEY9beootIBzEerY9ibVvzMXSJnpv1nvQ24Q0c5YXpg",
-	"C14VIEGUKiP+2YpNDxrTlZWpFjzM67ZUpo6Cfnhp3v/lZCRcW7sr9PL1z696RmuR17z1pmdkVDbQu0L/",
-	"CHxpx1c2v0uEier+/bqxsIXPU6z970GPiAjHdNU5m+/7Uzefbp2EnNuGvi2VWKG5VHgMF9I59g9yr7KJ",
-	"tqfNS7WrNLrXhkg7e2UDoj9PlTvn9RLS/1A+m9E+xjmsORdKke4c7pfG1PTsuTTfdrW9uXm5YEJebeKM",
-	"bC5fjsajpe1YprX5ovCSLUlN7ZL+d50aH5iQlR5bds6rcaVIzgHS/Y7Kdon2p24mpOlwWlCoGWA6u2TM",
-	"FqZ47hoZmda0VgVWq5dtGb92VZonAWpA7Y2XCpJXJ6MrVNQ0CZsLr9aojP+rE5napeZkx9qAewa2bn/1",
-	"MTP3XU2PyM5g/YAm/BvaegveY8yr06v/BAAA///kSNx9BbAAAA==",
+	"H4sIAAAAAAAC/+w9aVPkOLJ/RVGzEbMvXtEUfe0OEfOBgT54QXez0PMmZgceobKzqrRtS25JLqgh+O8v",
+	"dNmyLR/FNUDwjcJyKp3KW6nU5ShiacYoUClG25ejDHOcggSuf+3tfHhPEviMU1A/YxARJ5kkjI62R3IB",
+	"iOIUEJsh9ffezgc0IwmMxiOinmdYLkbjEdUvj2YOznjE4XtOOMSjbclzGI9EtIAUqwn+xmE22h79sFki",
+	"tWmeik0fl6urscItjFcNpzA69Iao+Ggc5XQ/buKxv+dhscFzihhHPyZYgpA/IsnQHKR+nDIhEYcIqHRD",
+	"w0jHeG7mugHiBoCP+TFgHi3uBv/vOfBV8AOujfCgRW+nYe/Cy1WmxgnJCZ2bebGErySF95ylzZmFxFyi",
+	"GEuQJAU0Y1xJgQT1ukNFIELR/vEX9M+3ky01JMUSnRO5QOqdPxmFFoLNOEvV9IMJ9islFwpXIXGaVbD/",
+	"ypq4A43vCnPJboj3R8ABofqcp1PgaqUTQkEoNuQgc06RIpVe/inMCaXqGyw/+EqphuVCTeLjmBJK0jwd",
+	"bW+NHScQKmEOXCN1QFIim1h9whfqLUTbsGuZPtHgKvMbSKPtrclkMhn34fNlNhMQQOiAUHDYSIYMj3LA",
+	"sSKLptTftzamWED8Xy2oMQN5Ddoc4nlAMDM8B48uREKq6TIDGS3Q32OY4TyRiAi01YaKAlFBxL6kEelD",
+	"CngYrzpKGXCkcfVRejUZoxRfaOwmk1b87BxBFN+oRfQXtRflI0iZhM8s7lFzXI9DVA0MI8ZLSEHcRgmL",
+	"cDIaB3TescQyF0FtJ3PRomlr05uxg1WAndLMDlm/nhcSsrCSF+799RT9seSAAyr+twXIhZEkq2yEjFku",
+	"lUEUMgbOUcLmopUMGupwMujhCp+vmCTXUoFKr/crP6nADxbwKzdSc8XugiSxMcgBdQgSx1hibVIwitRY",
+	"j1cyzjLgkoDhL+cTDHYFxsZLDXDnYeG9ogwLAbEijqJCBQVl0v7n+Mtna86C/F+yzR++12InPi1eYdP/",
+	"QCQVTruMxsTg0UCLQ+SeIrnAEqW5kGgKSGBJxIxAjKYwYxwQz43pwpq7FYO10S1qn+/dRcZBCDUb4yha",
+	"QPRNEQKWOMmNUa598HgEnDMegKT+jVIQQqlGYliq/BYiEGUSpSCDMC8yiCTEQQT1E8RBKFXL6oAtqmp0",
+	"AHCKZbQIwS0EtQLsHIsqilPGEsC0sdAlSUMLrGKJxoy7atFU5BMxOiPznGuk1S+JiV7JGGaEGkQwjRUi",
+	"WjaacmC08mELa+9Zq1QEaEiRCESNmdUaqSURGUREMxYunHIUcWilaWW2+uQf8xTTDeU/4GkCyHvoWYIf",
+	"BcpynjEB+kOnsMBLwnhosjlneRbwWticRDhB+rF14DioiEPLrtD6hPE5puRP/SE4cVOK0DQ0aELcLM04",
+	"sQGgTc8cEKGZtlwMBUwY2Y4wVaJdKqDCldb0h9jpaSJcfKo8kIBJKjDCnOPVyGrgOE+gHSU7QlEPCjUg",
+	"LBfSOTpfAC0xEguWJ2qt+nHrtFkOrQDKEs87KKie6mWNsIQ54+RPrf1oXA1FxBpUqgm1ZoIWed4DZQOD",
+	"0qYeGLariTahRtKMHD0wGU7wqjmtiqvUFEJbIe0wnGMincnRwYGxOaWtqZv/e1YQQJftPAN0STijKVCJ",
+	"lpgTNaX+KgHFR8EFRHnjq4YL2j1pqAWmcQL8C+2TsI/FQPUWEfIIJFA1wx5eiS4nMcYr5yNiQpF6l3H9",
+	"EdZnbS51wuZ7JOAN7BEOkWR8hZS7rb9VA6NzBUu7miJsry92IkmWYHw4MSSAjhiNcs69nJJAOEnYeUBH",
+	"Nb+gmFFFEvcwX9jS/ErJ9xwQidVKzQhwTTKXKz0nckEoIlIYdnoUBijzXFkRcofcs6qfm5aSiUtVhqlR",
+	"PkPNTOliPw3TKMLMWeCrHmvHXSszrcOHL2V3jAnZY7PV70lobd2mg8lJKlmyGYpOM43nA6LNIizqIIl5",
+	"joBGLKcSOMQozjUhTIbmew5CriVgs9b9FkUAVEnKu+C+AdQk6cvwvD+uPs7TFHPDlbnIgMZ98ZWanwhU",
+	"ju4Nr7wtILUCNTT9iQvCd/BCmEifwxtSNtLfHnGYw4UO5KUErt74vz/wxp87G/+ebPx0tnH6338L0XNv",
+	"58MHTuJ9CYHskHqik4haNpZE5DgxouEUnXVGmLO+qwZHuv83gB9X8m02JxBrRpuudA5+qMx/ZjG4FFuT",
+	"7WgvNW22rTtVYndX3Oe0LN+gpbuVVTvKqefj4yT5Mhtt/7GeQLTGBk1NU9h3o7qthS8s3ovGulMWg+ha",
+	"dUJjsiRxjpMqzFr2dSgDhJae0V1MI0iGvs/ouwuzCTJs9HtMkpzD8BeO8ygCMfh7elySwlXyh7V6J/52",
+	"5236J3U50eveFI/TcQ+zsZnnQBEaJbne0qnmNw30sOy1bFZ3uqqWy+ACp1mi96204r6mQDrJajqP1v8O",
+	"fOqtZI2VmycWEO8ENsyO3u+iV69e/aRVqt6ENO6gzw/u/aDFZfNQOlouXAbaBUhdeapBNQftQcFRTvVG",
+	"btaWBR+a/9ZTAJVDahvMyGbmIAyrX/P3w/ueQ379RTzHAhkIIdicsUFfrcZ14VjC6f/iPlhaBV3/g+3r",
+	"LZDtJt+QfTk3/gBP+43FsTe0rvxqxKlRfezvt1h/otxJ9MD6lKkIt5HGkO/xLrzL8QEocBIZbx5xEBmj",
+	"ApB9r7nxEvdKq55o1xqouC3LuBMbc4ETO7UbGUDd7sEEfIUF49K+7wb1uWmR2RJ2w1tJtRvchDabQgqG",
+	"dk8iLF3Ao6AUYZGyGDRPtefP+JTEMSj+nuL4rAyMKJNnM5bTWO9RKluCkzP3ek5xLhcq0NT8q96cYwnn",
+	"eKU3dlMm4UzZuuIFnHDA8erM7qJZ+OUv9xwuiJC+/S1l4qOfkWskN7w8sLKPsFS6yibxdBq33WJFg5ws",
+	"F5nDABfLjZ0Nc7DccDHMvTLDrwKs8RFwIhdHVkwCWqkqQIUnsdDv2f1IoHHGCG2Kl2ipPPiyBI6TxEGp",
+	"FiII4EvwOc6MWmkmcn+HlrtQnB3uiIbtYq0GhDzTT5pyaV4zj730ezB/uAQugol1h4Qd0Pjebjkv9KaD",
+	"X6Drf3lI/JXX/BXP11vkhAiTck8SnSxqrO39p1O6M1q58XotrtdMWtm3OzIWByzCyZ5JOl0nE+VC2Osl",
+	"pM4XJAGUcaak3tFSV/6snf3tzxL4cAelCjrJNg/uwAQj7iLHEiqUkEBlGJR7GNybEZ8Yh84sGAeEOaBU",
+	"hY6mGgcvMUnw1Hf0i3zYeETEOyFJimU3WA0L6SVERCBMEbjXQlDV6F01uL9YyFQK+e6gp4Ukkzg5UOMC",
+	"m4jqWaPA0WYimsGNX9BWK7HQ9A6td7jkrcyFYFpPhzQyLM3FV4ExB9ouMZXQWSAsBIuITq2bMtcFEUWl",
+	"2aAkgFcZFRChmA1YK2uiZ3mC1AwJmKTFTHunGRiHy+wehNZxnWIeTcaZzjGEhKAnZm4LPgzUjniZg+Sr",
+	"XjroUQhLCWkmBUpxDFbgy0Vpfn53wNSJ8o2DpWqWdY2AqXzRBk3q7Rg4704rCIlpjHlsAwAniG1U8j8n",
+	"ZrkcCJzlMsvlWtAhG+xgVj0WDdBiV9CgI9ZriQ09BvOFrk3vtNW7fs5THRpad7Me9LgtYxWF6DGwfUIn",
+	"2+hk9JlJx00noxO6pf53ZAIR9ful+v1ei536+Ur9NGlY+5/X6j82E6p+v9G/v5EsM89LX3cy3hq/HL8a",
+	"vx6/OW2Iw3h0saHGbSwx11vEisifmTwuGP2oiI7eOy1QIDIaOxTUX2by0WmFZAVzdxaEWPL5dSHOcNv6",
+	"Zee405JuahUL5AoVZeIo/aenYIRDLsCMh3hOKHaFKzX7YBYwXCPuVterYQ/v/sNFCwT1pPf1jMOypXie",
+	"w5KwXPSC0JZbwQiwsKxZ7kwPa4VyBBHj8QA43A7stfkVsOMKySuYe4T0iBKS2CNtBA9ZQqLVkDhd63Zj",
+	"TLyqoyon6OzDEifr1E/JcwBas1JByhqr3e3zGQNUVB0oqARipD7BBvjBHdYGcY5bCyHck1pF26ysMvbL",
+	"y2qhW1ExESA4Z9QrqdBl8W4qt0PQFw548EMrbg6p7e18EJ+wjBbhnVgbJ5mdA6HfQLpWuOInehW5ja9U",
+	"Xm2oWkhGC13lZNzy1pBBPTfeS/eRnHMdOVjUsHLsTAasxZc5CGKlVbhBSRdlKLQuZL846m+s4OpP0078",
+	"I12rHab8vueXG7rbyu5iXxzboPC6lRim5lt0LrpHVhDoXP0ocouDymICTHatKDh1DLNGIGxKItxnBpfh",
+	"Zj6KtyFwx27Kv/T+ivr5Vv08xFwSnCBvWNB7Gb+9U//lX27Xx+LjnpwWpL2xL+Ptla7nzjT8mWKLKrPE",
+	"c1nbkINzbL3tVpmUWHzzDyLo3e8M+IzxVChdaSqNI6Rk05U5d0TVmHdl1TCf56kSLGUpMyxEcQqHpSmu",
+	"imNvyilK49+IXOwEZ9w1wXEBGRk43sZ4BRdbRxfS3A61xhS/YFGC92rxlEVhuSwnCBdkZ0DjnhI/v3RT",
+	"VyRE7quKmgQbaYUrEnpJeIPK7XOFVOGcxCxc3xuHioV/Y/ybPv9SFA3rHZOiLttB/VF4fBEoHSbJF9qy",
+	"b+edyxNAYwRqNKJMKl7GJmfCaJniCPtQ61fv+qmnqtg38DeRcxP4/9q6dXMKRR/RdeUnlij2zTWKgr3T",
+	"b3XBW+v4221U+RZkut0iX15z/LsAVYKEK618A759oImFZEiRCYvA2cVmpkMDC/na6m/nLFaybVaFaMVr",
+	"RrUVhrRlgHQpaFGDH+FMml2SajZonbRPL8Q2dhxawVuerXWmsZ7jOfUK/iz0wAdUGwWEhPbCy+5Vtt2K",
+	"+qWtt/94+ebV1tZPP3lTEirfvg57zwKinBO5UvFTai1gRr6ybyavPAXMgb93gFiGv+fFiWutavSAEvZC",
+	"Sr0TO8WCRDu51M03ytHqv/XBCg1CZ8xtaOBIL6I9yfs7kxh9xCmO8Wg8ynli3xPbm5tzIhf59EXE0s0V",
+	"kxIv0rhhFEY7h/tFEMFZkrjC7pRRYk947OF5bvcdX+jwIQK7MWiR+HB4sPHqxaQLgRjP8w3G5/qPzWnC",
+	"ppspJnTzYH/33efjdy8MapJIXWWmZvT2LrdHL19MXky0Vs2A4oyMtkev9L90IdpCL4wCrTP56sc81Bvh",
+	"SAfWSy1/iXNZkqTcAtB5f5bZyoyytn26MqrCOBo261h4TPuxtevukMu40kynpei0HFLW2fSOrDQkWWP8",
+	"VzZodLUvzIA3vI4FzXLZ95p+JXUtFVvOpLuCn9ZT+qdK35itZ73ELyeT2iYfzrLEmv/N/wjj85TwQmWE",
+	"HQ5alSnkAgh3AUDtNO8g49Yotu/cWXbYNfXpVVOC/U0jRyEj6LbbwxpE6i1tCmEQrqIyCtSVfBq6+tI2",
+	"cnv0+nPNv07VO4Ugb14qprj6q+X5l5WtVnvMUm1LSO9YBzzL6NOSUUNYL01gtfQwwd28dAWd7TL8HkzO",
+	"Lu44W4GnOt4usSi98qrQfgBZPfqxrszW7Fm/rKwrVncjIt5Jl37+LmqKgvzsnt6Iq19PXt89R5uv0efl",
+	"Ta73wYmTs08N5q4dcFhbmjZdccvmZVQWndy6mNVD4IaweRUvD1jixu3V/NX0iDkr7y+ZrrwJd5qqEH6t",
+	"dlPPGuCWhHC3dvbpkSqCRqbp1tTBpj2c1KkSijI+xmuFduvI/wGbP1DZ7xmrW60NGKe7Ug4YZxszDhhp",
+	"WkpeTz15i/bQ1FOXGCkueXBq5MAVtz0GDVJIaruZvkX9oStNNy9dV8WbKhSdBNf7i+uolmMJ2bN6uYF6",
+	"6U1UmL6TD00RDcHcdvt8VlqPTWm1q4K7VF9lKXeGZaj1+e4C07nVYb6PVsW7KCrrVmO/ZjGWUNNkxy7f",
+	"+KjjpFx/WqV8XtHqIWgBfVTsFxavbhBUrV/yHz5/F46hqh9/FVZdg5XN5O6lfZ8ucULi4hzePad4XB3v",
+	"A1Z1nzDNcZKsnGBgV8xRdgAqMi63ovNi0IVirc7Ynnnu9QwpMdGlG0S4+sBkVfZFqCowC6To0/RYkqnP",
+	"acp1eLdkFcMGN+LLoQFCyY2lc9Cb1n+OAq4bBTz7xw/ZP57lSVKTiBtvEeizKdqzYUKGTm4ANpVoFM4L",
+	"G6EvBkFMmajiBJJ/vroqlwr/1QM3DrfhDfotp/puSrKx8Wr43QJ37yM+PK5fNb2SazH5neWnek3Ro05K",
+	"lRHTk0pgPRu5R5sEuomlu/MsT3d+55Gkdp6TKM9JlKeSRLmmmmBZuz/8nvEIlB++QmqgcozdjUyVE9KB",
+	"xutVpfAVeEpooReeXtbkYfFMQe7mgnVyyZBTAtUj48PKiW1PsGAx8fqmQfdBGLC27rLD2yvZv3G5fh9s",
+	"qU89h2+nm9/vQYDuCuMmC9xGobG+1CBwzu3+G+VllSYpXWh77VQC0azXCq8C9CnWRxe93ty1F56iMefK",
+	"h2RdIM3kClUvstAuaXH9k5WyqjYxQD7Due2rcG3zcmue3lptrIedGxzi4m3dAsrtrRwonCerwugP7ufw",
+	"hNjdMFqZIqz2T6mxvLOrm6K4VTxoXg/L5gPK3dqQcCFd6xAccSaEO4HgK96GEJQdO27qYTWWxuCijRIq",
+	"jqOGDNX3e62r6+/CajD3LuMZ1oP1XadJscu5jkUxHWBCt1v4HWJE2SxFzeNou0a/Fq8vTd9hHYdSR9vR",
+	"RyumlqphS1SIpRzm8yrZ85rjolxA7OSyTyY/gNxJkr2dD19tC+CbWaa7yuTVGhw/NXfEhSBtjHDpbmO6",
+	"MnyQQKgn7SHwFFNTHcAhZeaUZZUDymunxUooKWzWDyjgN3VTBoW2xcVQAd55Hb49rFzjZIUMHeL7zMo8",
+	"7JoA3YcGU6Q75nsdreqO7rDjRn3H+aquRWjP5d4OGHVx0m1b7DlIaa6K9vrXXb9d2s3ahd8wjlz/6jkP",
+	"3cQ2Su/AuGgwbnvPYK7vjLF3iK93DWLRlz10N+Nd3YLXceld+flP0UEptoAUZA4LoIIsLQUrlzX2m6z+",
+	"Jh9O9dib6CrHxIMZ3AGqRy/Zx/IGv8eigNY8Tu/dEHw7t402xLx52TKJ97DELXcrxljiyt2KjlGGzl7c",
+	"3Tj0ML+H0lMUwMZ9lL7FWUP6hpzsL2OKjrPGuslhlCeYr7nN4kvmX+Aa/NUn/m/joO9T4vAPIMOHawM9",
+	"IwbwOdCiurovkVvcEehioVqMhGmMcBwLRKRrymfKbb2miAHL84660uv72kesmZ27LZz74nbR9vfqPVTH",
+	"iMx0aJRxtiQxxDYBySigc5IkaAporngCt9zXsH6XxKH9Ea+uX4lwh6WHXoo63KtwvcrDRyn/Vlzq8jjY",
+	"sHFwGwIt8u5VDM2a13F3uJBHGvJfkQO5lZ0dOO+4chvObfkZTsEX4/6dEg/sc3nPU04kGcEpNzn394YJ",
+	"pLLbgyp5f9/5dFBYeezaF+Nhkd2xmuUxB3R3khSyzY2FIc7wDJBbs2ajXZ1uzSBSoPWCdVjYSgWgQeEJ",
+	"p0QcZQruDRYThBr3fmIxmZGbSUFRwfqXCMKtFJm28pzbtL42353eu7d3p/JZv3blycmUYeZizQfaGd2h",
+	"/JbiPA1MRXp+yWq1atCTsEbIZ7qDP1ZX8TnYew727rcuicbFpRzXjfvsJkyHAjB90QU69y/ssndccXdr",
+	"l1mVMmte3WDAUcS4vpREMq0ctNoA9RqjBbAO46yRFITRY2lugn2EdrokdK0myDxwSTt9o4cMB5NtG2sO",
+	"9n1Eks8R3Vc2n9tKE1EwprlbKixz5hb2rn2CnFPhrndv7hJoPijvIAiFcuZi+uL81Z3VDtUuwL+mCq1f",
+	"XAEXGURKqYNdmGoADdE3dxV95Qp8j9q2/sbQO1WxRSR6CX7IWap0Wi421KdiSaaJvspFva0lsH4JREH3",
+	"YO3XJztvL/0lXMjNLMGkRvnimo7RD+jju4NDFON5fqYYwkw/zUlSKSU5oT+gr78fvvMGznE+hxNa/OPS",
+	"XiLx88lo68XW6xeTk9FYwzlTyvXnk9HLycvXG5OtjcnW162X25PJ9mTy75PReM7O/Ddfbp2MrtDWiZ6y",
+	"xM3cqX/m7ofU90UKQiN3T7/xCKto1t7xEa49evV2MqnPGOP5mTIxZ0XzljN37KW8Pbls7OIdiVF/iyoq",
+	"HcB8tDqGvWnFz/QSOTN3h9bvEHfoKCdMD2zBqwIkiFJlxD9bselBY7qyMtWCh3ndlsrUUdAPL837P5+M",
+	"hLvs7gq9fP3Tq57RWuQ1b73pGRmVt+9doX8EvrTjK5vfJcJEdf9+3VjYwucp1v63oEdEhGO66pzN9/2p",
+	"m0+3TkLObUPflkqs0FwqPIYL6Rz7B7lX2UTb0+al2lUa3buGSDt75QVEf5wqd867S0j/Q/lsRvsY57Dm",
+	"XChFunO4XxpTc2fPpfm2q+3NzcsFE/JqE2dkc/lyNB4t7Y1lWpsvCi/ZktTULul/16nxkQlZuWPLznk1",
+	"rhTJOUD6vqPyAkX7U18mpOlwWlCoGWA6u2TMFqZ47i4yMvfaWhVYrV62ZfzaVWmeBKgBtR0vFSSvTkZX",
+	"qKhpEjYXXq1RGf9XJzK1S83JjrUB9wxs3f7qY2buu5oekZ3B+gFN+De09Ra8x5hXp1f/HwAA//93q5Un",
+	"QrAAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/v2/api.yaml
+++ b/api/v2/api.yaml
@@ -1481,7 +1481,7 @@ components:
 
     Status:
       type: integer
-      enum: [0, 1, 2, 3, 4, 5]
+      enum: [0, 1, 2, 3, 4, 5, 6]
       x-enum-varnames:
         - "NotStarted"
         - "Running"
@@ -1489,6 +1489,7 @@ components:
         - "Cancelled"
         - "Success"
         - "Queued"
+        - "PartialSuccess"
       description: |
         Numeric status code indicating current DAG-run state:
         0: "Not started"
@@ -1497,6 +1498,7 @@ components:
         3: "Cancelled"
         4: "Success"
         5: "Queued"
+        6: "Partial Success"
 
     StatusLabel:
       type: string
@@ -1508,6 +1510,7 @@ components:
         - "cancelled"
         - "finished"
         - "queued"
+        - "partial success"
 
     NodeStatus:
       type: integer

--- a/internal/agent/reporter.go
+++ b/internal/agent/reporter.go
@@ -71,7 +71,7 @@ func (r *reporter) send(ctx context.Context, dag *digraph.DAG, status models.DAG
 			attachments := addAttachments(dag.ErrorMail.AttachLogs, status.Nodes)
 			return r.senderFn(ctx, fromAddress, toAddresses, subject, html, attachments)
 		}
-	} else if status.Status == scheduler.StatusSuccess {
+	} else if status.Status == scheduler.StatusSuccess || status.Status == scheduler.StatusPartialSuccess {
 		if dag.MailOn != nil && dag.MailOn.Success && dag.InfoMail != nil {
 			fromAddress := dag.InfoMail.From
 			toAddresses := []string{dag.InfoMail.To}
@@ -194,6 +194,7 @@ func renderHTML(nodes []*models.Node) string {
         .status-failed { color: #dc2626; font-weight: 500; }
         .status-running { color: #2563eb; font-weight: 500; }
         .status-skipped { color: #6b7280; font-weight: 500; }
+        .status-partial-success { color: #ea580c; font-weight: 500; }
         .row-number { 
             background-color: #f1f5f9; 
             font-weight: 600; 
@@ -250,6 +251,8 @@ func renderHTML(nodes []*models.Node) string {
 			statusClass = "status-running"
 		case "skipped":
 			statusClass = "status-skipped"
+		case "partial success":
+			statusClass = "status-partial-success"
 		}
 		_, _ = buffer.WriteString(fmt.Sprintf("<td class=\"%s\">%s</td>", statusClass, status))
 

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -174,6 +174,8 @@ func displayDetailedStatus(dag *digraph.DAG, status *models.DAGRunStatus) {
 			color.RedString("✗"), status.DAGRunID, dag.Name)
 	case scheduler.StatusSuccess:
 		fmt.Printf("%s The DAG completed successfully.\n", color.GreenString("✓"))
+	case scheduler.StatusPartialSuccess:
+		fmt.Printf("%s The DAG completed with partial success.\n", color.YellowString("⚠"))
 	case scheduler.StatusCancel:
 		fmt.Printf("%s The DAG was cancelled.\n", color.YellowString("⚠"))
 	case scheduler.StatusQueued:
@@ -429,6 +431,8 @@ func formatStatus(status scheduler.Status) string {
 		return color.GreenString("Success")
 	case scheduler.StatusError:
 		return color.RedString("Failed")
+	case scheduler.StatusPartialSuccess:
+		return color.YellowString("Partial Success")
 	case scheduler.StatusRunning:
 		return color.New(color.FgHiGreen).Sprint("Running")
 	case scheduler.StatusCancel:

--- a/internal/digraph/scheduler/scheduler.go
+++ b/internal/digraph/scheduler/scheduler.go
@@ -283,7 +283,12 @@ func (sc *Scheduler) Schedule(ctx context.Context, graph *ExecutionGraph, progre
 								node.SetStatus(NodeStatusSuccess)
 							} else {
 								node.MarkError(execErr)
-								sc.setLastError(execErr)
+								// Only set lastError if this failure should not be allowed to continue
+								// If shouldContinue() is true, this error is allowed and should contribute
+								// to partial success rather than overall failure
+								if !node.shouldContinue(ctx) {
+									sc.setLastError(execErr)
+								}
 							}
 						}
 					}

--- a/internal/digraph/scheduler/scheduler_test.go
+++ b/internal/digraph/scheduler/scheduler_test.go
@@ -1287,7 +1287,7 @@ func (gh graphHelper) Schedule(t *testing.T, expectedStatus scheduler.Status) sc
 	close(progressCh)
 
 	switch expectedStatus {
-	case scheduler.StatusSuccess, scheduler.StatusCancel:
+	case scheduler.StatusSuccess, scheduler.StatusCancel, scheduler.StatusPartialSuccess:
 		require.NoError(t, err)
 
 	case scheduler.StatusError:

--- a/internal/digraph/scheduler/scheduler_test.go
+++ b/internal/digraph/scheduler/scheduler_test.go
@@ -144,7 +144,7 @@ func TestScheduler(t *testing.T) {
 			successStep("3", "2"),
 		)
 
-		result := graph.Schedule(t, scheduler.StatusSuccess)
+		result := graph.Schedule(t, scheduler.StatusPartialSuccess)
 
 		result.AssertNodeStatus(t, "1", scheduler.NodeStatusSuccess)
 		result.AssertNodeStatus(t, "2", scheduler.NodeStatusSkipped)

--- a/internal/digraph/scheduler/scheduler_test.go
+++ b/internal/digraph/scheduler/scheduler_test.go
@@ -144,7 +144,7 @@ func TestScheduler(t *testing.T) {
 			successStep("3", "2"),
 		)
 
-		result := graph.Schedule(t, scheduler.StatusPartialSuccess)
+		result := graph.Schedule(t, scheduler.StatusSuccess)
 
 		result.AssertNodeStatus(t, "1", scheduler.NodeStatusSuccess)
 		result.AssertNodeStatus(t, "2", scheduler.NodeStatusSkipped)

--- a/internal/digraph/scheduler/scheduler_test.go
+++ b/internal/digraph/scheduler/scheduler_test.go
@@ -117,7 +117,7 @@ func TestScheduler(t *testing.T) {
 			successStep("3", "2"),
 		)
 
-		result := graph.Schedule(t, scheduler.StatusError)
+		result := graph.Schedule(t, scheduler.StatusPartialSuccess)
 
 		// 1, 2, 3 should be executed even though 2 failed
 		result.AssertNodeStatus(t, "1", scheduler.NodeStatusSuccess)
@@ -164,7 +164,7 @@ func TestScheduler(t *testing.T) {
 			successStep("2", "1"),
 		)
 
-		result := graph.Schedule(t, scheduler.StatusError)
+		result := graph.Schedule(t, scheduler.StatusPartialSuccess)
 
 		// 1, 2 should be executed even though 1 failed
 		result.AssertNodeStatus(t, "1", scheduler.NodeStatusError)
@@ -186,7 +186,7 @@ func TestScheduler(t *testing.T) {
 			successStep("2", "1"),
 		)
 
-		result := graph.Schedule(t, scheduler.StatusError)
+		result := graph.Schedule(t, scheduler.StatusPartialSuccess)
 
 		// 1, 2 should be executed even though 1 failed
 		result.AssertNodeStatus(t, "1", scheduler.NodeStatusError)
@@ -208,7 +208,7 @@ func TestScheduler(t *testing.T) {
 			successStep("2", "1"),
 		)
 
-		result := graph.Schedule(t, scheduler.StatusError)
+		result := graph.Schedule(t, scheduler.StatusPartialSuccess)
 
 		// 1, 2 should be
 		result.AssertNodeStatus(t, "1", scheduler.NodeStatusError)
@@ -230,7 +230,7 @@ func TestScheduler(t *testing.T) {
 			successStep("2", "1"),
 		)
 
-		result := graph.Schedule(t, scheduler.StatusError)
+		result := graph.Schedule(t, scheduler.StatusPartialSuccess)
 
 		// 1, 2 should be executed even though 1 failed
 		result.AssertNodeStatus(t, "1", scheduler.NodeStatusError)

--- a/internal/integration/parallel_test.go
+++ b/internal/integration/parallel_test.go
@@ -759,7 +759,8 @@ steps:
 	dag := th.DAG(t, filepath.Join("integration", "test-parallel-both.yaml"))
 	agent := dag.Agent()
 	err = agent.Run(agent.Context)
-	require.Error(t, err, "DAG should still fail overall")
+	// DAG should complete successfully due to continueOn.failure: true, even after retries fail
+	require.NoError(t, err)
 
 	// Get status
 	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
@@ -846,8 +847,8 @@ steps:
 	dag := th.DAG(t, filepath.Join("integration", "test-parallel-output-failures.yaml"))
 	agent := dag.Agent()
 	err = agent.Run(agent.Context)
-	// Should fail because one child fails
-	require.Error(t, err)
+	// Should complete successfully due to continueOn.failure: true, despite one child failing
+	require.NoError(t, err)
 
 	// Get the latest status
 	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
@@ -1024,8 +1025,8 @@ steps:
 	dag := th.DAG(t, filepath.Join("integration", "test-parallel-output-exclusion.yaml"))
 	agent := dag.Agent()
 	err = agent.Run(agent.Context)
-	// Should fail because some children failed
-	require.Error(t, err)
+	// Should complete successfully due to continueOn.failure: true, despite some children failing
+	require.NoError(t, err)
 
 	// Get the latest status
 	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
@@ -1511,8 +1512,9 @@ steps:
 
 	agent := dag.Agent()
 	err = agent.Run(agent.Context)
-	// Should fail because api-service deployment fails, but continueOn.failure allows completion
-	require.Error(t, err)
+	// The DAG should complete successfully despite failures due to continueOn.failure = true
+	// but the individual steps may still show as failed
+	require.NoError(t, err)
 
 	// Get the latest status to verify parallel execution
 	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -175,6 +175,8 @@ func (c *Collector) collectDAGRunMetrics(ch chan<- prometheus.Metric) {
 			statusLabel = "success"
 		case scheduler.StatusError:
 			statusLabel = "error"
+		case scheduler.StatusPartialSuccess:
+			statusLabel = "partial_success"
 		case scheduler.StatusCancel:
 			statusLabel = "cancelled"
 		case scheduler.StatusRunning:

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -377,65 +377,16 @@ func (a *Agent) RunSuccess(t *testing.T) {
 	assert.NoError(t, err, "failed to run agent")
 
 	status := a.Status().Status
-
-	// Accept both StatusSuccess and StatusPartialSuccess as valid success outcomes
-	// StatusSuccess: All steps succeeded, no skipped steps
-	// StatusPartialSuccess: Some steps skipped with continueOn.skipped=true OR some steps failed with continueOn.failure=true
-	if status != scheduler.StatusSuccess && status != scheduler.StatusPartialSuccess {
-		require.Fail(t, "expected success or partial success", "expected status %q or %q, got %q", scheduler.StatusSuccess, scheduler.StatusPartialSuccess, status)
-	}
+	require.Equal(t, scheduler.StatusSuccess.String(), status.String(), "expected status %q, got %q", scheduler.StatusSuccess, status)
 
 	// check all nodes are in success or skipped state
 	for _, node := range a.Status().Nodes {
-		nodeStatus := node.Status
-		if nodeStatus == scheduler.NodeStatusSkipped || nodeStatus == scheduler.NodeStatusSuccess {
+		status := node.Status
+		if status == scheduler.NodeStatusSkipped || status == scheduler.NodeStatusSuccess {
 			continue
 		}
-		t.Errorf("expected node %q to be in success state, got %q", node.Step.Name, nodeStatus.String())
+		t.Errorf("expected node %q to be in success state, got %q", node.Step.Name, status.String())
 	}
-}
-
-func (a *Agent) RunPartialSuccess(t *testing.T) {
-	t.Helper()
-
-	err := a.Run(a.Context)
-	assert.NoError(t, err, "failed to run agent")
-
-	status := a.Status().Status
-	require.Equal(t, scheduler.StatusPartialSuccess.String(), status.String(), "expected status %q, got %q", scheduler.StatusPartialSuccess, status)
-
-	// check that there's a mix of success/skipped nodes and some failures or skips with continueOn
-	hasSuccessOrSkipped := false
-	hasFailuresOrSkipsWithContinue := false
-
-	for _, node := range a.Status().Nodes {
-		switch node.Status {
-		case scheduler.NodeStatusSuccess, scheduler.NodeStatusSkipped:
-			hasSuccessOrSkipped = true
-		case scheduler.NodeStatusError:
-			hasFailuresOrSkipsWithContinue = true
-		case scheduler.NodeStatusNone, scheduler.NodeStatusRunning, scheduler.NodeStatusCancel:
-			// These statuses don't contribute to partial success determination, we only
-			// need this case statement to satisfy linter asking for exhaustive switchcase.
-			// NodeStatusNone: node hasn't started
-			// NodeStatusRunning: node is still executing
-			// NodeStatusCancel: node was cancelled
-		}
-	}
-
-	require.True(t, hasSuccessOrSkipped, "partial success should have at least one successful or skipped node")
-	require.True(t, hasFailuresOrSkipsWithContinue || hasSkippedWithContinue(a), "partial success should have failures with continueOn or skipped nodes with continueOn")
-}
-
-func hasSkippedWithContinue(a *Agent) bool {
-	for _, node := range a.Status().Nodes {
-		if node.Status == scheduler.NodeStatusSkipped {
-			// This is a simplified check - in reality we'd need to check the DAG definition
-			// but for test purposes, we assume skipped nodes have continueOn.skipped = true
-			return true
-		}
-	}
-	return false
 }
 
 func (a *Agent) Abort() {

--- a/ui/src/api/v2/schema.ts
+++ b/ui/src/api/v2/schema.ts
@@ -2230,7 +2230,8 @@ export enum Status {
     Failed = 2,
     Cancelled = 3,
     Success = 4,
-    Queued = 5
+    Queued = 5,
+    PartialSuccess = 6
 }
 export enum StatusLabel {
     not_started = "not started",

--- a/ui/src/consts.ts
+++ b/ui/src/consts.ts
@@ -10,6 +10,7 @@ export const statusColorMapping: statusColorMapping = {
   [Status.Failed]: { backgroundColor: 'red', color: 'white' },
   [Status.Cancelled]: { backgroundColor: 'pink' },
   [Status.Success]: { backgroundColor: 'green', color: 'white' },
+  [Status.PartialSuccess]: { backgroundColor: '#f59e0b', color: 'white' },
 };
 
 export const nodeStatusColorMapping = {

--- a/ui/src/pages/dag-runs/index.tsx
+++ b/ui/src/pages/dag-runs/index.tsx
@@ -258,6 +258,10 @@ function DAGRuns() {
                   <StatusChip status={Status.Queued} size="sm">
                     queued
                   </StatusChip>
+                ) : status === String(Status.PartialSuccess) ? (
+                  <StatusChip status={Status.PartialSuccess} size="sm">
+                    partial success
+                  </StatusChip>
                 ) : null}
               </SelectValue>
             </SelectTrigger>
@@ -295,6 +299,11 @@ function DAGRuns() {
               <SelectItem value={String(Status.Queued)}>
                 <StatusChip status={Status.Queued} size="sm">
                   queued
+                </StatusChip>
+              </SelectItem>
+              <SelectItem value={String(Status.PartialSuccess)}>
+                <StatusChip status={Status.PartialSuccess} size="sm">
+                  partial success
                 </StatusChip>
               </SelectItem>
             </SelectContent>

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -42,6 +42,7 @@ const initializeMetrics = (): Metrics => {
     Status.Cancelled,
     Status.Queued,
     Status.NotStarted, // Include NotStarted if relevant
+    Status.PartialSuccess,
   ];
   relevantStatuses.forEach((status: Status) => {
     initialMetrics[status] = 0;
@@ -180,6 +181,11 @@ function Dashboard(): React.ReactElement | null {
       title: 'Success',
       value: metrics[Status.Success],
       icon: <CheckCircle className="h-5 w-5 text-[green]" />,
+    },
+    {
+      title: 'Partial Success',
+      value: metrics[Status.PartialSuccess],
+      icon: <CheckCircle className="h-5 w-5 text-[#f59e0b]" />,
     },
     {
       title: 'Failed',

--- a/ui/src/ui/StatusChip.tsx
+++ b/ui/src/ui/StatusChip.tsx
@@ -47,6 +47,11 @@ function StatusChip({ status, children, size = 'md' }: Props) {
       borderColorClass = 'border-[plum] dark:border-[mediumpurple]';
       textColorClass = 'text-[purple] dark:text-[plum]';
       break;
+    case Status.PartialSuccess: // partial success -> orange/amber
+      bgColorClass = 'bg-[rgba(251,146,60,0.1)] dark:bg-[rgba(245,158,11,0.2)]';
+      borderColorClass = 'border-[orange] dark:border-[#d97706]';
+      textColorClass = 'text-[#ea580c] dark:text-[#f59e0b]';
+      break;
     default: // Fallback to gray for any other status (including undefined)
       bgColorClass =
         'bg-[rgba(128,128,128,0.1)] dark:bg-[rgba(169,169,169,0.2)]';


### PR DESCRIPTION
## What does this PR do?
It implements a new `StatusPartialSuccess` enum value for DAG executions to handle scenarios where some nodes failed but were allowed to continue via continueOn.failure settings. The status indicates that primary work was completed despite some non-critical failures.

## Why is this needed?
Addresses issue #1009 . Previously, DAG runs would show as `Failed` even when critical steps succeeded and only optional/non-critical steps failed with `continueOn.failure: true`. This made it difficult to distinguish between complete failures and successful runs with minor issues, reducing visibility into workflow health and success metrics.

## What changed?
* Added `StatusPartialSuccess = 6` to scheduler `Status` enum with "partial success" string representation
* Implemented `isPartialSuccess()` method in scheduler to detect when DAG has both successful/skipped nodes AND error nodes that were allowed to continue
* Final status Detection: Updated main [Status()](vscode-file://vscode-app/c:/Users/Armand/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) method to check for PartialSuccess before returning StatusError, fixing the evaluation order
* Event Handlers: Updated event handler logic to treat PartialSuccess as success (triggers onSuccess handlers)
* API Schema: Updated v2 API YAML to include PartialSuccess status
* In the UI added `PartialSuccess` status chip component with orange styling
* DAG Runs UI: Added `PartialSuccess` option to status filter dropdown in `pages/dag-runs/index.tsx`
* Dashboard Metrics: Updated dashboard to include `PartialSuccess` count with orange CheckCircle icon

## How was this tested?
* Created test DAG with failing step that has continueOn.failure: true followed by successful steps
```yaml
name: Test Partial Success
description: Testing PartialSuccess status with continueOn.failure
steps:
  - name: step1
    command: echo "Step 1 successful"
    
  - name: step2_fail_but_continue
    command: exit 1
    continueOn:
      failure: true
    depends:
      - step1
      
  - name: step3
    command: echo "Step 3 successful despite step2 failure"
    depends:
      - step2_fail_but_continue
```

## Screenshots

![image](https://github.com/user-attachments/assets/421fdf22-c162-4d88-bd2c-aec02a7fdb1d)
