### PR TITLE
feat: add live log loading mode with reload button

### DIFF
--- a/ui/src/components/ui/reload-button.tsx
+++ b/ui/src/components/ui/reload-button.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+
+interface ReloadButtonProps {
+  onReload: () => void | Promise<void>;
+  isLoading?: boolean;
+  disabled?: boolean;
+  className?: string;
+  title?: string;
+}
+
+export const ReloadButton: React.FC<ReloadButtonProps> = ({
+  onReload,
+  isLoading = false,
+  disabled = false,
+  className = '',
+  title = 'Reload',
+}) => {
+  const [isReloading, setIsReloading] = useState(false);
+
+  const handleClick = async () => {
+    setIsReloading(true);
+    try {
+      await onReload();
+      // Brief success state
+      setTimeout(() => setIsReloading(false), 500);
+    } catch {
+      setIsReloading(false);
+    }
+  };
+
+  const isDisabled = disabled || isLoading || isReloading;
+  
+  return (
+    <button
+      onClick={handleClick}
+      disabled={isDisabled}
+      className={`
+        inline-flex items-center justify-center px-2.5 py-1 rounded-full text-xs
+        transition-all duration-200 ease-in-out transform
+        ${
+          isReloading
+            ? 'bg-blue-500 text-white scale-90'
+            : isDisabled
+            ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-400 cursor-not-allowed'
+            : 'bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-300 dark:hover:bg-zinc-600 hover:scale-110 active:scale-95'
+        }
+        ${className}
+      `}
+      title={title}
+    >
+      <svg
+        className={`w-4 h-4 ${isReloading || isLoading ? 'animate-spin' : ''} transition-transform duration-200`}
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+        />
+      </svg>
+    </button>
+  );
+};

