### PR TITLE
fix: correct DAG JSON schema for schedule field

### DIFF
--- a/schemas/dag.schema.json
+++ b/schemas/dag.schema.json
@@ -33,8 +33,72 @@
       "description": "Specifies candidate .env files to load environment variables from. By default, no env files are loaded unless explicitly specified."
     },
     "schedule": {
-      "type": "string",
-      "description": "Cron expression that determines how often the DAG triggers (e.g., '5 4 * * *' runs daily at 04:05). If omitted, the DAG will only run manually."
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Single cron expression for starting the DAG (e.g., '5 4 * * *' runs daily at 04:05)"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Multiple cron expressions for starting the DAG at different times"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "start": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Single cron expression for starting the DAG"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Multiple cron expressions for starting the DAG"
+                }
+              ]
+            },
+            "stop": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Single cron expression for stopping the DAG"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Multiple cron expressions for stopping the DAG"
+                }
+              ]
+            },
+            "restart": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Single cron expression for restarting the DAG"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Multiple cron expressions for restarting the DAG"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "description": "Advanced scheduling with separate start, stop, and restart schedules"
+        }
+      ],
+      "description": "Schedule configuration for the DAG. Can be a simple cron expression, multiple cron expressions, or an object with start/stop/restart schedules. If omitted, the DAG will only run manually."
     },
     "skipIfSuccessful": {
       "type": "boolean",


### PR DESCRIPTION
**Overview**
The DAG JSON schema had an incorrect definition for the `schedule` field. It only allowed a simple string, but the actual implementation supports multiple formats including arrays and objects with start/stop/restart schedules.

**Changes**
- Updated `schedule` field in `schemas/dag.schema.json` to properly support all valid formats:
  - Single cron expression (string): `"0 1 * * *"`
  - Multiple cron expressions (array): `["0 1 * * *", "0 13 * * *"]`
  - Advanced scheduling (object): `{start: "0 8 * * *", stop: "0 18 * * *", restart: "0 12 * * *"}`

**Example**
```yaml
# All these are now correctly validated by the schema:
schedule: "0 1 * * *"

schedule:
  - "0 1 * * *"
  - "0 13 * * *"

schedule:
  start: "0 8 * * MON-FRI"
  stop: "0 18 * * MON-FRI"
  restart: "0 12 * * MON-FRI"
```