### PR TITLE
feat: add skipTLSVerify option to HTTP executor for self-signed certificates

### DIFF
--- a/docs/features/executors/http.md
+++ b/docs/features/executors/http.md
@@ -20,6 +20,7 @@ steps:
 | `body` | Request body | `{"name": "value"}` |
 | `timeout` | Timeout in seconds | `30` |
 | `silent` | Return body only | `true` |
+| `skipTLSVerify` | Skip TLS certificate verification | `true` |
 
 ## Examples
 
@@ -135,6 +136,20 @@ handlerOn:
         headers:
           Content-Type: application/json
     command: POST https://hooks.example.com/workflow-complete
+```
+
+### Self-Signed Certificates
+
+```yaml
+steps:
+  - name: internal-api
+    executor:
+      type: http
+      config:
+        skipTLSVerify: true  # Allow self-signed certificates
+        headers:
+          Authorization: "Bearer ${INTERNAL_TOKEN}"
+    command: GET https://internal-api.company.local/data
 ```
 
 ## See Also

--- a/docs/reference/executors.md
+++ b/docs/reference/executors.md
@@ -380,6 +380,20 @@ steps:
     command: POST https://example.com/login
 ```
 
+### Self-Signed Certificates
+
+```yaml
+steps:
+  - name: internal-api
+    executor:
+      type: http
+      config:
+        skipTLSVerify: true  # Skip certificate verification
+        headers:
+          Authorization: Bearer ${INTERNAL_TOKEN}
+    command: GET https://internal-api.local/data
+```
+
 ### Complete HTTP Example
 
 ```yaml

--- a/examples/http_self_signed.yaml
+++ b/examples/http_self_signed.yaml
@@ -1,0 +1,39 @@
+# Example: HTTP requests to endpoints with self-signed certificates
+name: http-self-signed-example
+
+steps:
+  # Request to internal API with self-signed certificate
+  - name: internal-api-call
+    executor:
+      type: http
+      config:
+        skipTLSVerify: true  # Skip certificate verification for self-signed cert
+        headers:
+          Authorization: "Bearer ${INTERNAL_API_TOKEN}"
+          Accept: application/json
+        timeout: 30
+    command: GET https://internal-api.company.local/api/v1/status
+    output: API_STATUS
+
+  # Process the response
+  - name: check-status
+    command: |
+      echo "API Status Response:"
+      echo "${API_STATUS}"
+    depends: internal-api-call
+
+  # Example with retry on self-signed endpoint
+  - name: webhook-with-retry
+    executor:
+      type: http
+      config:
+        skipTLSVerify: true
+        body: '{"event": "workflow_complete", "dag": "${DAG_NAME}"}'
+        headers:
+          Content-Type: application/json
+    command: POST https://webhook.internal/notify
+    retryPolicy:
+      limit: 3
+      intervalSec: 5
+    continueOn:
+      failure: true  # Continue even if webhook fails

--- a/internal/digraph/executor/http.go
+++ b/internal/digraph/executor/http.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,13 +29,14 @@ type http struct {
 }
 
 type httpConfig struct {
-	Timeout int               `json:"timeout"`
-	Headers map[string]string `json:"headers"`
-	Query   map[string]string `json:"query"`
-	Body    string            `json:"body"`
-	Silent  bool              `json:"silent"`
-	Debug   bool              `json:"debug"`
-	JSON    bool              `json:"json"`
+	Timeout       int               `json:"timeout"`
+	Headers       map[string]string `json:"headers"`
+	Query         map[string]string `json:"query"`
+	Body          string            `json:"body"`
+	Silent        bool              `json:"silent"`
+	Debug         bool              `json:"debug"`
+	JSON          bool              `json:"json"`
+	SkipTLSVerify bool              `json:"skipTLSVerify"`
 }
 
 type httpJSONResult struct {
@@ -68,6 +70,11 @@ func newHTTP(ctx context.Context, step digraph.Step) (Executor, error) {
 	}
 	if reqCfg.Timeout > 0 {
 		client.SetTimeout(time.Second * time.Duration(reqCfg.Timeout))
+	}
+	if reqCfg.SkipTLSVerify {
+		client.SetTLSClientConfig(&tls.Config{
+			InsecureSkipVerify: true, // nolint:gosec
+		})
 	}
 	req := client.R().SetContext(ctx)
 	if len(reqCfg.Headers) > 0 {

--- a/internal/digraph/executor/http_executor_test.go
+++ b/internal/digraph/executor/http_executor_test.go
@@ -1,0 +1,167 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	nethttp "net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dagu-org/dagu/internal/digraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPExecutor_SkipTLSVerify(t *testing.T) {
+	t.Run("HTTPS request with self-signed certificate", func(t *testing.T) {
+		// Create a test server with a self-signed certificate
+		server := httptest.NewTLSServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+			w.WriteHeader(nethttp.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"message": "success",
+			})
+		}))
+		defer server.Close()
+
+		// Test with skipTLSVerify = true (should succeed)
+		step := digraph.Step{
+			Command: "GET",
+			Args:    []string{server.URL + "/test"},
+			ExecutorConfig: digraph.ExecutorConfig{
+				Type: "http",
+				Config: map[string]any{
+					"skipTLSVerify": true,
+					"silent":        true,
+					"json":          true,
+				},
+			},
+		}
+
+		executor, err := newHTTP(context.Background(), step)
+		require.NoError(t, err)
+
+		httpExec, ok := executor.(*http)
+		require.True(t, ok)
+		httpExec.SetStdout(&testWriter{})
+		httpExec.SetStderr(&testWriter{})
+
+		err = httpExec.Run(context.Background())
+		assert.NoError(t, err)
+	})
+
+	t.Run("HTTPS request without skipTLSVerify", func(t *testing.T) {
+		// Create a test server with a self-signed certificate
+		server := httptest.NewTLSServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+			w.WriteHeader(nethttp.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"message": "success",
+			})
+		}))
+		defer server.Close()
+
+		// Test with skipTLSVerify = false (should fail due to certificate verification)
+		step := digraph.Step{
+			Command: "GET",
+			Args:    []string{server.URL + "/test"},
+			ExecutorConfig: digraph.ExecutorConfig{
+				Type: "http",
+				Config: map[string]any{
+					"skipTLSVerify": false,
+					"silent":        true,
+				},
+			},
+		}
+
+		executor, err := newHTTP(context.Background(), step)
+		require.NoError(t, err)
+
+		httpExec, ok := executor.(*http)
+		require.True(t, ok)
+		httpExec.SetStdout(&testWriter{})
+		httpExec.SetStderr(&testWriter{})
+
+		err = httpExec.Run(context.Background())
+		// Should fail with certificate verification error
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "certificate")
+	})
+
+	t.Run("Config parsing with skipTLSVerify", func(t *testing.T) {
+		step := digraph.Step{
+			Command: "GET",
+			Args:    []string{"https://example.com"},
+			Script: `{
+				"skipTLSVerify": true,
+				"timeout": 30,
+				"headers": {"Authorization": "Bearer token"}
+			}`,
+		}
+
+		executor, err := newHTTP(context.Background(), step)
+		require.NoError(t, err)
+
+		httpExec, ok := executor.(*http)
+		require.True(t, ok)
+		assert.True(t, httpExec.cfg.SkipTLSVerify)
+		assert.Equal(t, 30, httpExec.cfg.Timeout)
+		assert.Equal(t, "Bearer token", httpExec.cfg.Headers["Authorization"])
+	})
+}
+
+func TestHTTPExecutor_StandardFeatures(t *testing.T) {
+	t.Run("GET request with headers and query params", func(t *testing.T) {
+		server := httptest.NewServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+			assert.Equal(t, "value1", r.URL.Query().Get("param1"))
+
+			w.WriteHeader(nethttp.StatusOK)
+			_, _ = w.Write([]byte("test response"))
+		}))
+		defer server.Close()
+
+		step := digraph.Step{
+			Command: "GET",
+			Args:    []string{server.URL},
+			ExecutorConfig: digraph.ExecutorConfig{
+				Type: "http",
+				Config: map[string]any{
+					"headers": map[string]string{
+						"Authorization": "Bearer test-token",
+					},
+					"query": map[string]string{
+						"param1": "value1",
+					},
+					"silent": true,
+				},
+			},
+		}
+
+		executor, err := newHTTP(context.Background(), step)
+		require.NoError(t, err)
+
+		out := &testWriter{}
+		httpExec, ok := executor.(*http)
+		require.True(t, ok)
+		httpExec.SetStdout(out)
+		httpExec.SetStderr(&testWriter{})
+
+		err = httpExec.Run(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, "test response", out.String())
+	})
+}
+
+// testWriter is a simple writer for capturing output in tests
+type testWriter struct {
+	data []byte
+}
+
+func (tw *testWriter) Write(p []byte) (n int, err error) {
+	tw.data = append(tw.data, p...)
+	return len(p), nil
+}
+
+func (tw *testWriter) String() string {
+	return string(tw.data)
+}


### PR DESCRIPTION
## Summary
- Adds `skipTLSVerify` configuration option to HTTP executor
- Enables HTTP requests to endpoints with self-signed certificates
- Resolves #452

## Problem
Users need to make HTTP requests to internal endpoints with self-signed certificates (common in enterprise networks), but the HTTP executor currently rejects these connections. They have to use workarounds with `curl -k`.

## Solution
Added a new `skipTLSVerify` boolean field to the HTTP executor configuration that, when set to `true`, configures the underlying Resty HTTP client to skip TLS certificate verification.

## Changes
- **Core Implementation**: Added `SkipTLSVerify` field to `httpConfig` struct and TLS configuration logic
- **Tests**: Comprehensive test coverage including:
  - Successful HTTPS requests with self-signed certificates
  - Failed requests without the flag (default behavior)
  - Configuration parsing validation
- **Documentation**: Updated both feature and reference documentation with examples
- **Example**: Added `examples/http_self_signed.yaml` demonstrating usage

## Usage
```yaml
steps:
  - name: internal-api
    executor:
      type: http
      config:
        skipTLSVerify: true  # Allow self-signed certificates
        headers:
          Authorization: "Bearer ${TOKEN}"
    command: GET https://internal-api.company.local/data
```

## Test plan
- [x] Unit tests pass
- [x] Linter passes (`make golangci-lint`)
- [x] All existing tests pass (`make test`)
- [x] Manual testing with self-signed certificate endpoints
- [x] Documentation updated