### PR TITLE
feat: enhance repeat policy with while until

### DIFF
--- a/internal/digraph/builder.go
+++ b/internal/digraph/builder.go
@@ -850,19 +850,52 @@ func buildRetryPolicy(_ BuildContext, def stepDef, step *Step) error {
 
 // buildRepeatPolicy sets up the repeat policy for a step.
 //
-// Semantics:
-//  1. If both "condition" and "expected" are set:
-//     - After the step runs, evaluate "condition" (may be a shell command, env var, or expression).
-//     - Compare its output to "expected". Repeat as long as the comparison does NOT match.
-//  2. If only "condition" is set (and "expected" is empty):
-//     - Repeat as long as "condition" (may be a shell command, env var, or expression) evaluates to exit code 0.
-//  3. If "exitCode" is specified (and "condition" is not set):
-//     - Repeat as long as the last step’s exit code matches any value in the list.
-//  4. If only "repeat: true", repeat unconditionally at the given interval.
+// The repeat policy supports two modes: "while" and "until", which determine when repetition stops:
+// - "while": Repeat as long as the condition is true (continues while condition matches)
+// - "until": Repeat as long as the condition is false (stops when condition matches)
 //
-// Precedence: Condition > ExitCode > Repeat.
+// Configuration options:
 //
-// This mirrors the Precondition logic for consistency.
+//  1. Explicit mode with condition:
+//     repeatPolicy:
+//     repeat: "while"  # or "until"
+//     condition: "echo test"
+//     expected: "test"  # optional, defaults to exit code 0 check
+//     intervalSec: 30
+//     limit: 10
+//
+//  2. Explicit mode with exit codes:
+//     repeatPolicy:
+//     repeat: "while"  # or "until"
+//     exitCode: [0, 1]  # repeat while/until exit code matches any in list
+//     intervalSec: 30
+//
+//  3. Boolean mode (backward compatibility):
+//     repeatPolicy:
+//     repeat: true  # equivalent to "while" mode, repeats unconditionally
+//     intervalSec: 30
+//
+//  4. Backward compatibility (mode inferred from configuration):
+//     repeatPolicy:
+//     condition: "echo test"
+//     expected: "test"     # inferred as "until" mode
+//     intervalSec: 30
+//     OR
+//     repeatPolicy:
+//     condition: "echo test"  # inferred as "while" mode (condition only)
+//     intervalSec: 30
+//     OR
+//     repeatPolicy:
+//     exitCode: [1, 2]       # inferred as "while" mode
+//     intervalSec: 30
+//
+// Validation rules:
+// - Explicit "while"/"until" modes require either 'condition' or 'exitCode' to be specified
+// - If both 'condition' and 'expected' are set, the mode defaults to "until"
+// - If only 'condition' or only 'exitCode' is set, the mode defaults to "while"
+// - Boolean true is equivalent to "while" mode with unconditional repetition
+//
+// Precedence: condition > exitCode > unconditional repeat
 func buildRepeatPolicy(_ BuildContext, def stepDef, step *Step) error {
 	if def.RepeatPolicy == nil {
 		return nil
@@ -903,6 +936,17 @@ func buildRepeatPolicy(_ BuildContext, def stepDef, step *Step) error {
 	// No repeat if mode is not determined
 	if mode == "" {
 		return nil
+	}
+
+	// Validate that explicit while/until modes have appropriate conditions
+	if rpDef.Repeat != nil {
+		// Check if mode was explicitly set (not inferred from backward compatibility)
+		switch v := rpDef.Repeat.(type) {
+		case string:
+			if (v == "while" || v == "until") && rpDef.Condition == "" && len(rpDef.ExitCode) == 0 {
+				return fmt.Errorf("repeat mode '%s' requires either 'condition' or 'exitCode' to be specified", v)
+			}
+		}
 	}
 
 	step.RepeatPolicy.Repeat = mode

--- a/internal/digraph/builder_test.go
+++ b/internal/digraph/builder_test.go
@@ -429,7 +429,7 @@ func TestBuildStep(t *testing.T) {
 		th := testLoad(t, "repeat_policy.yaml")
 		assert.Len(t, th.Steps, 1)
 		require.NotNil(t, th.Steps[0].RepeatPolicy)
-		assert.True(t, th.Steps[0].RepeatPolicy.Repeat)
+		assert.Equal(t, digraph.RepeatModeWhile, th.Steps[0].RepeatPolicy.Repeat)
 		assert.Equal(t, 60*time.Second, th.Steps[0].RepeatPolicy.Interval)
 	})
 	t.Run("RepeatPolicyCondition", func(t *testing.T) {

--- a/internal/digraph/definition.go
+++ b/internal/digraph/definition.go
@@ -144,7 +144,7 @@ type continueOnDef struct {
 
 // repeatPolicyDef defines the repeat policy for a step.
 type repeatPolicyDef struct {
-	Repeat      bool   `yaml:"repeat,omitempty"`      // Flag to indicate if the step should be repeated
+	Repeat      any    `yaml:"repeat,omitempty"`      // Flag to indicate if the step should be repeated, can be bool (legacy) or string ("while" or "until")
 	IntervalSec int    `yaml:"intervalSec,omitempty"` // Interval in seconds to wait before repeating the step
 	Limit       int    `yaml:"limit,omitempty"`       // Maximum number of times to repeat the step
 	Condition   string `yaml:"condition,omitempty"`   // Condition to check before repeating

--- a/internal/digraph/scheduler/scheduler_test.go
+++ b/internal/digraph/scheduler/scheduler_test.go
@@ -873,6 +873,45 @@ func TestScheduler(t *testing.T) {
 		assert.GreaterOrEqual(t, node.State().DoneCount, 2)
 	})
 
+	t.Run("RepeatPolicy_RepeatsWhileConditionExits0", func(t *testing.T) {
+		sc := setupScheduler(t)
+		// This step will repeat until the file exists
+		file := filepath.Join(os.TempDir(), fmt.Sprintf("repeat_exit0_%s", uuid.Must(uuid.NewV7()).String()))
+		err := os.Remove(file)
+		if err != nil && !os.IsNotExist(err) {
+			require.NoError(t, err)
+		}
+		defer func() {
+			err := os.Remove(file)
+			if err != nil && !os.IsNotExist(err) {
+				require.NoError(t, err)
+			}
+		}()
+		graph := sc.newGraph(t,
+			newStep("1",
+				withCommand("echo hello"),
+				func(step *digraph.Step) {
+					step.RepeatPolicy.Repeat = digraph.RepeatModeWhile
+					step.RepeatPolicy.Condition = &digraph.Condition{
+						Condition: "test ! -f " + file,
+					}
+					step.RepeatPolicy.Interval = 100 * time.Millisecond
+				},
+			),
+		)
+		// Create file 100 ms after step runs
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			f, _ := os.Create(file)
+			err := f.Close()
+			require.NoError(t, err)
+		}()
+		result := graph.Schedule(t, scheduler.StatusSuccess)
+		result.AssertNodeStatus(t, "1", scheduler.NodeStatusSuccess)
+		node := result.Node(t, "1")
+		assert.GreaterOrEqual(t, node.State().DoneCount, 2)
+	})
+
 	t.Run("RepeatPolicy_RepeatsWhileCommandExitCodeMatches", func(t *testing.T) {
 		sc := setupScheduler(t)
 		// This step will repeat until exit code is not 42.
@@ -892,11 +931,6 @@ func TestScheduler(t *testing.T) {
 		graph := sc.newGraph(t,
 			newStep("1",
 				withScript(script),
-				withContinueOn(digraph.ContinueOn{
-					ExitCode:    []int{42},
-					Failure:     true,
-					MarkSuccess: true,
-				}),
 				func(step *digraph.Step) {
 					step.RepeatPolicy.Repeat = digraph.RepeatModeWhile
 					step.RepeatPolicy.ExitCode = []int{42}
@@ -2028,6 +2062,412 @@ func TestScheduler_ComplexRetryScenarios(t *testing.T) {
 		node := result.Node(t, "1")
 		// Should retry once (first failure with code 42, then fail with code 100)
 		assert.Equal(t, 1, node.State().RetryCount)
+	})
+
+	// Test cases for behaviors when neither condition nor exitCode are present
+	t.Run("RepeatPolicy_BooleanTrue_RepeatsWhileStepSucceeds", func(t *testing.T) {
+		sc := setupScheduler(t)
+
+		// Test repeat: true (boolean mode) - should repeat while step succeeds (no condition/exitCode)
+		graph := sc.newGraph(t,
+			newStep("1",
+				withCommand("echo boolean true mode"),
+				func(step *digraph.Step) {
+					step.RepeatPolicy.Repeat = digraph.RepeatModeWhile // This is what repeat: true becomes
+					step.RepeatPolicy.Interval = 100 * time.Millisecond
+					step.RepeatPolicy.Limit = 3 // Limit to prevent infinite loop
+					// No condition, no exitCode - should repeat while step succeeds
+				},
+			),
+		)
+
+		result := graph.Schedule(t, scheduler.StatusSuccess)
+		result.AssertNodeStatus(t, "1", scheduler.NodeStatusSuccess)
+
+		node := result.Node(t, "1")
+		// Should have executed exactly 3 times (limit reached, step always succeeds)
+		assert.Equal(t, 3, node.State().DoneCount)
+	})
+
+	t.Run("RepeatPolicy_BooleanTrueWithFailure_StopsOnFailure", func(t *testing.T) {
+		sc := setupScheduler(t)
+
+		// Test repeat: true (boolean mode) with step that eventually fails
+		counterFile := filepath.Join(os.TempDir(), fmt.Sprintf("repeat_bool_fail_%s", uuid.Must(uuid.NewV7()).String()))
+		defer func() { _ = os.Remove(counterFile) }()
+
+		graph := sc.newGraph(t,
+			newStep("1",
+				withScript(fmt.Sprintf(`
+					COUNT=0
+					if [ -f "%s" ]; then
+						COUNT=$(cat "%s")
+					fi
+					COUNT=$((COUNT + 1))
+					echo "$COUNT" > "%s"
+					if [ "$COUNT" -le 2 ]; then
+						exit 0
+					else
+						exit 1
+					fi
+				`, counterFile, counterFile, counterFile)),
+				func(step *digraph.Step) {
+					step.RepeatPolicy.Repeat = digraph.RepeatModeWhile // Boolean true mode
+					step.RepeatPolicy.Interval = 100 * time.Millisecond
+					// No condition, no exitCode - should stop when step fails
+				},
+			),
+		)
+
+		result := graph.Schedule(t, scheduler.StatusError)
+		result.AssertNodeStatus(t, "1", scheduler.NodeStatusError)
+
+		node := result.Node(t, "1")
+		// Should have executed exactly 3 times (2 successes, then 1 failure stops it)
+		assert.Equal(t, 3, node.State().DoneCount)
+	})
+
+	t.Run("RepeatPolicy_UntilModeWithoutCondition_RepeatsOnFailure", func(t *testing.T) {
+		sc := setupScheduler(t)
+
+		// Test explicit until mode without condition/exitCode (repeats until step succeeds)
+		counterFile := filepath.Join(os.TempDir(), fmt.Sprintf("repeat_until_none_%s", uuid.Must(uuid.NewV7()).String()))
+		defer func() { _ = os.Remove(counterFile) }()
+
+		graph := sc.newGraph(t,
+			newStep("1",
+				withScript(fmt.Sprintf(`
+					COUNT=0
+					if [ -f "%s" ]; then
+						COUNT=$(cat "%s")
+					fi
+					COUNT=$((COUNT + 1))
+					echo "$COUNT" > "%s"
+					if [ "$COUNT" -le 2 ]; then
+						exit 1
+					else
+						exit 0
+					fi
+				`, counterFile, counterFile, counterFile)),
+				withContinueOn(digraph.ContinueOn{
+					ExitCode:    []int{1},
+					Failure:     true,
+					MarkSuccess: true,
+				}),
+				func(step *digraph.Step) {
+					step.RepeatPolicy.Repeat = digraph.RepeatModeUntil
+					step.RepeatPolicy.Interval = 100 * time.Millisecond
+					// No condition, no exitCode - should repeat until step succeeds
+				},
+			),
+		)
+
+		result := graph.Schedule(t, scheduler.StatusSuccess)
+		result.AssertNodeStatus(t, "1", scheduler.NodeStatusSuccess)
+
+		node := result.Node(t, "1")
+		// Should have executed exactly 3 times (fails twice, then succeeds)
+		assert.Equal(t, 3, node.State().DoneCount)
+	})
+
+	t.Run("RepeatPolicy_WhileWithCondition_RepeatsWhileConditionSucceeds", func(t *testing.T) {
+		sc := setupScheduler(t)
+
+		// Test explicit while mode with condition
+		counterFile := filepath.Join(os.TempDir(), fmt.Sprintf("repeat_while_cond_%s", uuid.Must(uuid.NewV7()).String()))
+		err := os.Remove(counterFile)
+		if err != nil && !os.IsNotExist(err) {
+			require.NoError(t, err)
+		}
+		defer func() {
+			err := os.Remove(counterFile)
+			if err != nil && !os.IsNotExist(err) {
+				require.NoError(t, err)
+			}
+		}()
+		graph := sc.newGraph(t,
+			newStep("1",
+				withCommand("cat "+counterFile+" || echo notfound"),
+				func(step *digraph.Step) {
+					step.RepeatPolicy.Repeat = digraph.RepeatModeWhile
+					step.RepeatPolicy.Condition = &digraph.Condition{
+						Condition: fmt.Sprintf("test ! -f %s", counterFile),
+					}
+					step.RepeatPolicy.Interval = 100 * time.Millisecond
+				},
+			),
+		)
+
+		go func() {
+			time.Sleep(time.Millisecond * 250)
+			f, _ := os.Create(counterFile)
+			_ = f.Close()
+		}()
+
+		result := graph.Schedule(t, scheduler.StatusSuccess)
+		result.AssertNodeStatus(t, "1", scheduler.NodeStatusSuccess)
+
+		node := result.Node(t, "1")
+		// Should have run at least twice (first: file not found, second: file created)
+		assert.GreaterOrEqual(t, node.State().DoneCount, 2)
+	})
+
+	t.Run("RepeatPolicy_WhileWithConditionAndExpected_RepeatsWhileMatches", func(t *testing.T) {
+		sc := setupScheduler(t)
+
+		// Test explicit while mode with condition and expected value
+		counterFile := filepath.Join(os.TempDir(), fmt.Sprintf("repeat_while_exp_%s", uuid.Must(uuid.NewV7()).String()))
+		defer func() { _ = os.Remove(counterFile) }()
+
+		// Write initial value
+		err := os.WriteFile(counterFile, []byte("continue"), 0600)
+		require.NoError(t, err)
+
+		graph := sc.newGraph(t,
+			newStep("1",
+				withCommand("echo while with expected"),
+				func(step *digraph.Step) {
+					step.RepeatPolicy.Repeat = digraph.RepeatModeWhile
+					step.RepeatPolicy.Condition = &digraph.Condition{
+						Condition: fmt.Sprintf("`cat %s`", counterFile),
+						Expected:  "continue",
+					}
+					step.RepeatPolicy.Interval = 100 * time.Millisecond
+				},
+			),
+		)
+
+		go func() {
+			time.Sleep(time.Millisecond * 250)
+			err := os.WriteFile(counterFile, []byte("stop"), 0600)
+			require.NoError(t, err)
+		}()
+
+		result := graph.Schedule(t, scheduler.StatusSuccess)
+		result.AssertNodeStatus(t, "1", scheduler.NodeStatusSuccess)
+
+		node := result.Node(t, "1")
+		// Should have executed at least 2 times (while expected matches)
+		assert.GreaterOrEqual(t, node.State().DoneCount, 2)
+	})
+
+	t.Run("RepeatPolicy_UntilWithCondition_RepeatsUntilConditionSucceeds", func(t *testing.T) {
+		sc := setupScheduler(t)
+
+		// Test explicit until mode with condition (no expected)
+		counterFile := filepath.Join(os.TempDir(), fmt.Sprintf("repeat_until_cond_%s", uuid.Must(uuid.NewV7()).String()))
+		err := os.Remove(counterFile)
+		if err != nil && !os.IsNotExist(err) {
+			require.NoError(t, err)
+		}
+		defer func() {
+			err := os.Remove(counterFile)
+			if err != nil && !os.IsNotExist(err) {
+				require.NoError(t, err)
+			}
+		}()
+		graph := sc.newGraph(t,
+			newStep("1",
+				withCommand("cat "+counterFile+" || echo notfound"),
+				func(step *digraph.Step) {
+					step.RepeatPolicy.Repeat = digraph.RepeatModeUntil
+					step.RepeatPolicy.Condition = &digraph.Condition{
+						Condition: fmt.Sprintf("test -f %s", counterFile),
+					}
+					step.RepeatPolicy.Interval = 100 * time.Millisecond
+				},
+			),
+		)
+
+		go func() {
+			time.Sleep(time.Millisecond * 350)
+			f, _ := os.Create(counterFile)
+			_ = f.Close()
+		}()
+
+		result := graph.Schedule(t, scheduler.StatusSuccess)
+		result.AssertNodeStatus(t, "1", scheduler.NodeStatusSuccess)
+
+		node := result.Node(t, "1")
+		// Should have run at least twice (first: file not found, second: file created)
+		assert.GreaterOrEqual(t, node.State().DoneCount, 2)
+	})
+
+	t.Run("RepeatPolicy_UntilWithConditionAndExpected_RepeatsUntilMatches", func(t *testing.T) {
+		sc := setupScheduler(t)
+
+		// Test explicit until mode with condition and expected value
+		counterFile := filepath.Join(os.TempDir(), fmt.Sprintf("repeat_until_exp_%s", uuid.Must(uuid.NewV7()).String()))
+		defer func() { _ = os.Remove(counterFile) }()
+
+		// Write initial value
+		err := os.WriteFile(counterFile, []byte("waiting"), 0600)
+		require.NoError(t, err)
+
+		graph := sc.newGraph(t,
+			newStep("1",
+				withCommand("echo until with expected"),
+				func(step *digraph.Step) {
+					step.RepeatPolicy.Repeat = digraph.RepeatModeUntil
+					step.RepeatPolicy.Condition = &digraph.Condition{
+						Condition: fmt.Sprintf("`cat %s`", counterFile),
+						Expected:  "ready",
+					}
+					step.RepeatPolicy.Interval = 100 * time.Millisecond
+				},
+			),
+		)
+
+		go func() {
+			time.Sleep(time.Millisecond * 250)
+			err := os.WriteFile(counterFile, []byte("ready"), 0600)
+			require.NoError(t, err)
+		}()
+
+		result := graph.Schedule(t, scheduler.StatusSuccess)
+		result.AssertNodeStatus(t, "1", scheduler.NodeStatusSuccess)
+
+		node := result.Node(t, "1")
+		// Should have executed at least 2 times (until expected matches)
+		assert.GreaterOrEqual(t, node.State().DoneCount, 2)
+	})
+
+	t.Run("RepeatPolicy_UntilWithExitCode_RepeatsUntilExitCodeMatches", func(t *testing.T) {
+		sc := setupScheduler(t)
+
+		// Test explicit until mode with exit codes
+		counterFile := filepath.Join(os.TempDir(), fmt.Sprintf("repeat_until_exit_%s", uuid.Must(uuid.NewV7()).String()))
+		defer func() { _ = os.Remove(counterFile) }()
+
+		graph := sc.newGraph(t,
+			newStep("1",
+				withScript(fmt.Sprintf(`
+					COUNT=0
+					if [ -f "%s" ]; then
+						COUNT=$(cat "%s")
+					fi
+					COUNT=$((COUNT + 1))
+					echo "$COUNT" > "%s"
+					if [ "$COUNT" -le 2 ]; then
+						exit 1
+					else
+						exit 42
+					fi
+				`, counterFile, counterFile, counterFile)),
+				withContinueOn(digraph.ContinueOn{
+					ExitCode:    []int{1},
+					Failure:     true,
+					MarkSuccess: true,
+				}),
+				func(step *digraph.Step) {
+					step.RepeatPolicy.Repeat = digraph.RepeatModeUntil
+					step.RepeatPolicy.ExitCode = []int{42}
+					step.RepeatPolicy.Interval = 100 * time.Millisecond
+				},
+			),
+		)
+
+		go func() {
+			time.Sleep(time.Millisecond * 350)
+			f, _ := os.Create(counterFile)
+			_ = f.Close()
+		}()
+
+		result := graph.Schedule(t, scheduler.StatusSuccess)
+		result.AssertNodeStatus(t, "1", scheduler.NodeStatusSuccess)
+
+		node := result.Node(t, "1")
+		// Should have executed exactly 3 times (until exit code is 42)
+		assert.Equal(t, 3, node.State().DoneCount)
+	})
+
+	t.Run("RepeatPolicy_LimitOverridesAllConditions", func(t *testing.T) {
+		sc := setupScheduler(t)
+
+		// This step will repeat until the file exists, but is limited to 3 repeats
+		file := filepath.Join(os.TempDir(), fmt.Sprintf("repeat_limit_%s", uuid.Must(uuid.NewV7()).String()))
+		err := os.Remove(file)
+		if err != nil && !os.IsNotExist(err) {
+			require.NoError(t, err)
+		}
+		defer func() {
+			err := os.Remove(file)
+			if err != nil && !os.IsNotExist(err) {
+				require.NoError(t, err)
+			}
+		}()
+		graph := sc.newGraph(t,
+			newStep("1",
+				withCommand("cat "+file+" || echo notfound"),
+				func(step *digraph.Step) {
+					step.RepeatPolicy.Repeat = digraph.RepeatModeUntil
+					step.RepeatPolicy.Condition = &digraph.Condition{
+						Condition: fmt.Sprintf("test -f %s", file),
+					}
+					step.RepeatPolicy.Limit = 3
+					step.RepeatPolicy.Interval = 100 * time.Millisecond
+				},
+			),
+		)
+
+		go func() {
+			time.Sleep(time.Millisecond * 250)
+			f, _ := os.Create(file)
+			_ = f.Close()
+		}()
+
+		result := graph.Schedule(t, scheduler.StatusSuccess)
+		result.AssertNodeStatus(t, "1", scheduler.NodeStatusSuccess)
+
+		node := result.Node(t, "1")
+		// Should have executed exactly 3 times (limit reached)
+		assert.Equal(t, 3, node.State().DoneCount)
+	})
+
+	t.Run("RepeatPolicy_OutputVariablesReloadedBeforeConditionEval", func(t *testing.T) {
+		sc := setupScheduler(t)
+
+		// Test that output variables are reloaded before evaluating repeat condition
+		// Use a file-based counter to track iterations properly
+		counterFile := filepath.Join(os.TempDir(), fmt.Sprintf("repeat_output_var_%s", uuid.Must(uuid.NewV7()).String()))
+		defer func() { _ = os.Remove(counterFile) }()
+
+		graph := sc.newGraph(t,
+			newStep("1",
+				withScript(fmt.Sprintf(`
+					# Read counter from file or start at 0
+					if [ -f "%s" ]; then
+						COUNT=$(cat "%s")
+					else
+						COUNT=0
+					fi
+					COUNT=$((COUNT + 1))
+					echo "$COUNT" > "%s"
+					echo "$COUNT"
+				`, counterFile, counterFile, counterFile)),
+				withOutput("COUNTER"),
+				func(step *digraph.Step) {
+					step.RepeatPolicy.Repeat = digraph.RepeatModeUntil
+					step.RepeatPolicy.Condition = &digraph.Condition{
+						Condition: "$COUNTER",
+						Expected:  "3",
+					}
+					step.RepeatPolicy.Interval = 100 * time.Millisecond
+				},
+			),
+		)
+
+		result := graph.Schedule(t, scheduler.StatusSuccess)
+		result.AssertNodeStatus(t, "1", scheduler.NodeStatusSuccess)
+
+		node := result.Node(t, "1")
+		// Should have executed exactly 3 times (until COUNTER equals 3)
+		assert.Equal(t, 3, node.State().DoneCount)
+
+		// Verify final output variable value
+		output, ok := node.NodeData().State.OutputVariables.Load("COUNTER")
+		require.True(t, ok, "output variable not found")
+		require.Equal(t, "COUNTER=3", output)
 	})
 }
 

--- a/internal/digraph/step.go
+++ b/internal/digraph/step.go
@@ -136,10 +136,21 @@ type RetryPolicy struct {
 	ExitCodes []int `json:"exitCode,omitempty"`
 }
 
+// RepeatMode is the type for the repeat mode.
+type RepeatMode string
+
+const (
+	// RepeatModeWhile repeats the step while the condition is met.
+	RepeatModeWhile RepeatMode = "while"
+	// RepeatModeUntil repeats the step until the condition is met.
+	RepeatModeUntil RepeatMode = "until"
+)
+
 // RepeatPolicy contains the repeat policy for a step.
 type RepeatPolicy struct {
-	// Repeat determines if the step should be repeated.
-	Repeat bool `json:"repeat,omitempty"`
+	// Repeat determines if and how the step should be repeated.
+	// It can be 'while' or 'until'.
+	Repeat RepeatMode `json:"repeat,omitempty"`
 	// Interval is the time to wait between repeats.
 	Interval time.Duration `json:"interval,omitempty"`
 	// Limit is the maximum number of times to repeat the step.

--- a/internal/frontend/api/v1/dags.go
+++ b/internal/frontend/api/v1/dags.go
@@ -815,7 +815,7 @@ func toStep(obj digraph.Step) api.Step {
 	}
 
 	repeatPolicy := api.RepeatPolicy{
-		Repeat:   ptrOf(obj.RepeatPolicy.Repeat),
+		Repeat:   ptrOf(obj.RepeatPolicy.Repeat != ""),
 		Interval: ptrOf(int(obj.RepeatPolicy.Interval.Seconds())),
 	}
 

--- a/internal/frontend/api/v2/transformer.go
+++ b/internal/frontend/api/v2/transformer.go
@@ -30,7 +30,7 @@ func toStep(obj digraph.Step) api.Step {
 	}
 
 	repeatPolicy := api.RepeatPolicy{
-		Repeat:   ptrOf(obj.RepeatPolicy.Repeat),
+		Repeat:   ptrOf(obj.RepeatPolicy.Repeat != ""),
 		Interval: ptrOf(int(obj.RepeatPolicy.Interval.Seconds())),
 	}
 

--- a/internal/testdata/digraph/repeat_policy_backward_until.yaml
+++ b/internal/testdata/digraph/repeat_policy_backward_until.yaml
@@ -1,0 +1,7 @@
+steps:
+  - name: "repeat-backward-compatibility-until"
+    command: "echo test"
+    repeatPolicy:
+      condition: "echo hello"
+      expected: "hello"
+      intervalSec: 25

--- a/internal/testdata/digraph/repeat_policy_backward_while.yaml
+++ b/internal/testdata/digraph/repeat_policy_backward_while.yaml
@@ -1,0 +1,6 @@
+steps:
+  - name: "repeat-backward-compatibility-while"
+    command: "echo test"
+    repeatPolicy:
+      condition: "echo hello"
+      intervalSec: 30

--- a/internal/testdata/digraph/repeat_policy_until_condition.yaml
+++ b/internal/testdata/digraph/repeat_policy_until_condition.yaml
@@ -1,0 +1,9 @@
+steps:
+  - name: "repeat-until-condition"
+    command: "echo test"
+    repeatPolicy:
+      repeat: "until"
+      condition: "echo hello"
+      expected: "hello"
+      intervalSec: 10
+      limit: 5

--- a/internal/testdata/digraph/repeat_policy_until_exitcode.yaml
+++ b/internal/testdata/digraph/repeat_policy_until_exitcode.yaml
@@ -1,0 +1,7 @@
+steps:
+  - name: "repeat-until-exitcode"
+    command: "exit 0"
+    repeatPolicy:
+      repeat: "until"
+      exitCode: [0]
+      intervalSec: 20

--- a/internal/testdata/digraph/repeat_policy_while_condition.yaml
+++ b/internal/testdata/digraph/repeat_policy_while_condition.yaml
@@ -1,0 +1,8 @@
+steps:
+  - name: "repeat-while-condition"
+    command: "echo test"
+    repeatPolicy:
+      repeat: "while"
+      condition: "echo hello"
+      intervalSec: 5
+      limit: 3

--- a/internal/testdata/digraph/repeat_policy_while_exitcode.yaml
+++ b/internal/testdata/digraph/repeat_policy_while_exitcode.yaml
@@ -1,0 +1,7 @@
+steps:
+  - name: "repeat-while-exitcode"
+    command: "exit 1"
+    repeatPolicy:
+      repeat: "while"
+      exitCode: [1, 2]
+      intervalSec: 15

--- a/internal/testdata/integration/repeat-backward-compatibility-true.yaml
+++ b/internal/testdata/integration/repeat-backward-compatibility-true.yaml
@@ -1,0 +1,8 @@
+name: repeat-backward-compatibility-true
+steps:
+  - name: repeat-step
+    command: echo "Boolean true compatibility test"
+    repeatPolicy:
+      repeat: true
+      limit: 4
+      intervalSec: 0

--- a/internal/testdata/integration/repeat-limit-condition.yaml
+++ b/internal/testdata/integration/repeat-limit-condition.yaml
@@ -18,7 +18,7 @@ steps:
       fi
     output: FINAL_COUNT
     repeatPolicy:
-      repeat: true
+      repeat: until
       limit: 5
       intervalSec: 0
       condition: "`[ -f /tmp/dagu_repeat_counter_test2 ] && cat /tmp/dagu_repeat_counter_test2 || echo 0`"

--- a/internal/testdata/integration/repeat-until-unconditional.yaml
+++ b/internal/testdata/integration/repeat-until-unconditional.yaml
@@ -1,0 +1,26 @@
+name: repeat-until-unconditional
+steps:
+  - name: repeat-step
+    script: |
+      COUNT_FILE="/tmp/dagu_repeat_until_unconditional_test"
+      COUNT=0
+      if [ -f "$COUNT_FILE" ]; then
+        COUNT=$(cat "$COUNT_FILE")
+      fi
+      COUNT=$((COUNT + 1))
+      echo "$COUNT" > "$COUNT_FILE"
+      echo "Count: $COUNT"
+      if [ "$COUNT" -le 2 ]; then
+        exit 1
+      else
+        rm -f "$COUNT_FILE"
+        exit 0
+      fi
+    repeatPolicy:
+      # Using backward compatibility mode: exitCode only infers "while" mode
+      # but we can test "until" behavior with explicit condition that inverts logic
+      repeat: "until"
+      exitCode: [0]  # Repeat until we get exit code 0
+      intervalSec: 0
+    continueOn:
+      exitCode: [1]

--- a/internal/testdata/integration/repeat-while-unconditional.yaml
+++ b/internal/testdata/integration/repeat-while-unconditional.yaml
@@ -1,0 +1,8 @@
+name: repeat-while-unconditional
+steps:
+  - name: repeat-step
+    command: echo "Unconditional while loop using boolean mode"
+    repeatPolicy:
+      repeat: true
+      limit: 3
+      intervalSec: 0

--- a/schemas/dag.schema.json
+++ b/schemas/dag.schema.json
@@ -512,8 +512,16 @@
           "type": "object",
           "properties": {
             "repeat": {
-              "type": "boolean",
-              "description": "Whether to repeat this step"
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "enum": ["while", "until"]
+                }
+              ],
+              "description": "Determines if and how the step should be repeated. Can be a boolean or a string ('while' or 'until')."
             },
             "intervalSec": {
               "type": "integer",


### PR DESCRIPTION
Still in draft because PR has Todos.

Todo:
* ensure tests for all repeat behaviors (both implicit and explicit)
* add validation for when `while`/`until` is used to always be accompanied by a `condition` or `exitCode`

Behaviour:
1. **Mode is omitted** (backwards compatibility)
* condition and expected are set: mode defaults to `until` 
* condition/exitcode are set: default to `while` 
2. **Mode is `while`:** 
* \+ condition & expected: repeats as long as the condition matches the expected value
* \+ condition: repeats as long as the condition evaluates successfully
* \+ exit code: repeats as long as step exit code matches any in the list
* neither: repeats as long as the step execution succeeds (no execErr)
3. **Mode is `until`**: vice versa
4. **Mode is `true`**: executes as a `while` with no `condition` or `exitCode` (indefinite loop, repeats as long as the step succeeds).

