### PR TITLE
fix: HTTP executor output not written to stdout

### DIFF
--- a/internal/digraph/executor/http.go
+++ b/internal/digraph/executor/http.go
@@ -19,6 +19,7 @@ var _ Executor = (*http)(nil)
 
 type http struct {
 	stdout    io.Writer
+	stderr    io.Writer
 	req       *resty.Request
 	reqCancel context.CancelFunc
 	url       string
@@ -79,6 +80,7 @@ func newHTTP(ctx context.Context, step digraph.Step) (Executor, error) {
 
 	return &http{
 		stdout:    os.Stdout,
+		stderr:    os.Stderr,
 		req:       req,
 		reqCancel: cancel,
 		method:    method,
@@ -92,7 +94,7 @@ func (e *http) SetStdout(out io.Writer) {
 }
 
 func (e *http) SetStderr(out io.Writer) {
-	e.stdout = out
+	e.stderr = out
 }
 
 func (e *http) Kill(_ os.Signal) error {

--- a/internal/digraph/scheduler/data.go
+++ b/internal/digraph/scheduler/data.go
@@ -64,7 +64,6 @@ type NodeState struct {
 	OutputVariables *executor.SyncMap
 }
 
-
 // Parallel represents the evaluated parallel execution configuration for a node.
 // It contains the expanded list of items to be processed in parallel.
 type Parallel struct {

--- a/internal/digraph/scheduler/debug_test.go
+++ b/internal/digraph/scheduler/debug_test.go
@@ -14,74 +14,74 @@ func TestDebugVariables(t *testing.T) {
 	// Create a test context with environment variables
 	ctx := digraph.SetupEnv(context.Background(), &digraph.DAG{}, nil, digraph.DAGRunRef{}, "test-run", "test.log", nil)
 	env := executor.GetEnv(ctx)
-	
+
 	// Store variable with spaces
 	env.Variables.Store("SPACES", "SPACES=  ")
-	
+
 	// IMPORTANT: Update the context with the modified env
 	ctx = executor.WithEnv(ctx, env)
-	
+
 	// Print out what Variables() returns
 	vars := env.Variables.Variables()
 	fmt.Printf("Variables map: %#v\n", vars)
-	
+
 	// Try evaluating directly
 	result, err := scheduler.EvalString(ctx, "${SPACES}")
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
-	
+
 	fmt.Printf("Input: '${SPACES}'\n")
 	fmt.Printf("Result: '%s' (len=%d)\n", result, len(result))
 	fmt.Printf("Result bytes: %v\n", []byte(result))
-	
+
 	// Expected result
 	fmt.Printf("Expected: '  ' (len=2)\n")
 	fmt.Printf("Expected bytes: %v\n", []byte("  "))
-	
+
 	// Let's also check what Envs map has
 	fmt.Printf("\nEnvs map: %#v\n", env.Envs)
-	
+
 	// Let's check what GetEnv returns
 	envFromCtx := executor.GetEnv(ctx)
 	fmt.Printf("\nEnv from context Variables: %#v\n", envFromCtx.Variables.Variables())
-	
+
 	// Test with special characters too
 	env.Variables.Store("SPECIAL", "SPECIAL=$pecial!@#")
-	
+
 	// Update context again after adding new variable
 	ctx = executor.WithEnv(ctx, env)
-	
+
 	vars2 := env.Variables.Variables()
 	fmt.Printf("\nVariables map with special: %#v\n", vars2)
-	
+
 	result2, err := scheduler.EvalString(ctx, "${SPECIAL}")
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
 	fmt.Printf("\nSpecial Input: '${SPECIAL}'\n")
 	fmt.Printf("Special Result: '%s' (len=%d)\n", result2, len(result2))
-	
+
 	// Let's debug the $pecial issue
 	// Try different patterns
 	env.Variables.Store("DOLLAR", "DOLLAR=$")
 	env.Variables.Store("DOLLAR_P", "DOLLAR_P=$p")
 	env.Variables.Store("ESCAPED", "ESCAPED=\\$pecial")
 	ctx = executor.WithEnv(ctx, env)
-	
+
 	r3, _ := scheduler.EvalString(ctx, "${DOLLAR}")
 	r4, _ := scheduler.EvalString(ctx, "${DOLLAR_P}")
 	r5, _ := scheduler.EvalString(ctx, "${ESCAPED}")
-	
+
 	fmt.Printf("\n'${DOLLAR}' -> '%s'\n", r3)
 	fmt.Printf("'${DOLLAR_P}' -> '%s'\n", r4)
 	fmt.Printf("'${ESCAPED}' -> '%s'\n", r5)
-	
+
 	// Test without environment expansion
 	fmt.Printf("\n--- Testing without env expansion ---\n")
 	env.Variables.Store("TEST_DOLLAR", "TEST_DOLLAR=$HOME/test")
 	ctx = executor.WithEnv(ctx, env)
-	
+
 	// This should expand $HOME
 	r6, _ := scheduler.EvalString(ctx, "${TEST_DOLLAR}")
 	fmt.Printf("With env expansion: '${TEST_DOLLAR}' -> '%s'\n", r6)

--- a/internal/digraph/scheduler/graph_test.go
+++ b/internal/digraph/scheduler/graph_test.go
@@ -237,38 +237,38 @@ func TestStepRetryExecutionForSuccessfulStep(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	
+
 	// Test retrying a successful step in the middle
 	graph, err := scheduler.CreateStepRetryGraph(ctx, dag, nodes, "step2")
 	require.NoError(t, err)
 	require.NotNil(t, graph)
-	
+
 	// Only step2 should be reset, others remain unchanged
 	require.Equal(t, scheduler.NodeStatusSuccess, nodes[0].State().Status) // step1 (unchanged)
 	require.Equal(t, scheduler.NodeStatusNone, nodes[1].State().Status)    // step2 (reset)
 	require.Equal(t, scheduler.NodeStatusSuccess, nodes[2].State().Status) // step3 (unchanged)
-	
+
 	// Test retrying the first successful step
 	// Reset nodes to original state
 	nodes[1].SetStatus(scheduler.NodeStatusSuccess)
-	
+
 	graph, err = scheduler.CreateStepRetryGraph(ctx, dag, nodes, "step1")
 	require.NoError(t, err)
 	require.NotNil(t, graph)
-	
+
 	// Only step1 should be reset
 	require.Equal(t, scheduler.NodeStatusNone, nodes[0].State().Status)    // step1 (reset)
 	require.Equal(t, scheduler.NodeStatusSuccess, nodes[1].State().Status) // step2 (unchanged)
 	require.Equal(t, scheduler.NodeStatusSuccess, nodes[2].State().Status) // step3 (unchanged)
-	
+
 	// Test retrying the last successful step
 	// Reset nodes to original state
 	nodes[0].SetStatus(scheduler.NodeStatusSuccess)
-	
+
 	graph, err = scheduler.CreateStepRetryGraph(ctx, dag, nodes, "step3")
 	require.NoError(t, err)
 	require.NotNil(t, graph)
-	
+
 	// Only step3 should be reset
 	require.Equal(t, scheduler.NodeStatusSuccess, nodes[0].State().Status) // step1 (unchanged)
 	require.Equal(t, scheduler.NodeStatusSuccess, nodes[1].State().Status) // step2 (unchanged)

--- a/internal/digraph/scheduler/node.go
+++ b/internal/digraph/scheduler/node.go
@@ -238,10 +238,15 @@ func (n *Node) Execute(ctx context.Context) error {
 
 	n.SetExitCode(exitCode)
 
+	// Flush all output writers to ensure data is written before capturing output
+	// This is especially important for buffered writers
+	_ = n.outputs.flushWriters()
+
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
-	if output := n.Step().Output; output != "" {
+	// Only capture output if the step succeeded
+	if output := n.Step().Output; output != "" && n.Error() == nil {
 		value, err := n.outputs.capturedOutput(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to capture output: %w", err)
@@ -914,7 +919,7 @@ func (oc *OutputCoordinator) setupExecutorIO(ctx context.Context, cmd executor.E
 
 	// Output to both log and stdout
 	if oc.stdoutRedirectWriter != nil {
-		stdout = io.MultiWriter(oc.stdoutWriter, oc.stdoutRedirectWriter)
+		stdout = executor.NewFlushableMultiWriter(oc.stdoutWriter, oc.stdoutRedirectWriter)
 	}
 
 	// Setup output capture only if not already set up
@@ -942,7 +947,7 @@ func (oc *OutputCoordinator) setupExecutorIO(ctx context.Context, cmd executor.E
 	}
 
 	if oc.outputWriter != nil {
-		stdout = io.MultiWriter(stdout, oc.outputWriter)
+		stdout = executor.NewFlushableMultiWriter(stdout, oc.outputWriter)
 	}
 
 	cmd.SetStdout(stdout)
@@ -953,14 +958,14 @@ func (oc *OutputCoordinator) setupExecutorIO(ctx context.Context, cmd executor.E
 		stderr = oc.stderrWriter
 	}
 	if oc.stderrRedirectWriter != nil {
-		stderr = io.MultiWriter(oc.stderrWriter, oc.stderrRedirectWriter)
+		stderr = executor.NewFlushableMultiWriter(oc.stderrWriter, oc.stderrRedirectWriter)
 	}
 	cmd.SetStderr(stderr)
 
 	return nil
 }
 
-func (oc *OutputCoordinator) closeResources(_ context.Context) error {
+func (oc *OutputCoordinator) flushWriters() error {
 	oc.mu.Lock()
 	defer oc.mu.Unlock()
 
@@ -972,6 +977,17 @@ func (oc *OutputCoordinator) closeResources(_ context.Context) error {
 			}
 		}
 	}
+	return lastErr
+}
+
+func (oc *OutputCoordinator) closeResources(_ context.Context) error {
+	// First flush all writers
+	_ = oc.flushWriters()
+
+	oc.mu.Lock()
+	defer oc.mu.Unlock()
+
+	var lastErr error
 
 	// Close the output writer first to signal EOF to any readers
 	if oc.outputWriter != nil {

--- a/internal/digraph/scheduler/node.go
+++ b/internal/digraph/scheduler/node.go
@@ -919,7 +919,7 @@ func (oc *OutputCoordinator) setupExecutorIO(ctx context.Context, cmd executor.E
 
 	// Output to both log and stdout
 	if oc.stdoutRedirectWriter != nil {
-		stdout = executor.NewFlushableMultiWriter(oc.stdoutWriter, oc.stdoutRedirectWriter)
+		stdout = newFlushableMultiWriter(oc.stdoutWriter, oc.stdoutRedirectWriter)
 	}
 
 	// Setup output capture only if not already set up
@@ -947,7 +947,7 @@ func (oc *OutputCoordinator) setupExecutorIO(ctx context.Context, cmd executor.E
 	}
 
 	if oc.outputWriter != nil {
-		stdout = executor.NewFlushableMultiWriter(stdout, oc.outputWriter)
+		stdout = newFlushableMultiWriter(stdout, oc.outputWriter)
 	}
 
 	cmd.SetStdout(stdout)
@@ -958,7 +958,7 @@ func (oc *OutputCoordinator) setupExecutorIO(ctx context.Context, cmd executor.E
 		stderr = oc.stderrWriter
 	}
 	if oc.stderrRedirectWriter != nil {
-		stderr = executor.NewFlushableMultiWriter(oc.stderrWriter, oc.stderrRedirectWriter)
+		stderr = newFlushableMultiWriter(oc.stderrWriter, oc.stderrRedirectWriter)
 	}
 	cmd.SetStderr(stderr)
 

--- a/internal/digraph/scheduler/node.go
+++ b/internal/digraph/scheduler/node.go
@@ -245,8 +245,8 @@ func (n *Node) Execute(ctx context.Context) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
-	// Only capture output if the step succeeded
-	if output := n.Step().Output; output != "" && n.Error() == nil {
+	// Capture output if configured
+	if output := n.Step().Output; output != "" {
 		value, err := n.outputs.capturedOutput(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to capture output: %w", err)

--- a/internal/digraph/scheduler/node_misc_test.go
+++ b/internal/digraph/scheduler/node_misc_test.go
@@ -310,7 +310,7 @@ func TestNodeBuildChildDAGRuns(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := digraph.SetupEnv(context.Background(), &digraph.DAG{}, nil, digraph.DAGRunRef{}, "test-run", "test.log", nil)
-			
+
 			if tt.setupEnv != nil {
 				ctx = tt.setupEnv(ctx)
 			}
@@ -324,7 +324,7 @@ func TestNodeBuildChildDAGRuns(t *testing.T) {
 
 			// Now we can test the public method directly
 			runs, err := node.BuildChildDAGRuns(ctx, tt.childDAG)
-			
+
 			if tt.expectError {
 				assert.Error(t, err)
 				if tt.errorContains != "" {
@@ -415,7 +415,7 @@ func TestNodeItemToParam(t *testing.T) {
 
 			// Now we can test the public method directly
 			result, err := node.ItemToParam(tt.item)
-			
+
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -528,21 +528,21 @@ func TestNodeSetupAndTeardown(t *testing.T) {
 
 func TestNodeInit(t *testing.T) {
 	step := digraph.Step{Name: "test-step"}
-	
+
 	// Create multiple nodes to verify they get different IDs
 	node1 := scheduler.NewNode(step, scheduler.NodeState{})
 	node2 := scheduler.NewNode(step, scheduler.NodeState{})
 
 	// Call Init on first node
 	node1.Init()
-	
+
 	// Call Init multiple times on same node - should be idempotent
 	node1.Init()
 	node1.Init()
-	
+
 	// Call Init on second node
 	node2.Init()
-	
+
 	// While we can't directly access the ID, we can verify that
 	// two different nodes don't interfere with each other
 	// and that multiple Init calls are safe
@@ -631,36 +631,36 @@ func TestNodeOutputCaptureWithLargeOutput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			tempDir := t.TempDir()
-			
+
 			// Create DAG with output size limit
 			dag := &digraph.DAG{
 				MaxOutputSize: tt.maxOutputSize,
 			}
-			
+
 			// Setup environment with DAG
 			ctx = digraph.SetupEnv(ctx, dag, nil, digraph.DAGRunRef{}, "test-run", "test.log", nil)
-			
+
 			step := digraph.Step{
 				Name:    "test-output-capture",
 				Command: tt.command,
 				Args:    tt.args,
 				Output:  "CAPTURED_OUTPUT",
 			}
-			
+
 			node := scheduler.NewNode(step, scheduler.NodeState{})
 			node.Init()
-			
+
 			// Setup node
 			err := node.Setup(ctx, tempDir, "test-run-output")
 			require.NoError(t, err)
-			
+
 			// Execute node
 			err = node.Execute(ctx)
-			
+
 			if tt.expectSuccess {
 				// Execution should succeed
 				assert.NoError(t, err)
-				
+
 				// Check if output was captured
 				nodeData := node.NodeData()
 				if nodeData.State.OutputVariables != nil {
@@ -668,35 +668,35 @@ func TestNodeOutputCaptureWithLargeOutput(t *testing.T) {
 					assert.True(t, ok, "Expected output variable to be captured")
 				}
 			}
-			
+
 			// Verify that MaxOutputSize is respected in the DAG configuration
 			env := executor.GetEnv(ctx)
 			assert.Equal(t, tt.maxOutputSize, env.DAG.MaxOutputSize)
-			
+
 			// Cleanup
 			err = node.Teardown(ctx)
 			assert.NoError(t, err)
 		})
 	}
-	
+
 	// Additional test to verify configuration is respected
 	t.Run("DAG MaxOutputSize configuration", func(t *testing.T) {
 		// Test that different MaxOutputSize values are properly configured
 		sizes := []int{0, 100, 1024, 1024 * 1024}
-		
+
 		for _, size := range sizes {
 			t.Run(fmt.Sprintf("size_%d", size), func(t *testing.T) {
 				ctx := context.Background()
 				dag := &digraph.DAG{
 					MaxOutputSize: size,
 				}
-				
+
 				ctx = digraph.SetupEnv(ctx, dag, nil, digraph.DAGRunRef{}, "test-run", "test.log", nil)
 				env := executor.GetEnv(ctx)
-				
+
 				// Verify the MaxOutputSize is properly set in the environment
 				assert.Equal(t, size, env.DAG.MaxOutputSize)
-				
+
 				// Create a node with output capture
 				step := digraph.Step{
 					Name:    "test-size-config",
@@ -704,10 +704,10 @@ func TestNodeOutputCaptureWithLargeOutput(t *testing.T) {
 					Args:    []string{"test"},
 					Output:  "TEST_VAR",
 				}
-				
+
 				node := scheduler.NewNode(step, scheduler.NodeState{})
 				node.Init()
-				
+
 				// The node should respect the configured MaxOutputSize
 				// This is validated through the DAG configuration
 				assert.NotNil(t, node)
@@ -788,7 +788,7 @@ func TestNodeShouldContinue(t *testing.T) {
 				ctx := context.Background()
 				err := node.Setup(ctx, tempDir, "test-run")
 				require.NoError(t, err)
-				
+
 				// Write test output to stdout file
 				stdoutFile := node.StdoutFile()
 				err = os.WriteFile(stdoutFile, []byte("WARNING: This is just a warning\n"), 0644)
@@ -807,7 +807,7 @@ func TestNodeShouldContinue(t *testing.T) {
 				ctx := context.Background()
 				err := node.Setup(ctx, tempDir, "test-run")
 				require.NoError(t, err)
-				
+
 				// Write test output to stdout file
 				stdoutFile := node.StdoutFile()
 				err = os.WriteFile(stdoutFile, []byte("ERROR: Connection timeout after 30 seconds\n"), 0644)
@@ -836,7 +836,7 @@ func TestNodeShouldContinue(t *testing.T) {
 			// Now we can test the public method directly
 			node.SetStatus(tt.nodeStatus)
 			node.SetExitCode(tt.exitCode)
-			
+
 			result := node.ShouldContinue(ctx)
 			assert.Equal(t, tt.expectContinue, result)
 		})

--- a/internal/digraph/scheduler/writer.go
+++ b/internal/digraph/scheduler/writer.go
@@ -1,0 +1,54 @@
+package scheduler
+
+import (
+	"bufio"
+	"io"
+)
+
+// flushableMultiWriter creates a MultiWriter that can flush all underlying writers
+type flushableMultiWriter struct {
+	writers []io.Writer
+}
+
+// newFlushableMultiWriter creates a new flushableMultiWriter
+func newFlushableMultiWriter(writers ...io.Writer) *flushableMultiWriter {
+	return &flushableMultiWriter{writers: writers}
+}
+
+// Write writes to all underlying writers
+func (fw *flushableMultiWriter) Write(p []byte) (n int, err error) {
+	for _, w := range fw.writers {
+		n, err = w.Write(p)
+		if err != nil {
+			return
+		}
+		if n != len(p) {
+			err = io.ErrShortWrite
+			return
+		}
+	}
+	return len(p), nil
+}
+
+// Flush flushes all underlying writers that support flushing
+func (fw *flushableMultiWriter) Flush() error {
+	var lastErr error
+	for _, w := range fw.writers {
+		// Try different flush interfaces
+		switch v := w.(type) {
+		case *bufio.Writer:
+			if err := v.Flush(); err != nil {
+				lastErr = err
+			}
+		case interface{ Flush() error }:
+			if err := v.Flush(); err != nil {
+				lastErr = err
+			}
+		case interface{ Sync() error }:
+			if err := v.Sync(); err != nil {
+				lastErr = err
+			}
+		}
+	}
+	return lastErr
+}

--- a/internal/digraph/scheduler/writer_test.go
+++ b/internal/digraph/scheduler/writer_test.go
@@ -1,0 +1,284 @@
+package scheduler
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlushableMultiWriter_Write(t *testing.T) {
+	tests := []struct {
+		name    string
+		writers []io.Writer
+		input   []byte
+		wantErr bool
+	}{
+		{
+			name:    "write to single writer",
+			writers: []io.Writer{&bytes.Buffer{}},
+			input:   []byte("hello world"),
+			wantErr: false,
+		},
+		{
+			name:    "write to multiple writers",
+			writers: []io.Writer{&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}},
+			input:   []byte("test data"),
+			wantErr: false,
+		},
+		{
+			name:    "empty write",
+			writers: []io.Writer{&bytes.Buffer{}},
+			input:   []byte{},
+			wantErr: false,
+		},
+		{
+			name:    "write with error",
+			writers: []io.Writer{&errorWriter{err: errors.New("write failed")}},
+			input:   []byte("data"),
+			wantErr: true,
+		},
+		{
+			name:    "write with short write",
+			writers: []io.Writer{&shortWriter{}},
+			input:   []byte("data"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fw := newFlushableMultiWriter(tt.writers...)
+			n, err := fw.Write(tt.input)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, len(tt.input), n)
+
+				// Verify all writers received the data
+				for _, w := range tt.writers {
+					if buf, ok := w.(*bytes.Buffer); ok {
+						assert.Equal(t, string(tt.input), buf.String())
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFlushableMultiWriter_Flush(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func() (*flushableMultiWriter, func())
+		wantErr bool
+	}{
+		{
+			name: "flush buffered writer",
+			setup: func() (*flushableMultiWriter, func()) {
+				var buf bytes.Buffer
+				bw := bufio.NewWriter(&buf)
+				fw := newFlushableMultiWriter(bw)
+				
+				// Write some data that will be buffered
+				_, err := fw.Write([]byte("buffered data"))
+				require.NoError(t, err)
+				
+				return fw, func() {
+					// Check that data was flushed to underlying buffer
+					assert.Equal(t, "buffered data", buf.String())
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "flush multiple writers",
+			setup: func() (*flushableMultiWriter, func()) {
+				var buf1, buf2, buf3 bytes.Buffer
+				bw1 := bufio.NewWriter(&buf1)
+				bw2 := bufio.NewWriter(&buf2)
+				fw := newFlushableMultiWriter(bw1, &buf3, bw2)
+				
+				// Write data
+				_, err := fw.Write([]byte("test"))
+				require.NoError(t, err)
+				
+				return fw, func() {
+					// Both buffered writers should be flushed
+					assert.Equal(t, "test", buf1.String())
+					assert.Equal(t, "test", buf2.String())
+					// Regular buffer gets data immediately
+					assert.Equal(t, "test", buf3.String())
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "flush with flushable interface",
+			setup: func() (*flushableMultiWriter, func()) {
+				f := &flushableWriter{flushed: false}
+				fw := newFlushableMultiWriter(f)
+				return fw, func() {
+					assert.True(t, f.flushed, "flushable writer should be flushed")
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "flush with syncable interface",
+			setup: func() (*flushableMultiWriter, func()) {
+				s := &syncableWriter{synced: false}
+				fw := newFlushableMultiWriter(s)
+				return fw, func() {
+					assert.True(t, s.synced, "syncable writer should be synced")
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "flush with error",
+			setup: func() (*flushableMultiWriter, func()) {
+				f := &flushableWriter{err: errors.New("flush failed")}
+				fw := newFlushableMultiWriter(f)
+				return fw, func() {}
+			},
+			wantErr: true,
+		},
+		{
+			name: "flush with no flushable writers",
+			setup: func() (*flushableMultiWriter, func()) {
+				fw := newFlushableMultiWriter(&bytes.Buffer{})
+				return fw, func() {}
+			},
+			wantErr: false,
+		},
+		{
+			name: "flush with mixed writer types",
+			setup: func() (*flushableMultiWriter, func()) {
+				var buf bytes.Buffer
+				bw := bufio.NewWriter(&buf)
+				f := &flushableWriter{flushed: false}
+				s := &syncableWriter{synced: false}
+				
+				fw := newFlushableMultiWriter(bw, &bytes.Buffer{}, f, s)
+				_, err := fw.Write([]byte("mixed"))
+				require.NoError(t, err)
+				
+				return fw, func() {
+					assert.Equal(t, "mixed", buf.String())
+					assert.True(t, f.flushed)
+					assert.True(t, s.synced)
+				}
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fw, verify := tt.setup()
+			err := fw.Flush()
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			verify()
+		})
+	}
+}
+
+func TestFlushableMultiWriter_Integration(t *testing.T) {
+	// Test the full flow with pipes similar to how it's used in node.go
+	t.Run("pipe with buffered writer", func(t *testing.T) {
+		pr, pw := io.Pipe()
+		defer func() { _ = pr.Close() }()
+		defer func() { _ = pw.Close() }()
+
+		var captured bytes.Buffer
+		done := make(chan struct{})
+
+		// Start reading from pipe
+		go func() {
+			defer close(done)
+			_, _ = io.Copy(&captured, pr)
+		}()
+
+		// Create flushable multi writer with buffered writer
+		var logBuffer bytes.Buffer
+		logWriter := bufio.NewWriter(&logBuffer)
+		fw := newFlushableMultiWriter(pw, logWriter)
+
+		// Write data
+		data := "test data for pipe"
+		n, err := fw.Write([]byte(data))
+		require.NoError(t, err)
+		require.Equal(t, len(data), n)
+
+		// Data should be in pipe but not yet in logBuffer
+		assert.Empty(t, logBuffer.String(), "data should still be buffered")
+
+		// Flush the writer
+		err = fw.Flush()
+		require.NoError(t, err)
+
+		// Now data should be in logBuffer
+		assert.Equal(t, data, logBuffer.String())
+
+		// Close pipe and wait for reader
+		err = pw.Close()
+		require.NoError(t, err)
+		<-done
+
+		// Verify captured data
+		assert.Equal(t, data, captured.String())
+	})
+}
+
+// Helper types for testing
+
+type errorWriter struct {
+	err error
+}
+
+func (e *errorWriter) Write(_ []byte) (n int, err error) {
+	return 0, e.err
+}
+
+type shortWriter struct{}
+
+func (s *shortWriter) Write(p []byte) (n int, err error) {
+	if len(p) > 0 {
+		return len(p) - 1, nil
+	}
+	return 0, nil
+}
+
+type flushableWriter struct {
+	bytes.Buffer
+	flushed bool
+	err     error
+}
+
+func (f *flushableWriter) Flush() error {
+	f.flushed = true
+	return f.err
+}
+
+type syncableWriter struct {
+	bytes.Buffer
+	synced bool
+	err    error
+}
+
+func (s *syncableWriter) Sync() error {
+	s.synced = true
+	return s.err
+}

--- a/internal/frontend/server.go
+++ b/internal/frontend/server.go
@@ -156,16 +156,16 @@ func (srv *Server) setupRoutes(ctx context.Context, r *chi.Mux) {
 	if !strings.HasPrefix(assetsPath, "/") {
 		assetsPath = "/" + assetsPath
 	}
-	
+
 	// Create a file server for the embedded assets
 	fileServer := http.FileServer(http.FS(assetsFS))
-	
+
 	// If there's a base path, we need to strip it from the request URL
 	if srv.config.Server.BasePath != "" && srv.config.Server.BasePath != "/" {
 		stripPrefix := strings.TrimSuffix(srv.config.Server.BasePath, "/")
 		fileServer = http.StripPrefix(stripPrefix, fileServer)
 	}
-	
+
 	r.Get(assetsPath, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "max-age=86400")
 		fileServer.ServeHTTP(w, r)

--- a/internal/integration/http_test.go
+++ b/internal/integration/http_test.go
@@ -30,11 +30,11 @@ func TestHTTPExecutor(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, status)
 
-	// Verify that only successful response is captured in output variable
+	// Verify that all responses are captured in output variables
 	dag.AssertOutputs(t, map[string]any{
 		"RET200": test.NotEmpty{},
-		"RET500": "", // Should be empty because HTTP 500 is an error
-		"RET404": "", // Should be empty because HTTP 404 is an error
+		"RET500": test.NotEmpty{}, // Now captured regardless of status code
+		"RET404": test.NotEmpty{}, // Now captured regardless of status code
 	})
 
 	// Check that HTTP responses are written to stdout for all response codes
@@ -55,13 +55,13 @@ func TestHTTPExecutor(t *testing.T) {
 			stepName:         "test_500",
 			expectedInLog:    `{"code":500,"description":"Internal Server Error"}`,
 			outputVar:        "RET500",
-			shouldHaveOutput: false, // Error responses should not be captured
+			shouldHaveOutput: true, // Now captured regardless of status code
 		},
 		{
 			stepName:         "test_404",
 			expectedInLog:    `{"code":404,"description":"Not Found"}`,
 			outputVar:        "RET404",
-			shouldHaveOutput: false, // Error responses should not be captured
+			shouldHaveOutput: true, // Now captured regardless of status code
 		},
 	}
 
@@ -141,14 +141,14 @@ func TestHTTPExecutor(t *testing.T) {
 		{
 			stepName:        "ret_500",
 			outputVar:       "RET500",
-			expectedValue:   ``, // Should be empty since RET500 is not set
-			shouldHaveValue: false,
+			expectedValue:   `{code:500,description:Internal Server Error}`, // Now captured
+			shouldHaveValue: true,
 		},
 		{
 			stepName:        "ret_404",
 			outputVar:       "RET404",
-			expectedValue:   ``, // Should be empty since RET404 is not set
-			shouldHaveValue: false,
+			expectedValue:   `{code:404,description:Not Found}`, // Now captured
+			shouldHaveValue: true,
 		},
 	}
 

--- a/internal/integration/http_test.go
+++ b/internal/integration/http_test.go
@@ -1,0 +1,36 @@
+package integration_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dagu-org/dagu/internal/digraph/scheduler"
+	"github.com/dagu-org/dagu/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPExecutor(t *testing.T) {
+	th := test.Setup(t, test.WithDAGsDir(test.TestdataPath(t, "integration")))
+
+	// Load chain DAG
+	dag := th.DAG(t, filepath.Join("integration", "http.yaml"))
+
+	// Run the DAG
+	agent := dag.Agent()
+	require.NoError(t, agent.Run(agent.Context))
+
+	// Verify successful completion
+	dag.AssertLatestStatus(t, scheduler.StatusSuccess)
+
+	// Get the latest status to verify execution order
+	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	// Verify steps ran in order (chain type adds implicit dependencies)
+	dag.AssertOutputs(t, map[string]any{
+		"RET200": test.NotEmpty{},
+		"RET500": test.NotEmpty{},
+		"RET404": test.NotEmpty{},
+	})
+}

--- a/internal/integration/http_test.go
+++ b/internal/integration/http_test.go
@@ -2,9 +2,12 @@ package integration_test
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dagu-org/dagu/internal/digraph/scheduler"
+	"github.com/dagu-org/dagu/internal/fileutil"
+	"github.com/dagu-org/dagu/internal/models"
 	"github.com/dagu-org/dagu/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -27,10 +30,153 @@ func TestHTTPExecutor(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, status)
 
-	// Verify steps ran in order (chain type adds implicit dependencies)
+	// Verify that only successful response is captured in output variable
 	dag.AssertOutputs(t, map[string]any{
 		"RET200": test.NotEmpty{},
-		"RET500": test.NotEmpty{},
-		"RET404": test.NotEmpty{},
+		"RET500": "", // Should be empty because HTTP 500 is an error
+		"RET404": "", // Should be empty because HTTP 404 is an error
 	})
+
+	// Check that HTTP responses are written to stdout for all response codes
+	// This includes both successful (200) and error responses (404, 500)
+	testCases := []struct {
+		stepName         string
+		expectedInLog    string
+		outputVar        string
+		shouldHaveOutput bool
+	}{
+		{
+			stepName:         "test_200",
+			expectedInLog:    `{"code":200,"description":"OK"}`,
+			outputVar:        "RET200",
+			shouldHaveOutput: true,
+		},
+		{
+			stepName:         "test_500",
+			expectedInLog:    `{"code":500,"description":"Internal Server Error"}`,
+			outputVar:        "RET500",
+			shouldHaveOutput: false, // Error responses should not be captured
+		},
+		{
+			stepName:         "test_404",
+			expectedInLog:    `{"code":404,"description":"Not Found"}`,
+			outputVar:        "RET404",
+			shouldHaveOutput: false, // Error responses should not be captured
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.stepName, func(t *testing.T) {
+			// Find the node for this step
+			var node *models.Node
+			for _, n := range status.Nodes {
+				if n.Step.Name == tc.stepName {
+					node = n
+					break
+				}
+			}
+			require.NotNil(t, node, "node %s not found", tc.stepName)
+
+			// Read the stdout log file
+			t.Logf("Reading stdout file: %s", node.Stdout)
+			logContent, _, _, _, _, err := fileutil.ReadLogContent(node.Stdout, fileutil.LogReadOptions{})
+			require.NoError(t, err, "failed to read stdout for step %s", tc.stepName)
+
+			t.Logf("Step %s stdout content: %q", tc.stepName, logContent)
+
+			// Check that the expected content is in the log
+			require.Contains(t, logContent, tc.expectedInLog,
+				"step %s stdout should contain expected response", tc.stepName)
+
+			// For non-200 responses with silent=true, headers should be included
+			if tc.stepName == "test_500" || tc.stepName == "test_404" {
+				statusLine := map[string]string{
+					"test_500": "500 Internal Server Error",
+					"test_404": "404 Not Found",
+				}[tc.stepName]
+				require.Contains(t, logContent, statusLine,
+					"step %s stdout should contain status line", tc.stepName)
+				require.Contains(t, logContent, "Content-Type:",
+					"step %s stdout should contain headers", tc.stepName)
+			}
+
+			// Verify output variable capture behavior
+			if tc.outputVar != "" {
+				if tc.shouldHaveOutput {
+					require.NotNil(t, node.OutputVariables, "OutputVariables should not be nil for step %s", tc.stepName)
+					value, ok := node.OutputVariables.Load(tc.outputVar)
+					require.True(t, ok, "output variable %s should be set", tc.outputVar)
+					require.NotEmpty(t, value, "output variable %s should not be empty", tc.outputVar)
+
+					strValue := value.(string)
+
+					// Verify the output contains the expected JSON response
+					require.Contains(t, strValue, tc.expectedInLog,
+						"output variable %s should contain response body", tc.outputVar)
+				} else {
+					// For error responses, output variable should not be set
+					if node.OutputVariables != nil {
+						value, ok := node.OutputVariables.Load(tc.outputVar)
+						require.False(t, ok, "output variable %s should not be set for error response", tc.outputVar)
+						require.Nil(t, value, "output variable %s should be nil", tc.outputVar)
+					}
+				}
+			}
+		})
+	}
+
+	// Additional checks for the echo steps that use the captured variables
+	echoSteps := []struct {
+		stepName        string
+		outputVar       string
+		expectedValue   string
+		shouldHaveValue bool
+	}{
+		{
+			stepName:        "ret_200",
+			outputVar:       "RET200",
+			expectedValue:   `{code:200,description:OK}`, // Echo removes quotes from JSON
+			shouldHaveValue: true,
+		},
+		{
+			stepName:        "ret_500",
+			outputVar:       "RET500",
+			expectedValue:   ``, // Should be empty since RET500 is not set
+			shouldHaveValue: false,
+		},
+		{
+			stepName:        "ret_404",
+			outputVar:       "RET404",
+			expectedValue:   ``, // Should be empty since RET404 is not set
+			shouldHaveValue: false,
+		},
+	}
+
+	for _, es := range echoSteps {
+		t.Run(es.stepName+"_echo_check", func(t *testing.T) {
+			// Find the node for the echo step
+			var node *models.Node
+			for _, n := range status.Nodes {
+				if n.Step.Name == es.stepName {
+					node = n
+					break
+				}
+			}
+			require.NotNil(t, node, "echo node %s not found", es.stepName)
+
+			// Read the stdout log file for the echo step
+			logContent, _, _, _, _, err := fileutil.ReadLogContent(node.Stdout, fileutil.LogReadOptions{})
+			require.NoError(t, err, "failed to read stdout for echo step %s", es.stepName)
+
+			if es.shouldHaveValue {
+				// The echo step should output the value of the variable
+				require.Contains(t, logContent, es.expectedValue,
+					"echo step %s should output the captured HTTP response", es.stepName)
+			} else {
+				// For error responses, the variable is empty so echo outputs nothing (just newline)
+				require.Equal(t, "", strings.TrimSpace(logContent),
+					"echo step %s should output empty string for unset variable", es.stepName)
+			}
+		})
+	}
 }

--- a/internal/persistence/legacy/model/node_test.go
+++ b/internal/persistence/legacy/model/node_test.go
@@ -76,7 +76,7 @@ func TestFromNodes(t *testing.T) {
 	nodes := model.FromNodes(nodeDataList)
 
 	assert.Len(t, nodes, 2)
-	
+
 	// Check first node
 	assert.Equal(t, "step1", nodes[0].Step.Name)
 	assert.Equal(t, "/tmp/step1.log", nodes[0].Log)
@@ -88,7 +88,7 @@ func TestFromNodes(t *testing.T) {
 	assert.Equal(t, 2, nodes[0].RetryCount)
 	assert.Equal(t, 1, nodes[0].DoneCount)
 	assert.Empty(t, nodes[0].Error)
-	
+
 	// Check second node
 	assert.Equal(t, "step2", nodes[1].Step.Name)
 	assert.Equal(t, scheduler.NodeStatusError, nodes[1].Status)
@@ -182,16 +182,16 @@ func TestNodeToNode(t *testing.T) {
 	assert.Equal(t, modelNode.Status, schedulerNode.NodeData().State.Status)
 	assert.Equal(t, modelNode.RetryCount, schedulerNode.NodeData().State.RetryCount)
 	assert.Equal(t, modelNode.DoneCount, schedulerNode.NodeData().State.DoneCount)
-	
+
 	// Check times
 	expectedStart, _ := stringutil.ParseTime(modelNode.StartedAt)
 	expectedFinish, _ := stringutil.ParseTime(modelNode.FinishedAt)
 	expectedRetry, _ := stringutil.ParseTime(modelNode.RetriedAt)
-	
+
 	assert.Equal(t, expectedStart, schedulerNode.NodeData().State.StartedAt)
 	assert.Equal(t, expectedFinish, schedulerNode.NodeData().State.FinishedAt)
 	assert.Equal(t, expectedRetry, schedulerNode.NodeData().State.RetriedAt)
-	
+
 	// Check error
 	if modelNode.Error != "" {
 		assert.NotNil(t, schedulerNode.NodeData().State.Error)
@@ -266,7 +266,7 @@ func TestErrFromText(t *testing.T) {
 			// We need to test through the public interface
 			node := &model.Node{Error: tt.input}
 			schedulerNode := node.ToNode()
-			
+
 			if tt.expected == nil {
 				assert.Nil(t, schedulerNode.NodeData().State.Error)
 			} else {
@@ -309,7 +309,7 @@ func TestErrText(t *testing.T) {
 					Error: tt.input,
 				},
 			}
-			
+
 			node := model.FromNode(nodeData)
 			assert.Equal(t, tt.expected, node.Error)
 		})

--- a/internal/testdata/integration/http.yaml
+++ b/internal/testdata/integration/http.yaml
@@ -1,0 +1,58 @@
+steps:
+  - name: echo_works
+    command: echo "Echo works"
+
+  - name: echo_into_var
+    command: echo "Echo works in var"
+    output: ECHOVAR
+
+  - name: echo_from_var
+    command: echo "${ECHOVAR}"
+
+  - name: test_200
+    command: GET https://httpstat.us/200
+    executor:
+      type: http
+      config:
+        timeout: 10
+        silent: true
+        headers:
+          Accept: application/json
+    output: RET200
+
+  - name: ret_200
+    command: echo "${RET200}"
+
+  - name: test_500
+    command: GET https://httpstat.us/500
+    executor:
+      type: http
+      config:
+        timeout: 10
+        silent: true
+        headers:
+          Accept: application/json
+    continueOn:
+      failure: true
+      markSuccess: true
+    output: RET500
+
+  - name: ret_500
+    command: echo "${RET500}"
+
+  - name: test_404
+    command: GET https://httpstat.us/404
+    executor:
+      type: http
+      config:
+        timeout: 10
+        silent: true
+        headers:
+          Accept: application/json
+    continueOn:
+      failure: true
+      markSuccess: true
+    output: RET404
+
+  - name: ret_404
+    command: echo "${RET404}"


### PR DESCRIPTION
## Summary
- Fixed HTTP executor stdout buffering issue where responses weren't being written to log files
- Fixed SetStderr bug that was incorrectly setting stdout 
- Added flushable multi-writer to ensure buffered output is properly flushed

## Test plan
- [x] Run `make test` - all tests pass
- [x] Run `make golangci-lint` - no lint issues
- [x] Verified HTTP responses are written to stdout for all status codes (200, 404, 500)
- [x] Verified output variables capture responses for all status codes