### PR TITLE
[#1003,#999] fix(ui): set remote node properly

### DIFF
--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -108,6 +108,7 @@ func NewContext(cmd *cobra.Command, flags []commandLineFlag) (*Context, error) {
 	// Initialize history repository and history manager
 	hrOpts := []filedagrun.DAGRunStoreOption{
 		filedagrun.WithLatestStatusToday(cfg.Server.LatestStatusToday),
+		filedagrun.WithLocation(cfg.Global.Location),
 	}
 
 	switch cmd.Name() {

--- a/internal/frontend/api/v2/remote.go
+++ b/internal/frontend/api/v2/remote.go
@@ -157,7 +157,6 @@ func (h *remoteNodeProxy) proxy(r *http.Request) (*http.Response, error) {
 			}
 		}
 	}
-
 	// forward the request to the remote node
 	return h.doRequest(body, r, h.remoteNode)
 }
@@ -215,6 +214,10 @@ func (h *remoteNodeProxy) doRequest(body any, r *http.Request, node config.Remot
 
 	// Set the Accept-Encoding header to handle gzip and deflate responses
 	req.Header.Set("Accept-Encoding", "gzip, deflate")
+	// Add application/json content type
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	// Create a custom transport that skips certificate verification
 	transport := &http.Transport{

--- a/ui/index.html
+++ b/ui/index.html
@@ -8,7 +8,7 @@
     <title>Dagu</title>
     <script>
       // Apply theme immediately to prevent flash
-      (function() {
+      (function () {
         try {
           const saved = localStorage.getItem('user_preferences');
           const preferences = saved ? JSON.parse(saved) : { theme: 'dark' };
@@ -20,7 +20,7 @@
           document.documentElement.classList.add('dark');
         }
       })();
-      
+
       function getConfig() {
         return {
           apiURL: 'http://localhost:8080/api/v2',
@@ -31,7 +31,7 @@
           tz: '',
           tzOffsetInSec: undefined,
           maxDashboardPageLimit: '',
-          remoteNodes: 'local,dev1',
+          remoteNodes: 'local,dev,dev1',
           permissions: {
             writeDags: true,
             runDags: true,

--- a/ui/src/components/ui/date-range-picker.tsx
+++ b/ui/src/components/ui/date-range-picker.tsx
@@ -99,8 +99,6 @@ function CustomDateTimeInput({
     // Format: YYYY-MM-DD HH:mm:ss
     // Positions: 0-4 (year), 5-7 (month), 8-10 (day), 11-13 (hour), 14-16 (minute), 17-19 (second)
 
-    console.log('Cursor position:', pos);
-
     if (pos <= 4) {
       date.setFullYear(date.getFullYear() + increment);
     } else if (pos <= 7) {

--- a/ui/src/features/dags/components/common/LiveSwitch.tsx
+++ b/ui/src/features/dags/components/common/LiveSwitch.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { components } from '../../../../api/v2/schema';
 import { useConfig } from '../../../../contexts/ConfigContext';
 import { useClient } from '../../../../hooks/api';
+import { AppBarContext } from '@/contexts/AppBarContext';
 
 /**
  * Props for the LiveSwitch component
@@ -33,6 +34,9 @@ function LiveSwitch({ dag, refresh, 'aria-label': ariaLabel }: Props) {
   // Initialize state based on DAG suspension state
   const [checked, setChecked] = React.useState(!dag.suspended);
 
+  const appBarContext = React.useContext(AppBarContext);
+  const remoteNode = appBarContext.selectedRemoteNode || 'local';
+
   /**
    * Submit the suspension state change to the API
    */
@@ -42,6 +46,9 @@ function LiveSwitch({ dag, refresh, 'aria-label': ariaLabel }: Props) {
         params: {
           path: {
             fileName: dag.fileName,
+          },
+          query: {
+            remoteNode,
           },
         },
         body: {
@@ -56,7 +63,7 @@ function LiveSwitch({ dag, refresh, 'aria-label': ariaLabel }: Props) {
         refresh();
       }
     },
-    [client, dag.fileName, refresh]
+    [client, dag.fileName, refresh, remoteNode] // Include remoteNode in dependencies
   );
 
   /**
@@ -76,7 +83,9 @@ function LiveSwitch({ dag, refresh, 'aria-label': ariaLabel }: Props) {
   return (
     <Switch
       checked={checked}
-      onCheckedChange={config.permissions.runDags ? handleCheckedChange : undefined}
+      onCheckedChange={
+        config.permissions.runDags ? handleCheckedChange : undefined
+      }
       disabled={!config.permissions.runDags}
       aria-label={ariaLabel} // Pass aria-label directly
       // Add custom styling for better visibility in both states

--- a/ui/src/features/dags/components/dag-editor/DAGEditButtons.tsx
+++ b/ui/src/features/dags/components/dag-editor/DAGEditButtons.tsx
@@ -53,9 +53,9 @@ function DAGEditButtons({ fileName }: Props) {
               path: {
                 fileName: fileName,
               },
-            },
-            query: {
-              remoteNode: appBarContext.selectedRemoteNode || 'local',
+              query: {
+                remoteNode: appBarContext.selectedRemoteNode || 'local',
+              },
             },
             body: {
               newFileName: newFileName,


### PR DESCRIPTION
## Summary
- Fixed an issue where the remote node was not being set properly in the UI
- Fixed timezone handling issue where DAGs running at midnight in non-UTC timezones would incorrectly show as "Not Started" when `latestStatusToday` is enabled.

## Root Cause
- When `latestStatusToday: true` is set, the system was using UTC time to determine "today" instead of the configured timezone. This caused DAGs that run at 00:00 in timezones like Europe/Paris (which is 22:00 UTC the previous day) to be considered as having run "yesterday" in UTC terms.

## Changes
- Modified `internal/frontend/api/v2/remote.go` to fix node handling
- Fixed LiveSwitch component to properly handle node changes
- Added timezone location field to filedagrun Store
- Added WithLocation option to configure timezone when creating the store
- Updated LatestAttempt to calculate "today" using the configured timezone

Issue: #1003 #999 