### PR TITLE
feat(scheduler): implement directory locking for scheduler instances

### DIFF
--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -173,7 +173,7 @@ func (c *Context) NewScheduler() (*scheduler.Scheduler, error) {
 	}
 
 	m := scheduler.NewEntryReader(c.Config.Paths.DAGsDir, dr, c.DAGRunMgr, c.Config.Paths.Executable, c.Config.Global.WorkDir)
-	return scheduler.New(c.Config, m, c.DAGRunMgr, c.DAGRunStore, c.QueueStore, c.ProcStore), nil
+	return scheduler.New(c.Config, m, c.DAGRunMgr, c.DAGRunStore, c.QueueStore, c.ProcStore)
 }
 
 // StringParam retrieves a string parameter from the command line flags.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,14 @@ type Global struct {
 
 	// ConfigPath is the path to the configuration file used to load settings.
 	ConfigPath string
+
+	// SchedulerLockStaleThreshold is the time after which a scheduler lock is considered stale.
+	// Default is 30 seconds.
+	SchedulerLockStaleThreshold time.Duration
+
+	// SchedulerLockRetryInterval is the interval between lock acquisition attempts.
+	// Default is 50 milliseconds.
+	SchedulerLockRetryInterval time.Duration
 }
 
 func (cfg *Global) setTimezone() error {

--- a/internal/config/definition.go
+++ b/internal/config/definition.go
@@ -69,6 +69,14 @@ type Definition struct {
 	// Queues contains global queue configuration settings.
 	Queues *queuesDef `mapstructure:"queues"`
 
+	// SchedulerLockStaleThreshold is the time after which a scheduler lock is considered stale.
+	// Default is 30 seconds.
+	SchedulerLockStaleThreshold string `mapstructure:"schedulerLockStaleThreshold"`
+
+	// SchedulerLockRetryInterval is the interval between lock acquisition attempts.
+	// Default is 50 milliseconds.
+	SchedulerLockRetryInterval string `mapstructure:"schedulerLockRetryInterval"`
+
 	// ----------------------------------------------------------------------------
 	// Legacy fields for backward compatibility - Start
 	// These fields are maintained for compatibility with older configuration formats.

--- a/internal/scheduler/setup_test.go
+++ b/internal/scheduler/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/dagu-org/dagu/internal/build"
 	"github.com/dagu-org/dagu/internal/config"
@@ -67,7 +68,11 @@ func setupTest(t *testing.T) testHelper {
 			SuspendFlagsDir: tempDir,
 			DAGRunsDir:      filepath.Join(tempDir, "."+build.Slug, "data", "dag-runs"),
 		},
-		Global: config.Global{WorkDir: tempDir},
+		Global: config.Global{
+			WorkDir:                     tempDir,
+			SchedulerLockStaleThreshold: 30 * time.Second,
+			SchedulerLockRetryInterval:  50 * time.Millisecond,
+		},
 	}
 
 	ds := filedag.New(cfg.Paths.DAGsDir, filedag.WithFlagsBaseDir(cfg.Paths.SuspendFlagsDir))


### PR DESCRIPTION
## What does this PR do?
This PR adds directory-level file-based locking for multiple scheduler instances.

## Why is this needed?
It addresses issue https://github.com/dagu-org/dagu/issues/1055, and implicitly protecting against similar issues to https://github.com/dagu-org/dagu/issues/1054.

## What changed?
- Added `SchedulerLockStaleThreshold` and `SchedulerLockRetryInterval` config vars.
- Updated scheduler initialization and start methods to handle locking.
- Added tests to verify scheduler lock functionality and its helper methods.