### PR TITLE
fix: handle || and && operators correctly in SSH executor command parsing

### DIFF
--- a/internal/cmdutil/cmd_test.go
+++ b/internal/cmdutil/cmd_test.go
@@ -483,6 +483,11 @@ func TestParsePipedCommandShellOperators(t *testing.T) {
 			input: "$(false || true) && echo ok",
 			want:  [][]string{{"$(false", "||", "true)", "&&", "echo", "ok"}},
 		},
+		{
+			name:  "Issue #1065 - clamscan with grep and OR fallback",
+			input: `clamscan -r / 2>&1 | grep -A 20 "SCAN SUMMARY" || true`,
+			want:  [][]string{{"clamscan", "-r", "/", "2>&1"}, {"grep", "-A", "20", "SCAN SUMMARY", "||", "true"}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -531,6 +536,12 @@ func TestSplitCommandShellOperators(t *testing.T) {
 			input:    "test -f file && cat file || touch file",
 			wantCmd:  "test",
 			wantArgs: []string{"-f", "file", "&&", "cat", "file", "||", "touch", "file"}, // Fixed: || stays as single token
+		},
+		{
+			name:     "Issue #1065 - clamscan command with pipe and OR",
+			input:    `clamscan -r / 2>&1 | grep -A 20 "SCAN SUMMARY" || true`,
+			wantCmd:  "clamscan",
+			wantArgs: []string{"-r", "/", "2>&1", "|", "grep", "-A", "20", "SCAN SUMMARY", "||", "true"},
 		},
 	}
 

--- a/internal/cmdutil/cmd_test.go
+++ b/internal/cmdutil/cmd_test.go
@@ -404,3 +404,149 @@ func TestParsePipedCommandErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestParsePipedCommandShellOperators tests handling of shell operators like || and &&
+func TestParsePipedCommandShellOperators(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    [][]string
+		wantErr bool
+	}{
+		{
+			name:  "OR operator - false || true",
+			input: "false || true",
+			want:  [][]string{{"false", "||", "true"}}, // Currently incorrect behavior
+		},
+		{
+			name:  "AND operator - true && echo success",
+			input: "true && echo success",
+			want:  [][]string{{"true", "&&", "echo", "success"}}, // Should be single command
+		},
+		{
+			name:  "Mixed operators - false || true && echo done",
+			input: "false || true && echo done",
+			want:  [][]string{{"false", "||", "true", "&&", "echo", "done"}}, // Should be single command
+		},
+		{
+			name:  "OR with spaces - false  ||  true",
+			input: "false  ||  true",
+			want:  [][]string{{"false", "||", "true"}}, // Should handle extra spaces
+		},
+		{
+			name:  "Single pipe vs double pipe - echo a | grep a || echo failed",
+			input: "echo a | grep a || echo failed",
+			want:  [][]string{{"echo", "a"}, {"grep", "a", "||", "echo", "failed"}}, // First | is pipe, || is OR
+		},
+		{
+			name:  "Complex shell command",
+			input: "test -f file.txt && cat file.txt || echo 'file not found'",
+			want:  [][]string{{"test", "-f", "file.txt", "&&", "cat", "file.txt", "||", "echo", "file not found"}},
+		},
+		{
+			name:  "Parentheses grouping",
+			input: "(false || true) && echo success",
+			want:  [][]string{{"(false", "||", "true)", "&&", "echo", "success"}},
+		},
+		{
+			name:  "OR in quotes should not be parsed",
+			input: `echo "false || true"`,
+			want:  [][]string{{"echo", "false || true"}}, // Quoted || should remain intact
+		},
+		{
+			name:  "AND in quotes should not be parsed",
+			input: `echo "true && false"`,
+			want:  [][]string{{"echo", "true && false"}}, // Quoted && should remain intact
+		},
+		{
+			name:  "Mixed pipe and OR",
+			input: "ps aux | grep process || echo 'not found'",
+			want:  [][]string{{"ps", "aux"}, {"grep", "process", "||", "echo", "not found"}},
+		},
+		{
+			name:  "Triple pipe edge case",
+			input: "echo a ||| echo b",
+			want:  [][]string{{"echo", "a", "||"}, {"echo", "b"}}, // ||| = | + ||
+		},
+		{
+			name:  "Semicolon operator",
+			input: "echo first; echo second",
+			want:  [][]string{{"echo", "first;", "echo", "second"}}, // Semicolon not handled specially
+		},
+		{
+			name:  "Background operator",
+			input: "sleep 10 &",
+			want:  [][]string{{"sleep", "10", "&"}}, // & not handled specially
+		},
+		{
+			name:  "Subshell with operators",
+			input: "$(false || true) && echo ok",
+			want:  [][]string{{"$(false", "||", "true)", "&&", "echo", "ok"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePipedCommand(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParsePipedCommand() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParsePipedCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSplitCommandShellOperators tests SplitCommand behavior with shell operators
+func TestSplitCommandShellOperators(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantCmd  string
+		wantArgs []string
+		wantErr  bool
+	}{
+		{
+			name:     "OR operator - false || true",
+			input:    "false || true",
+			wantCmd:  "false",
+			wantArgs: []string{"||", "true"}, // Correct behavior: || stays as single token
+		},
+		{
+			name:     "AND operator - true && echo success",
+			input:    "true && echo success",
+			wantCmd:  "true",
+			wantArgs: []string{"&&", "echo", "success"},
+		},
+		{
+			name:     "Mixed pipe and OR",
+			input:    "echo hello | grep hello || echo not found",
+			wantCmd:  "echo",
+			wantArgs: []string{"hello", "|", "grep", "hello", "||", "echo", "not", "found"}, // Fixed: || stays as single token
+		},
+		{
+			name:     "Complex conditional",
+			input:    "test -f file && cat file || touch file",
+			wantCmd:  "test",
+			wantArgs: []string{"-f", "file", "&&", "cat", "file", "||", "touch", "file"}, // Fixed: || stays as single token
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCmd, gotArgs, err := SplitCommand(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SplitCommand() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotCmd != tt.wantCmd {
+				t.Errorf("SplitCommand() gotCmd = %v, want %v", gotCmd, tt.wantCmd)
+			}
+			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Errorf("SplitCommand() gotArgs = %v, want %v", gotArgs, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/internal/digraph/executor/ssh.go
+++ b/internal/digraph/executor/ssh.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/dagu-org/dagu/internal/digraph"
+	"github.com/dagu-org/dagu/internal/fileutil"
 )
 
 var _ Executor = (*sshExec)(nil)
@@ -47,14 +48,15 @@ type sshExecConfig struct {
 // If the key is provided, it will use the public key authentication method.
 // Otherwise, it will use the password authentication method.
 func selectSSHAuthMethod(cfg *sshExecConfig) (ssh.AuthMethod, error) {
-	var (
-		signer ssh.Signer
-		err    error
-	)
+	var signer ssh.Signer
 
 	if len(cfg.Key) != 0 {
 		// Create the Signer for this private key.
-		if signer, err = getPublicKeySigner(cfg.Key); err != nil {
+		keyPath, err := fileutil.ResolvePath(cfg.Key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve key path: %w", err)
+		}
+		if signer, err = getPublicKeySigner(keyPath); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
**Overview**
Users reported that SSH executor was failing to run commands with `||` operator correctly. The command would complete too quickly and produce unexpected errors like "grep: SUMMARY: No such file or directory".

As a solution, this PR fixes the command parsing logic to treat `||` and `&&` as single tokens instead of splitting them into separate pipe operators.

Issue: #1065
Feedback-from: @phscherer

**Changes**
- Modified `ParsePipedCommand` to recognize `||` and `&&` as single tokens
- Added comprehensive tests for shell operators (||, &&, mixed pipes)
- Added specific test cases for the exact command from issue #1065

**Example**
```yaml
steps:
  - name: scan with fallback
    executor: ssh
    config:
      user: root
      ip: 192.168.1.100
      key: ~/.ssh/id_rsa
    command: clamscan -r / 2>&1 | grep -A 20 "SCAN SUMMARY" || true
```

Previously, this would fail because `||` was parsed as two separate `|` tokens. Now it correctly preserves the OR operator, allowing the command to run as intended on the remote server.