### PR TITLE
[#1081] feat: enable errexit flag by default for shell executors

### DIFF
--- a/docs/features/executors/shell.md
+++ b/docs/features/executors/shell.md
@@ -10,6 +10,40 @@ steps:
     command: echo "Hello, World!"  # Shell executor is default
 ```
 
+## Errexit Mode (Exit on Error)
+
+Starting from v1.XX, Dagu enables the errexit flag (`-e`) by default for shell executors when no specific shell is configured. This means multi-line commands will stop execution on the first error:
+
+```yaml
+steps:
+  # Default behavior - errexit enabled
+  - name: safe-by-default
+    command: |
+      false  # This will cause the step to fail
+      echo "This won't execute"  # Script stops here
+
+  # Specify shell to control errexit
+  - name: continue-on-error
+    shell: bash  # No -e flag when shell is specified
+    command: |
+      false  # Command fails but continues
+      echo "This will execute"
+
+  # Explicitly enable errexit
+  - name: explicit-errexit
+    shell: bash -e
+    command: |
+      false  # Step fails immediately
+      echo "This won't execute"
+
+  # Disable errexit if needed
+  - name: disable-errexit
+    command: |
+      set +e  # Disable errexit
+      false  # Command fails but continues
+      echo "This will execute"
+```
+
 ## Writing Scripts
 
 ```yaml
@@ -17,7 +51,7 @@ steps:
   - name: script-example
     shell: bash  # Specify shell if needed
     script: |
-      set -e  # Exit on error
+      # No need for 'set -e' with default shell
       echo "Running script..."
       python process.py  # Run a Python script
 ```
@@ -104,7 +138,7 @@ steps:
   - name: script
     script: |
       #!/bin/bash
-      set -e
+      # errexit is enabled by default, no need for 'set -e'
       find /data -name "*.csv" -exec process {} \;
       
   # Working directory

--- a/docs/features/executors/shell.md
+++ b/docs/features/executors/shell.md
@@ -22,19 +22,26 @@ steps:
       false  # This will cause the step to fail
       echo "This won't execute"  # Script stops here
 
-  # Specify shell to control errexit
+  # Specify shell to bypass default errexit
   - name: continue-on-error
     shell: bash  # No -e flag when shell is specified
     command: |
       false  # Command fails but continues
       echo "This will execute"
 
-  # Explicitly enable errexit
+  # Explicitly enable errexit with options
   - name: explicit-errexit
-    shell: bash -e
+    shell: bash -e  # Add -e flag manually
     command: |
       false  # Step fails immediately
       echo "This won't execute"
+      
+  # Multiple shell options
+  - name: strict-mode
+    shell: bash -euo pipefail  # Enable strict error handling
+    command: |
+      set -x  # Also enable debug output
+      echo "Running with strict mode"
 
   # Disable errexit if needed
   - name: disable-errexit
@@ -70,6 +77,10 @@ steps:
   - name: custom-shell
     shell: /usr/local/bin/fish
     command: echo "Using Fish shell"
+    
+  - name: with-options
+    shell: bash -euo pipefail  # Add custom shell options
+    command: echo "Strict mode enabled"
 ```
 
 ### Nix Shell

--- a/internal/digraph/executor/command.go
+++ b/internal/digraph/executor/command.go
@@ -216,10 +216,12 @@ func (b *shellCommandBuilder) Build(ctx context.Context) (*exec.Cmd, error) {
 
 	default:
 		// other shell (sh, bash, zsh, etc.)
-		args = append(args, b.Args...)
 		if b.Command != "" && b.Script != "" {
-			return exec.CommandContext(ctx, b.Command, append(args, b.Script)...), nil // nolint: gosec
+			// When running a command directly with a script (e.g., perl script.pl),
+			// don't include shell arguments like -e
+			return exec.CommandContext(ctx, b.Command, append(b.Args, b.Script)...), nil // nolint: gosec
 		}
+		args = append(args, b.Args...)
 		if !slices.Contains(args, "-c") {
 			args = append(args, "-c")
 		}

--- a/internal/digraph/executor/command_errexit_simple_test.go
+++ b/internal/digraph/executor/command_errexit_simple_test.go
@@ -1,0 +1,121 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/dagu-org/dagu/internal/digraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandExecutor_ErrexitSimple(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping errexit tests on Windows")
+	}
+
+	setupTest := func(step digraph.Step) context.Context {
+		// Create a minimal DAG for testing
+		dag := &digraph.DAG{
+			Name: "test-dag",
+			Env:  []string{},
+		}
+
+		// Set up the digraph environment
+		ctx := digraph.SetupEnv(
+			context.Background(),
+			dag,
+			nil, // database
+			digraph.DAGRunRef{},
+			"test-run-id",
+			"/tmp/test.log",
+			[]string{},
+		)
+
+		// Set up the executor environment
+		return WithEnv(ctx, NewEnv(ctx, step))
+	}
+
+	t.Run("DefaultShell_WithErrexitFlag", func(t *testing.T) {
+		// Simulate how the scheduler would set up a step
+		step := digraph.Step{
+			Name:         "test",
+			ShellCmdArgs: `false && echo "This should not execute"`,
+		}
+
+		ctx := setupTest(step)
+
+		cfg, err := createCommandConfig(ctx, step)
+		require.NoError(t, err)
+
+		// Check that -e flag was added to shell command
+		assert.Contains(t, cfg.ShellCommand, " -e", "Default shell should have -e flag added")
+
+		executor := &commandExecutor{config: cfg}
+
+		var stdout, stderr bytes.Buffer
+		executor.SetStdout(&stdout)
+		executor.SetStderr(&stderr)
+
+		err = executor.Run(ctx)
+		assert.Error(t, err, "Command should fail due to 'false' command")
+		assert.NotContains(t, stdout.String(), "This should not execute",
+			"Second command should not run after failure with errexit")
+	})
+
+	t.Run("UserSpecifiedShell_NoErrexitFlag", func(t *testing.T) {
+		step := digraph.Step{
+			Name:         "test",
+			Shell:        "bash",
+			ShellCmdArgs: `false; echo "This should execute"`,
+		}
+
+		ctx := setupTest(step)
+
+		cfg, err := createCommandConfig(ctx, step)
+		require.NoError(t, err)
+
+		// Check that -e flag was NOT added
+		assert.Equal(t, "bash", cfg.ShellCommand, "User-specified shell should not have -e flag added")
+
+		executor := &commandExecutor{config: cfg}
+
+		var stdout, stderr bytes.Buffer
+		executor.SetStdout(&stdout)
+		executor.SetStderr(&stderr)
+
+		err = executor.Run(ctx)
+		assert.NoError(t, err, "Command should succeed overall")
+		assert.Contains(t, stdout.String(), "This should execute",
+			"Second command should run when user specifies shell without errexit")
+	})
+
+	t.Run("UserSpecifiedShell_WithExplicitErrexitFlag", func(t *testing.T) {
+		step := digraph.Step{
+			Name:         "test",
+			Shell:        "bash -e",
+			ShellCmdArgs: `false && echo "This should not execute"`,
+		}
+
+		ctx := setupTest(step)
+
+		cfg, err := createCommandConfig(ctx, step)
+		require.NoError(t, err)
+
+		// Check that user's shell command is preserved
+		assert.Equal(t, "bash -e", cfg.ShellCommand, "User-specified shell with -e should be preserved")
+
+		executor := &commandExecutor{config: cfg}
+
+		var stdout, stderr bytes.Buffer
+		executor.SetStdout(&stdout)
+		executor.SetStderr(&stderr)
+
+		err = executor.Run(ctx)
+		assert.Error(t, err, "Command should fail due to 'false' command with -e flag")
+		assert.NotContains(t, stdout.String(), "This should not execute",
+			"Second command should not run when user explicitly adds -e flag")
+	})
+}

--- a/spec/ERREXIT_FLAG_IMPLEMENTATION.md
+++ b/spec/ERREXIT_FLAG_IMPLEMENTATION.md
@@ -242,45 +242,7 @@ Ensure existing DAGs continue to work:
 - DAGs relying on error continuation
 - DAGs with custom error handling
 
-## Migration Guide
-
-### For Users
-
-#### No Action Required If:
-- You explicitly set the `shell` field in your steps
-- You want the new safer behavior for steps without `shell` field
-
-#### Action Required If:
-- You have steps without `shell` field that rely on continuing after errors
-- Solution: Add `shell: bash` (or your preferred shell) to those steps
-
-#### Examples:
-
-```yaml
-# Before: This might break with the update
-steps:
-  - name: cleanup
-    command: |
-      rm -f /tmp/file1  # Might fail if doesn't exist
-      rm -f /tmp/file2  # Previously would continue
-      
-# After: Explicitly disable errexit
-steps:
-  - name: cleanup
-    shell: bash  # Or use: shell: bash +e
-    command: |
-      rm -f /tmp/file1
-      rm -f /tmp/file2
-      
-# Alternative: Use proper error handling
-steps:
-  - name: cleanup
-    command: |
-      rm -f /tmp/file1 || true
-      rm -f /tmp/file2 || true
-```
-
-### Documentation Updates
+## Documentation Updates
 
 1. Remove `set -e` from examples (no longer needed)
 2. Add section explaining errexit is default

--- a/spec/ERREXIT_FLAG_IMPLEMENTATION.md
+++ b/spec/ERREXIT_FLAG_IMPLEMENTATION.md
@@ -1,0 +1,323 @@
+# Enable errexit (-e) Flag by Default for Shell Executors
+
+## Overview
+
+This specification describes the implementation of automatic errexit (`-e`) flag for shell executors in Dagu. The feature aims to prevent multi-line scripts from continuing execution after a command fails, improving reliability and aligning with modern CI/CD best practices.
+
+## Problem Statement
+
+Currently, when executing multi-line shell commands in Dagu, if one command fails, subsequent commands continue to execute:
+
+```yaml
+steps:
+  - name: dangerous-example
+    command: |
+      false  # This fails with exit code 1
+      rm -rf /important/data  # This still executes!
+```
+
+This behavior can lead to:
+- Silent failures in workflows
+- Data corruption or loss
+- Difficult debugging of failed workflows
+- Inconsistent state in systems
+
+## Solution
+
+Enable the errexit flag (`-e`) by default for shell executors, but **only when the user has not explicitly specified a shell**.
+
+### Core Principle
+
+1. **User specifies `shell` field**: Use exactly what they specified, no modifications
+2. **User doesn't specify `shell` field**: Add `-e` flag to the default shell
+
+### Examples
+
+```yaml
+# Case 1: No shell specified - errexit enabled automatically
+steps:
+  - name: safe-by-default
+    command: |
+      false
+      echo "This won't execute"  # Script stops at false
+# Executes as: /bin/sh -e -c "..."
+
+# Case 2: User specifies shell - respect their choice
+steps:
+  - name: user-controlled
+    shell: bash
+    command: |
+      false
+      echo "This will execute"  # No errexit, continues
+# Executes as: bash -c "..."
+
+# Case 3: User explicitly wants errexit
+steps:
+  - name: explicit-safety
+    shell: bash -e
+    command: |
+      false
+      echo "This won't execute"
+# Executes as: bash -e -c "..."
+```
+
+## Implementation Details
+
+### 1. Affected Files
+
+- `/internal/digraph/executor/command.go` - Main implementation
+- `/internal/digraph/executor/command_test.go` - Tests
+- `/docs/features/executors/shell.md` - Documentation updates
+
+### 2. Code Changes
+
+#### 2.1 Modify `createCommandConfig` function
+
+```go
+func createCommandConfig(ctx context.Context, step digraph.Step) (*commandConfig, error) {
+    var shellCommand string
+    
+    if step.Shell != "" {
+        // User explicitly set shell - respect their choice exactly
+        shellCommand = cmdutil.GetShellCommand(step.Shell)
+    } else {
+        // No shell specified - use default with errexit
+        defaultShell := cmdutil.GetShellCommand("")
+        
+        // Add errexit flag for Unix-like shells
+        if isUnixLikeShell(defaultShell) {
+            shellCommand = defaultShell + " -e"
+        } else {
+            shellCommand = defaultShell
+        }
+    }
+    
+    shellCmdArgs := step.ShellCmdArgs
+    
+    return &commandConfig{
+        Ctx:              ctx,
+        Dir:              GetEnv(ctx).WorkingDir,
+        Command:          step.Command,
+        Args:             step.Args,
+        Script:           step.Script,
+        ShellCommand:     shellCommand,
+        ShellCommandArgs: shellCmdArgs,
+        ShellPackages:    step.ShellPackages,
+    }, nil
+}
+```
+
+#### 2.2 Add helper function
+
+```go
+// isUnixLikeShell returns true if the shell supports -e flag
+func isUnixLikeShell(shell string) bool {
+    if shell == "" {
+        return false
+    }
+    
+    // Extract just the executable name (handle full paths)
+    shellName := filepath.Base(shell)
+    
+    switch shellName {
+    case "sh", "bash", "zsh", "ksh", "ash", "dash":
+        return true
+    case "fish":
+        // Fish shell doesn't support -e flag
+        return false
+    default:
+        return false
+    }
+}
+```
+
+#### 2.3 Script file execution
+
+When executing script files, also consider errexit:
+
+```go
+case cfg.ShellCommand != "" && scriptFile != "":
+    // Determine if we should add -e based on whether user specified shell
+    if needsErrexitForScript(ctx, step) {
+        cmd = exec.CommandContext(cfg.Ctx, cfg.ShellCommand, "-e", scriptFile)
+    } else {
+        cmd = exec.CommandContext(cfg.Ctx, cfg.ShellCommand, scriptFile)
+    }
+```
+
+### 3. Special Cases
+
+#### 3.1 Nix-shell
+
+For nix-shell, errexit must be applied to the inner shell:
+
+```go
+case "nix-shell":
+    // ... existing package handling ...
+    
+    if userDidNotSpecifyShell(ctx) {
+        // For inline commands, prepend set -e
+        b.ShellCommandArgs = "set -e; " + b.ShellCommandArgs
+    }
+```
+
+#### 3.2 Environment Variables
+
+The implementation respects these environment variables in order:
+1. Step-level `shell` field (if specified)
+2. `DAGU_DEFAULT_SHELL` environment variable
+3. System `$SHELL` environment variable
+4. Platform defaults (sh on Unix, PowerShell on Windows)
+
+### 4. Shell Support Matrix
+
+| Shell | Supports -e | Implementation |
+|-------|-------------|----------------|
+| sh | Yes | Add -e flag |
+| bash | Yes | Add -e flag |
+| zsh | Yes | Add -e flag |
+| ksh | Yes | Add -e flag |
+| dash | Yes | Add -e flag |
+| ash | Yes | Add -e flag |
+| fish | No | No modification |
+| PowerShell | No | No modification |
+| cmd.exe | No | No modification |
+
+## Testing Strategy
+
+### 1. Unit Tests
+
+```go
+func TestErrexitDefaultBehavior(t *testing.T) {
+    tests := []struct {
+        name        string
+        step        digraph.Step
+        shouldFail  bool
+        shouldAddE  bool
+    }{
+        {
+            name: "no shell specified - adds errexit",
+            step: digraph.Step{
+                Command: "false\necho 'should not print'",
+            },
+            shouldFail: true,
+            shouldAddE: true,
+        },
+        {
+            name: "shell specified - no errexit",
+            step: digraph.Step{
+                Shell:   "bash",
+                Command: "false\necho 'should print'",
+            },
+            shouldFail: false,
+            shouldAddE: false,
+        },
+        {
+            name: "explicit errexit",
+            step: digraph.Step{
+                Shell:   "bash -e",
+                Command: "false\necho 'should not print'",
+            },
+            shouldFail: true,
+            shouldAddE: false, // Already has -e
+        },
+    }
+    
+    // Test implementation...
+}
+```
+
+### 2. Integration Tests
+
+- Test with real multi-line scripts
+- Test with various shell types
+- Test with environment variables
+- Test script file execution
+- Test nix-shell integration
+
+### 3. Backward Compatibility Tests
+
+Ensure existing DAGs continue to work:
+- DAGs with explicit `shell:` field
+- DAGs relying on error continuation
+- DAGs with custom error handling
+
+## Migration Guide
+
+### For Users
+
+#### No Action Required If:
+- You explicitly set the `shell` field in your steps
+- You want the new safer behavior for steps without `shell` field
+
+#### Action Required If:
+- You have steps without `shell` field that rely on continuing after errors
+- Solution: Add `shell: bash` (or your preferred shell) to those steps
+
+#### Examples:
+
+```yaml
+# Before: This might break with the update
+steps:
+  - name: cleanup
+    command: |
+      rm -f /tmp/file1  # Might fail if doesn't exist
+      rm -f /tmp/file2  # Previously would continue
+      
+# After: Explicitly disable errexit
+steps:
+  - name: cleanup
+    shell: bash  # Or use: shell: bash +e
+    command: |
+      rm -f /tmp/file1
+      rm -f /tmp/file2
+      
+# Alternative: Use proper error handling
+steps:
+  - name: cleanup
+    command: |
+      rm -f /tmp/file1 || true
+      rm -f /tmp/file2 || true
+```
+
+### Documentation Updates
+
+1. Remove `set -e` from examples (no longer needed)
+2. Add section explaining errexit is default
+3. Show how to disable with explicit `shell:` field
+4. Update best practices guide
+
+## Security Considerations
+
+This change improves security by:
+- Preventing unintended command execution after failures
+- Reducing risk of partial state changes
+- Making failures more visible and debuggable
+
+## Performance Impact
+
+Minimal - only adds one flag to shell invocation.
+
+## Rollout Plan
+
+1. **v1.XX.0**: Feature released with clear documentation
+2. **Migration period**: Users update DAGs if needed
+3. **Monitoring**: Track any issues or unexpected behaviors
+
+## Future Considerations
+
+1. **Configuration option**: Consider adding global config to disable this behavior
+2. **Per-DAG override**: Allow DAGs to specify default behavior
+3. **Enhanced error messages**: Clearly indicate when errexit stops execution
+
+## Decision Log
+
+- **Why not modify user-specified shells?** Respects user intent and prevents breaking changes
+- **Why add to default shells only?** Provides safety while maintaining flexibility
+- **Why not make it configurable?** Follows principle of safe defaults; users can opt-out via `shell:` field
+
+## References
+
+- GitHub Issue: #1081
+- Shell errexit documentation: `man sh` (see `-e` flag)
+- POSIX specification: IEEE Std 1003.1-2017


### PR DESCRIPTION
**Overview:**
Users need to prevent multi-line shell scripts from continuing execution after a command fails. They have to manually add `set -e` to every script to ensure failures stop execution.

As a solution, Dagu now automatically enables the errexit flag (`-e`) for default shell executors, making scripts fail-fast by default while respecting user choices when they specify a shell.

Issue: #1081

**Changes:**
- Add `-e` flag to default shell when no shell is specified by user
- Respect user's exact shell choice when `shell:` field is set
- Special handling for nix-shell (prepend `set -e;` to commands)
- Add comprehensive tests for errexit behavior
- Update documentation to explain new default behavior

**Example:**
```yaml
steps:
  # Default behavior - errexit enabled automatically
  - name: safe-by-default
    command: |
      false  # This will cause the step to fail
      echo "This won't execute"  # Script stops here

  # User controls behavior by specifying shell
  - name: continue-on-error
    shell: bash  # No -e flag when shell is specified
    command: |
      false  # Command fails but continues
      echo "This will execute"
```