### PR TITLE
fix: repeat policy non zero exit codes

### DIFF
--- a/internal/digraph/scheduler/scheduler.go
+++ b/internal/digraph/scheduler/scheduler.go
@@ -257,10 +257,6 @@ func (sc *Scheduler) Schedule(ctx context.Context, graph *ExecutionGraph, progre
 				for setupSucceed && !sc.isCanceled() {
 					execErr := sc.execNode(ctx, node)
 					if execErr != nil {
-						lastExit := node.State().ExitCode
-						step := node.Step()
-						shouldRepeatOnExitCode := len(step.RepeatPolicy.ExitCode) > 0 && slices.Contains(step.RepeatPolicy.ExitCode, lastExit)
-
 						status := node.State().Status
 						switch {
 						case status == NodeStatusSuccess || status == NodeStatusCancel:
@@ -278,11 +274,6 @@ func (sc *Scheduler) Schedule(ctx context.Context, graph *ExecutionGraph, progre
 							if sc.handleNodeRetry(ctx, node, execErr) {
 								continue ExecRepeat
 							}
-
-						case shouldRepeatOnExitCode:
-							// The step failed with an exit code that is configured to trigger a repeat.
-							// Don't mark the node as failed, as it will be repeated.
-							// The repeat logic later in the loop will handle the repetition.
 
 						default:
 							// finish the node
@@ -340,6 +331,10 @@ func (sc *Scheduler) Schedule(ctx context.Context, graph *ExecutionGraph, progre
 					}
 
 					if shouldRepeat && !sc.isCanceled() {
+						node.SetStatus(NodeStatusRunning) // reset status to running for the repeat
+						if sc.lastError == node.Error() {
+							sc.setLastError(nil) // clear last error if we are repeating
+						}
 						logger.Info(ctx, "Step will be repeated", "step", node.Name(), "interval", step.RepeatPolicy.Interval)
 						time.Sleep(step.RepeatPolicy.Interval)
 						node.SetRepeated(true) // mark as repeated

--- a/internal/integration/repeat_on_exitcode_test.go
+++ b/internal/integration/repeat_on_exitcode_test.go
@@ -1,0 +1,46 @@
+package integration_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dagu-org/dagu/internal/digraph/scheduler"
+	"github.com/dagu-org/dagu/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepeatPolicy_OnExitCode(t *testing.T) {
+	counterFile := "/tmp/dagu-test-counter-repeat-on-exitcode"
+	_ = os.Remove(counterFile)
+	t.Cleanup(func() {
+		_ = os.Remove(counterFile)
+	})
+
+	th := test.Setup(t, test.WithDAGsDir(test.TestdataPath(t, "integration")))
+
+	dag := th.DAG(t, filepath.Join("integration", "repeat-on-exitcode-fail.yaml"))
+	agent := dag.Agent()
+
+	ctx, cancel := context.WithTimeout(agent.Context, 15*time.Second)
+	defer cancel()
+
+	err := agent.Run(ctx)
+	require.NoError(t, err, "DAG should complete successfully")
+
+	dag.AssertLatestStatus(t, scheduler.StatusSuccess)
+
+	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	require.Len(t, status.Nodes, 1)
+	nodeStatus := status.Nodes[0]
+
+	assert.Equal(t, scheduler.NodeStatusSuccess, nodeStatus.Status, "The final status of the node should be Success")
+	assert.True(t, nodeStatus.Repeated, "The step should be marked as repeated")
+	assert.GreaterOrEqual(t, nodeStatus.DoneCount, 3, "The step should have executed at least 3 times")
+}

--- a/internal/testdata/integration/repeat-on-exitcode-fail.yaml
+++ b/internal/testdata/integration/repeat-on-exitcode-fail.yaml
@@ -1,0 +1,23 @@
+name: test-repeat-on-exitcode
+steps:
+  - name: repeat-on-fail
+    command: |
+      #!/bin/bash
+      COUNTER_FILE="/tmp/dagu-test-counter-repeat-on-exitcode"
+      if [ ! -f "$COUNTER_FILE" ]; then
+          echo 1 > "$COUNTER_FILE"
+          exit 1
+      fi
+
+      count=$(cat "$COUNTER_FILE")
+      if [ "$count" -lt 3 ]; then
+          echo $((count + 1)) > "$COUNTER_FILE"
+          exit 1
+      else
+          echo $((count + 1)) > "$COUNTER_FILE"
+          exit 0
+      fi
+    repeatPolicy:
+      exitCode: [1]
+      limit: 5
+      intervalSec: 1


### PR DESCRIPTION
## What does this PR do?

* Introduce case for repeat policy on non-zero exit codes to workflow/node success definition logic

## Why is this needed?
Addresses issue #1051 . Previously although the repeat process was working correctly, nodes were marked as failed due to their non-zero exit code early, not allowing to account for exit codes repeat policy.