--- a/ui/src/features/dags/components/dag-execution/ExecutionLog.tsx
+++ b/ui/src/features/dags/components/dag-execution/ExecutionLog.tsx
@@ -65,6 +65,7 @@ function ExecutionLog({ name, dagRunId, dagRun, stream = 'stdout' }: Props) {
   // Default to live mode if explicitly running
   const defaultLiveMode = isRunningStatus;
   const [isLiveMode, setIsLiveMode] = useState(defaultLiveMode);
+  const [isReloading, setIsReloading] = useState(false);
 
   // Keep track of previous data to prevent flashing
   const [cachedData, setCachedData] = useState<LogWithPagination | null>(null);
@@ -346,25 +347,34 @@ function ExecutionLog({ name, dagRunId, dagRun, stream = 'stdout' }: Props) {
           <div className="flex items-center gap-2 ml-auto">
             {/* Reload button */}
             <button
-              onClick={() => {
+              onClick={async () => {
                 if (mutate) {
-                  mutate();
+                  setIsReloading(true);
+                  try {
+                    await mutate();
+                    // Brief success state
+                    setTimeout(() => setIsReloading(false), 500);
+                  } catch {
+                    setIsReloading(false);
+                  }
                 }
               }}
-              disabled={isNavigating || isLoading}
+              disabled={isNavigating || isLoading || isReloading}
               className={`
-                inline-flex items-center justify-center w-8 h-8 rounded-full text-xs
-                transition-all duration-200 ease-in-out
+                inline-flex items-center justify-center px-2.5 py-1 rounded-full text-xs
+                transition-all duration-200 ease-in-out transform
                 ${
-                  isNavigating || isLoading
+                  isReloading
+                    ? 'bg-blue-500 text-white scale-90'
+                    : isNavigating || isLoading
                     ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-400 cursor-not-allowed'
-                    : 'bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-300 dark:hover:bg-zinc-600'
+                    : 'bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-300 dark:hover:bg-zinc-600 hover:scale-110 active:scale-95'
                 }
               `}
               title="Reload logs"
             >
               <svg
-                className={`w-4 h-4 ${isNavigating || isLoading ? 'animate-spin' : ''}`}
+                className={`w-4 h-4 ${isReloading || isNavigating || isLoading ? 'animate-spin' : ''} transition-transform duration-200`}
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"

--- a/ui/src/features/dags/components/dag-execution/ExecutionLog.tsx
+++ b/ui/src/features/dags/components/dag-execution/ExecutionLog.tsx
@@ -4,7 +4,7 @@
  * @module features/dags/components/dag-execution
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { components } from '../../../../api/v2/schema';
+import { components, Status } from '../../../../api/v2/schema';
 import { Button } from '../../../../components/ui/button';
 import { AppBarContext } from '../../../../contexts/AppBarContext';
 import { useQuery } from '../../../../hooks/api';
@@ -62,6 +62,10 @@ function ExecutionLog({
   const [pageSize, setPageSize] = useState(1000);
   const [currentPage, setCurrentPage] = useState(1);
   const [jumpToLine, setJumpToLine] = useState<number | ''>('');
+  // Check if the DAG is running
+  const isRunning = dagRun?.status?.status === Status.Running;
+  
+  const [isLiveMode, setIsLiveMode] = useState(isRunning);
 
   // Keep track of previous data to prevent flashing
   const [cachedData, setCachedData] = useState<LogWithPagination | null>(null);
@@ -121,7 +125,7 @@ function ExecutionLog({
       },
     },
     {
-      refreshInterval: 30000, // Refresh every 30 seconds
+      refreshInterval: isLiveMode && isRunning ? 2000 : 0, // 2s in live mode, 0 (disabled) otherwise
       keepPreviousData: true, // Keep previous data while loading new data
       revalidateOnFocus: false, // Don't revalidate when window regains focus
       dedupingInterval: 1000, // Deduplicate requests within 1 second
@@ -340,6 +344,29 @@ function ExecutionLog({
             <option value="5000">5000 lines</option>
             <option value="10000">10000 lines</option>
           </select>
+
+          {/* Live mode toggle - only show when DAG is running */}
+          {isRunning && (
+            <div className="flex items-center gap-1 ml-auto">
+              <button
+                onClick={() => setIsLiveMode(!isLiveMode)}
+                className={`
+                  relative inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium
+                  transition-all duration-200 ease-in-out
+                  ${isLiveMode 
+                    ? 'bg-green-500 text-white shadow-lg shadow-green-500/25' 
+                    : 'bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-300 dark:hover:bg-zinc-600'
+                  }
+                `}
+              >
+                <span className={`
+                  inline-block w-2 h-2 rounded-full
+                  ${isLiveMode ? 'bg-white animate-pulse' : 'bg-zinc-400 dark:bg-zinc-500'}
+                `} />
+                <span>LIVE</span>
+              </button>
+            </div>
+          )}
         </div>
         
         {/* Stats line - full width on mobile */}

--- a/ui/src/features/dags/components/dag-execution/ExecutionLog.tsx
+++ b/ui/src/features/dags/components/dag-execution/ExecutionLog.tsx
@@ -116,7 +116,7 @@ function ExecutionLog({
       };
 
   // Fetch log data with periodic refresh
-  const { data, isLoading, error } = useQuery(
+  const { data, isLoading, error, mutate } = useQuery(
     apiEndpoint,
     {
       params: {
@@ -345,9 +345,43 @@ function ExecutionLog({
             <option value="10000">10000 lines</option>
           </select>
 
-          {/* Live mode toggle - only show when DAG is running */}
-          {isRunning && (
-            <div className="flex items-center gap-1 ml-auto">
+          {/* Live mode toggle and reload button */}
+          <div className="flex items-center gap-2 ml-auto">
+            {/* Reload button */}
+            <button
+              onClick={() => {
+                if (mutate) {
+                  mutate();
+                }
+              }}
+              disabled={isNavigating || isLoading}
+              className={`
+                inline-flex items-center justify-center w-8 h-8 rounded-full text-xs
+                transition-all duration-200 ease-in-out
+                ${isNavigating || isLoading
+                  ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-400 cursor-not-allowed'
+                  : 'bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-300 dark:hover:bg-zinc-600'
+                }
+              `}
+              title="Reload logs"
+            >
+              <svg 
+                className={`w-4 h-4 ${isNavigating || isLoading ? 'animate-spin' : ''}`} 
+                fill="none" 
+                stroke="currentColor" 
+                viewBox="0 0 24 24"
+              >
+                <path 
+                  strokeLinecap="round" 
+                  strokeLinejoin="round" 
+                  strokeWidth={2} 
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" 
+                />
+              </svg>
+            </button>
+
+            {/* Live mode toggle - only show when DAG is running */}
+            {isRunning && (
               <button
                 onClick={() => setIsLiveMode(!isLiveMode)}
                 className={`
@@ -365,8 +399,8 @@ function ExecutionLog({
                 `} />
                 <span>LIVE</span>
               </button>
-            </div>
-          )}
+            )}
+          </div>
         </div>
         
         {/* Stats line - full width on mobile */}

--- a/ui/src/features/dags/components/dag-execution/ExecutionLog.tsx
+++ b/ui/src/features/dags/components/dag-execution/ExecutionLog.tsx
@@ -6,6 +6,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { components, Status } from '../../../../api/v2/schema';
 import { Button } from '../../../../components/ui/button';
+import { ReloadButton } from '../../../../components/ui/reload-button';
 import { AppBarContext } from '../../../../contexts/AppBarContext';
 import { useQuery } from '../../../../hooks/api';
 import LoadingIndicator from '../../../../ui/LoadingIndicator';
@@ -65,7 +66,6 @@ function ExecutionLog({ name, dagRunId, dagRun, stream = 'stdout' }: Props) {
   // Default to live mode if explicitly running
   const defaultLiveMode = isRunningStatus;
   const [isLiveMode, setIsLiveMode] = useState(defaultLiveMode);
-  const [isReloading, setIsReloading] = useState(false);
 
   // Keep track of previous data to prevent flashing
   const [cachedData, setCachedData] = useState<LogWithPagination | null>(null);
@@ -346,47 +346,15 @@ function ExecutionLog({ name, dagRunId, dagRun, stream = 'stdout' }: Props) {
           {/* Live mode toggle and reload button */}
           <div className="flex items-center gap-2 ml-auto">
             {/* Reload button */}
-            <button
-              onClick={async () => {
+            <ReloadButton
+              onReload={async () => {
                 if (mutate) {
-                  setIsReloading(true);
-                  try {
-                    await mutate();
-                    // Brief success state
-                    setTimeout(() => setIsReloading(false), 500);
-                  } catch {
-                    setIsReloading(false);
-                  }
+                  await mutate();
                 }
               }}
-              disabled={isNavigating || isLoading || isReloading}
-              className={`
-                inline-flex items-center justify-center px-2.5 py-1 rounded-full text-xs
-                transition-all duration-200 ease-in-out transform
-                ${
-                  isReloading
-                    ? 'bg-blue-500 text-white scale-90'
-                    : isNavigating || isLoading
-                    ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-400 cursor-not-allowed'
-                    : 'bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-300 dark:hover:bg-zinc-600 hover:scale-110 active:scale-95'
-                }
-              `}
+              isLoading={isNavigating || isLoading}
               title="Reload logs"
-            >
-              <svg
-                className={`w-4 h-4 ${isReloading || isNavigating || isLoading ? 'animate-spin' : ''} transition-transform duration-200`}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-                />
-              </svg>
-            </button>
+            />
 
             {/* Live mode toggle - only show when DAG is running */}
             {isRunningStatus && (

--- a/ui/src/features/dags/components/dag-execution/StepLog.tsx
+++ b/ui/src/features/dags/components/dag-execution/StepLog.tsx
@@ -124,7 +124,7 @@ function StepLog({
       };
 
   // Fetch log data with periodic refresh
-  const { data, isLoading, error } = useQuery(
+  const { data, isLoading, error, mutate } = useQuery(
     apiEndpoint,
     {
       params: {
@@ -352,9 +352,43 @@ function StepLog({
             <option value="5000">5000 lines</option>
           </select>
 
-          {/* Live mode toggle - only show when node is running */}
-          {isRunning && (
-            <div className="flex items-center gap-1 ml-auto">
+          {/* Live mode toggle and reload button */}
+          <div className="flex items-center gap-2 ml-auto">
+            {/* Reload button */}
+            <button
+              onClick={() => {
+                if (mutate) {
+                  mutate();
+                }
+              }}
+              disabled={isNavigating || isLoading}
+              className={`
+                inline-flex items-center justify-center w-8 h-8 rounded-full text-xs
+                transition-all duration-200 ease-in-out
+                ${isNavigating || isLoading
+                  ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-400 cursor-not-allowed'
+                  : 'bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-300 dark:hover:bg-zinc-600'
+                }
+              `}
+              title="Reload logs"
+            >
+              <svg 
+                className={`w-4 h-4 ${isNavigating || isLoading ? 'animate-spin' : ''}`} 
+                fill="none" 
+                stroke="currentColor" 
+                viewBox="0 0 24 24"
+              >
+                <path 
+                  strokeLinecap="round" 
+                  strokeLinejoin="round" 
+                  strokeWidth={2} 
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" 
+                />
+              </svg>
+            </button>
+
+            {/* Live mode toggle - only show when node is running */}
+            {isRunning && (
               <button
                 onClick={() => setIsLiveMode(!isLiveMode)}
                 className={`
@@ -372,8 +406,8 @@ function StepLog({
                 `} />
                 <span>LIVE</span>
               </button>
-            </div>
-          )}
+            )}
+          </div>
         </div>
         
         {/* Stats line - full width on mobile */}

--- a/ui/src/features/dags/components/dag-execution/StepLog.tsx
+++ b/ui/src/features/dags/components/dag-execution/StepLog.tsx
@@ -6,6 +6,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { components, NodeStatus } from '../../../../api/v2/schema';
 import { Button } from '../../../../components/ui/button';
+import { ReloadButton } from '../../../../components/ui/reload-button';
 import { AppBarContext } from '../../../../contexts/AppBarContext';
 import { useQuery } from '../../../../hooks/api';
 import LoadingIndicator from '../../../../ui/LoadingIndicator';
@@ -72,7 +73,6 @@ function StepLog({
   const isRunning = node?.status === NodeStatus.Running;
   
   const [isLiveMode, setIsLiveMode] = useState(isRunning);
-  const [isReloading, setIsReloading] = useState(false);
 
   // Keep track of previous data to prevent flashing
   const [cachedData, setCachedData] = useState<LogWithPagination | null>(null);
@@ -356,47 +356,15 @@ function StepLog({
           {/* Live mode toggle and reload button */}
           <div className="flex items-center gap-2 ml-auto">
             {/* Reload button */}
-            <button
-              onClick={async () => {
+            <ReloadButton
+              onReload={async () => {
                 if (mutate) {
-                  setIsReloading(true);
-                  try {
-                    await mutate();
-                    // Brief success state
-                    setTimeout(() => setIsReloading(false), 500);
-                  } catch {
-                    setIsReloading(false);
-                  }
+                  await mutate();
                 }
               }}
-              disabled={isNavigating || isLoading || isReloading}
-              className={`
-                inline-flex items-center justify-center px-2.5 py-1 rounded-full text-xs
-                transition-all duration-200 ease-in-out transform
-                ${
-                  isReloading
-                    ? 'bg-blue-500 text-white scale-90'
-                    : isNavigating || isLoading
-                    ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-400 cursor-not-allowed'
-                    : 'bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-300 dark:hover:bg-zinc-600 hover:scale-110 active:scale-95'
-                }
-              `}
+              isLoading={isNavigating || isLoading}
               title="Reload logs"
-            >
-              <svg 
-                className={`w-4 h-4 ${isReloading || isNavigating || isLoading ? 'animate-spin' : ''} transition-transform duration-200`} 
-                fill="none" 
-                stroke="currentColor" 
-                viewBox="0 0 24 24"
-              >
-                <path 
-                  strokeLinecap="round" 
-                  strokeLinejoin="round" 
-                  strokeWidth={2} 
-                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" 
-                />
-              </svg>
-            </button>
+            />
 
             {/* Live mode toggle - only show when node is running */}
             {isRunning && (

--- a/ui/src/features/dags/components/dag-execution/StepLog.tsx
+++ b/ui/src/features/dags/components/dag-execution/StepLog.tsx
@@ -4,7 +4,7 @@
  * @module features/dags/components/dag-execution
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { components } from '../../../../api/v2/schema';
+import { components, NodeStatus } from '../../../../api/v2/schema';
 import { Button } from '../../../../components/ui/button';
 import { AppBarContext } from '../../../../contexts/AppBarContext';
 import { useQuery } from '../../../../hooks/api';
@@ -68,6 +68,10 @@ function StepLog({
   const [pageSize, setPageSize] = useState(1000);
   const [currentPage, setCurrentPage] = useState(1);
   const [jumpToLine, setJumpToLine] = useState<number | ''>('');
+  // Check if the node is running
+  const isRunning = node?.status === NodeStatus.Running;
+  
+  const [isLiveMode, setIsLiveMode] = useState(isRunning);
 
   // Keep track of previous data to prevent flashing
   const [cachedData, setCachedData] = useState<LogWithPagination | null>(null);
@@ -129,7 +133,7 @@ function StepLog({
       },
     },
     {
-      refreshInterval: 30000, // Refresh every 30 seconds
+      refreshInterval: isLiveMode && isRunning ? 2000 : 0, // 2s in live mode, 0 (disabled) otherwise
       keepPreviousData: true, // Keep previous data while loading new data
       revalidateOnFocus: false, // Don't revalidate when window regains focus
       dedupingInterval: 1000, // Deduplicate requests within 1 second
@@ -347,6 +351,29 @@ function StepLog({
             <option value="1000">1000 lines</option>
             <option value="5000">5000 lines</option>
           </select>
+
+          {/* Live mode toggle - only show when node is running */}
+          {isRunning && (
+            <div className="flex items-center gap-1 ml-auto">
+              <button
+                onClick={() => setIsLiveMode(!isLiveMode)}
+                className={`
+                  relative inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium
+                  transition-all duration-200 ease-in-out
+                  ${isLiveMode 
+                    ? 'bg-green-500 text-white shadow-lg shadow-green-500/25' 
+                    : 'bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-300 dark:hover:bg-zinc-600'
+                  }
+                `}
+              >
+                <span className={`
+                  inline-block w-2 h-2 rounded-full
+                  ${isLiveMode ? 'bg-white animate-pulse' : 'bg-zinc-400 dark:bg-zinc-500'}
+                `} />
+                <span>LIVE</span>
+              </button>
+            </div>
+          )}
         </div>
         
         {/* Stats line - full width on mobile */}

--- a/ui/src/features/dags/components/dag-execution/StepLog.tsx
+++ b/ui/src/features/dags/components/dag-execution/StepLog.tsx
@@ -72,6 +72,7 @@ function StepLog({
   const isRunning = node?.status === NodeStatus.Running;
   
   const [isLiveMode, setIsLiveMode] = useState(isRunning);
+  const [isReloading, setIsReloading] = useState(false);
 
   // Keep track of previous data to prevent flashing
   const [cachedData, setCachedData] = useState<LogWithPagination | null>(null);
@@ -356,24 +357,34 @@ function StepLog({
           <div className="flex items-center gap-2 ml-auto">
             {/* Reload button */}
             <button
-              onClick={() => {
+              onClick={async () => {
                 if (mutate) {
-                  mutate();
+                  setIsReloading(true);
+                  try {
+                    await mutate();
+                    // Brief success state
+                    setTimeout(() => setIsReloading(false), 500);
+                  } catch {
+                    setIsReloading(false);
+                  }
                 }
               }}
-              disabled={isNavigating || isLoading}
+              disabled={isNavigating || isLoading || isReloading}
               className={`
-                inline-flex items-center justify-center w-8 h-8 rounded-full text-xs
-                transition-all duration-200 ease-in-out
-                ${isNavigating || isLoading
-                  ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-400 cursor-not-allowed'
-                  : 'bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-300 dark:hover:bg-zinc-600'
+                inline-flex items-center justify-center px-2.5 py-1 rounded-full text-xs
+                transition-all duration-200 ease-in-out transform
+                ${
+                  isReloading
+                    ? 'bg-blue-500 text-white scale-90'
+                    : isNavigating || isLoading
+                    ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-400 cursor-not-allowed'
+                    : 'bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-300 dark:hover:bg-zinc-600 hover:scale-110 active:scale-95'
                 }
               `}
               title="Reload logs"
             >
               <svg 
-                className={`w-4 h-4 ${isNavigating || isLoading ? 'animate-spin' : ''}`} 
+                className={`w-4 h-4 ${isReloading || isNavigating || isLoading ? 'animate-spin' : ''} transition-transform duration-200`} 
                 fill="none" 
                 stroke="currentColor" 
                 viewBox="0 0 24 24"


### PR DESCRIPTION
Users need to see real-time log updates when viewing running DAGs. Currently they must manually refresh to see new logs.

This PR adds a LIVE toggle that auto-refreshes logs every 2 seconds for running processes, plus a manual reload button.

Issue: #1084
Feedback-from: @tapir

**Changes**
- Added LIVE toggle (appears for running DAGs/steps, enabled by default)
- Manual reload button with visual feedback
- 2-second refresh interval in live mode
- Fixed scheduler log detection
- Refactored reload button as reusable component