### PR TITLE
feat: add exponential backoff support for retry and repeat policies

### DIFF
--- a/api/v1/api.yaml
+++ b/api/v1/api.yaml
@@ -1036,6 +1036,16 @@ components:
         Interval:
           type: integer
           description: "Time in seconds to wait between retry attempts"
+        Backoff:
+          oneOf:
+            - type: boolean
+              description: "When true, uses default multiplier of 2.0"
+            - type: number
+              format: float
+              description: "Custom exponential backoff multiplier"
+        MaxIntervalSec:
+          type: integer
+          description: "Maximum interval in seconds (caps exponential growth)"
 
     ListTagResponse:
       type: object

--- a/api/v2/api.gen.go
+++ b/api/v2/api.gen.go
@@ -518,6 +518,8 @@ type RepeatMode string
 
 // RepeatPolicy Configuration for step repeat behavior
 type RepeatPolicy struct {
+	Backoff *RepeatPolicy_Backoff `json:"backoff,omitempty"`
+
 	// Condition Precondition that must be satisfied before running a step or DAG-run
 	Condition *Condition `json:"condition,omitempty"`
 
@@ -530,8 +532,22 @@ type RepeatPolicy struct {
 	// Limit Maximum number of times to repeat the step
 	Limit *int `json:"limit,omitempty"`
 
+	// MaxIntervalSec Maximum interval in seconds (caps exponential growth)
+	MaxIntervalSec *int `json:"maxIntervalSec,omitempty"`
+
 	// Repeat Repeat execution mode for steps
 	Repeat *RepeatMode `json:"repeat,omitempty"`
+}
+
+// RepeatPolicyBackoff0 When true, uses default multiplier of 2.0
+type RepeatPolicyBackoff0 = bool
+
+// RepeatPolicyBackoff1 Custom exponential backoff multiplier
+type RepeatPolicyBackoff1 = float32
+
+// RepeatPolicy_Backoff defines model for RepeatPolicy.Backoff.
+type RepeatPolicy_Backoff struct {
+	union json.RawMessage
 }
 
 // Schedule Schedule configuration for DAG-run creation
@@ -1052,6 +1068,68 @@ type ExecuteDAGJSONRequestBody ExecuteDAGJSONBody
 
 // UpdateDAGSuspensionStateJSONRequestBody defines body for UpdateDAGSuspensionState for application/json ContentType.
 type UpdateDAGSuspensionStateJSONRequestBody UpdateDAGSuspensionStateJSONBody
+
+// AsRepeatPolicyBackoff0 returns the union data inside the RepeatPolicy_Backoff as a RepeatPolicyBackoff0
+func (t RepeatPolicy_Backoff) AsRepeatPolicyBackoff0() (RepeatPolicyBackoff0, error) {
+	var body RepeatPolicyBackoff0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromRepeatPolicyBackoff0 overwrites any union data inside the RepeatPolicy_Backoff as the provided RepeatPolicyBackoff0
+func (t *RepeatPolicy_Backoff) FromRepeatPolicyBackoff0(v RepeatPolicyBackoff0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeRepeatPolicyBackoff0 performs a merge with any union data inside the RepeatPolicy_Backoff, using the provided RepeatPolicyBackoff0
+func (t *RepeatPolicy_Backoff) MergeRepeatPolicyBackoff0(v RepeatPolicyBackoff0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsRepeatPolicyBackoff1 returns the union data inside the RepeatPolicy_Backoff as a RepeatPolicyBackoff1
+func (t RepeatPolicy_Backoff) AsRepeatPolicyBackoff1() (RepeatPolicyBackoff1, error) {
+	var body RepeatPolicyBackoff1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromRepeatPolicyBackoff1 overwrites any union data inside the RepeatPolicy_Backoff as the provided RepeatPolicyBackoff1
+func (t *RepeatPolicy_Backoff) FromRepeatPolicyBackoff1(v RepeatPolicyBackoff1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeRepeatPolicyBackoff1 performs a merge with any union data inside the RepeatPolicy_Backoff, using the provided RepeatPolicyBackoff1
+func (t *RepeatPolicy_Backoff) MergeRepeatPolicyBackoff1(v RepeatPolicyBackoff1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t RepeatPolicy_Backoff) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *RepeatPolicy_Backoff) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
 
 // AsStepParallelItems0 returns the union data inside the Step_Parallel_Items as a StepParallelItems0
 func (t Step_Parallel_Items) AsStepParallelItems0() (StepParallelItems0, error) {
@@ -5290,120 +5368,122 @@ func (sh *strictHandler) GetMetrics(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+w9aVPkOLJ/RVG7EbMvXgFFd8/sDhH7gYW+XvTBQs+b2B14hLCzqrRtS25JBmo6+O8v",
-	"dFq25aO4Bgi+UVhOpVN5K5X6PklYXjAKVIrJzvdJgTnOQQLXv/Z3374hGXzCOaifKYiEk0ISRic7E7kE",
-	"RHEOiM2R+nt/9y2akwwm0wlRzwssl5PphOqXJ3MHZzrh8K0kHNLJjuQlTCciWUKO1QR/5jCf7Ez+tFUh",
-	"tWWeiq0Ql6urqcItjlcDpzg69IaohGgclvR92sbj/X6AxQYvKWIc/ZBhCUL+gCRDC5D6cc6ERBwSoNIN",
-	"jSOd4oWZ6waIGwAh5keAebK8G/y/lcBX0Q+4NsKjFr2bhoMLL1eFGickJ3Rh5sUSvpAc3nCWt2cWEnOJ",
-	"UixBkhzQnHElBRLU6w4VgQhF748+o7/9NNtWQ3Is0QWRS6Te+Z1R6CDYnLNcTT+aYL9QcqlwFRLnRQ37",
-	"L6yNO9D0rjCX7IZ4vwMcEapPZX4GXK10RigIxYYcZMkpUqTSy38GC0Kp+gbLD6FSamC5VJOEOOaEkrzM",
-	"JzvbU8cJhEpYANdIfSA5kW2sPuJL9RaiXdh1TJ9pcLX5DaTJzvZsNptNh/D5PJ8LiCD0gVBw2EiGDI9y",
-	"wKkii6bUX7Y3zrCA9L86UGMG8hq0OcCLiGAWeAEBXYiEXNNlDjJZor+kMMdlJhERaLsLFQWihoh9SSMy",
-	"hBTwOF5NlArgSOMaovRyNkU5vtTYzWad+Nk5oij+qBYxXNRBlA8hZxI+sXRAzXE9DlE1MI4YryBFcZtk",
-	"LMHZZBrReUcSy1JEtZ0sRYembUxvxo5WAXZKMzsUw3peSCjiSl6499dT9EeSA46o+F+XIJdGkqyyETJl",
-	"pVQGUcgUOEcZW4hOMmio48mghyt8vmCSXUsFKr0+rPykAj9awK/cSM0Ve0uSpcYgR9QhSJxiibVJwShR",
-	"YwNeKTgrgEsChr+cTzDaFZgaLzXCnQfee0UFFgJSRRxFhRoKyqT9z9HnT9acRfm/YpvfQq/FTnziX2Fn",
-	"/4FEKpz2GE2JwaOFFofEPUVyiSXKSyHRGSCBJRFzAik6gznjgHhpTBfW3K0YrItuSfd8ry8LDkKo2RhH",
-	"yRKSr4oQcI6z0hjlxgdPJ8A54xFI6t8oByGUaiSGpapvIQJRJlEOMgrzsoBEQhpFUD9BHIRStawJ2KKq",
-	"RkcA51gmyxhcL6g1YBdY1FE8YywDTFsLXZE0tsAqlmjNuKcWTUU+CaNzsii5Rlr9kpjolUxhTqhBBNNU",
-	"IaJloy0HRisfdLD2vrVKPkBDikQgGsys1kgtiSggIZqxsHfKUcKhk6a12ZqTvytzTDeU/4DPMkDBw8AS",
-	"/CBQUfKCCdAfegZLfE4Yj0224KwsIl4LW5AEZ0g/tg4cBxVxaNkVWp8wvsCU/K4/BGduShGbhkZNiJul",
-	"HSe2AHTpmQ9EaKatFkMBE0a2E0yVaFcKyLvSmv6QOj1NhItPlQcSMUkeI8w5Xk2sBk7LDLpRsiMU9cCr",
-	"AWG5kC7QxRJohZFYsjJTazWMW6/NcmhFUJZ40UNB9VQva4IlLBgnv2vtR9N6KCLWoFJDqDUTdMjzPigb",
-	"GJU29cCwXUO0CTWSZuTogclwhlftaVVcpaYQ2gpph+ECE+lMjg4OjM2pbE3T/N+zggB63s0zQM8JZzQH",
-	"KtE55kRNqb9KgP8ouISkbH3VeEG7Jw21xDTNgH+mQxL2zg9UbxEhD0ECVTPs45XocxJTvHI+IiYUqXcZ",
-	"1x9hfdb2UmdssU8i3sA+4ZBIxldIudv6WzUwulCwtKsp4vb6cjeR5BwOSyrGRM8Jo0nJeZBQEghnGbuI",
-	"KKg2+n46FUasO59yu6rJCDX8g7qkIm5ifqHkWwmIpGqJ5gS4ppVLkl4QuSQUESkMHz0Ky1MEPqyI+UHu",
-	"Wd3BzSuRxJUOw9RonbH2pfKtn4ZNFHHG9PhqHlQeu9ZiWnmPX8r+4BKKx2ak35DY2rrdBpOMVLJkUxO9",
-	"9hkvRoSZPh7qIYl5joAmrKQSOKQoLTUhTGrmWwlCriVg886NFkUAVMvGu6i+BdRk56u4fDigPirzHHPD",
-	"laUogKZDgZWanwhUjR6Mq4K9H7UCDTTDiT3he3ghTqRP8Z0oG+LvTDgs4FJH8FICV2/832944/fdjX/P",
-	"Nn4+3Tj57z/H6Lm/+/YtJ+l7CZG0kHqis4daNs6JKHFmRMMpOuuFMGd2Vy2OdP9vAT+qJdpsMiDVjHa2",
-	"0sn3sTL/iaXgcmtttqOD1LRptv4cid1WcZ/TsXyjlu5WVu2wpIFzj7Ps83yy89t6AtEZFLQ1jbfvRnVb",
-	"C+8t3mZr3SlLQfStOqEpOSdpibM6zEbadSwDxJae0T1ME8jGvs/o60uz+zFu9BtMspLD+BeOyiQBMfp7",
-	"BlwS7yqFwzq9k3Cf8zb9k6ac6HVvi8fJdIDZ2DxwoAhNslLv5dQTmwZ6XPY6dql7XVXLZXCJ8yLTG1Za",
-	"cV9TIJ1ktZ1H73u3PvVW0sXKzRNLSHcjO2WHb/bQy5cvf9YqVe8+Gncw5Af3ftTiskUsDy2XLvXsIqO+",
-	"BNWoYoPuoOCwpHoHt+hKf49NfOspgMoxRQ1mZDtlEIc1rPmH4X0robz+Il5ggQyEGGzO2KivVuP6cKzg",
-	"DH/xECytgq7/wfb1Dsh2d2/Mhpwb/wGfDRuLo2BoU/k1iNOg+jTcaLH+RLWFGIANKVMTbiONMd/jdXx7",
-	"4y1Q4CQx3jziIApGBSD7XnvHJR2UVj3RnjVQaVd6cTc15gJndmo3MoK63XyJ+ApLxqV93w0actMSsxfs",
-	"hneSai+6+2x2gxQM7Z4kWLqAR0HxYZGyGLTMtefP+BlJU1D8fYbT0yowokyezllJU705qWwJzk7d6yXF",
-	"pVyqQFPzr3pzgSVc4JXe0c2ZhFNl6/wLOOOA09Wp3T6z8Ktf7jlcEiFD+1vJxLswFddKbgQJYGUf4Vzp",
-	"Kpu9Eyj09dpsM8rJcpE5jHCx3Nj5OAfLDRfj3Csz/CrCGu8AZ3J5aMUkopXqAuQ9iaV+z25EAk0LRmhb",
-	"vERHycHnc+A4yxyUegWCAH4OIceZUSvNRO7v2HJ7xdnjjmjYLtZqQSgL/aQtl+Y18zjIu0fzh+fARTSj",
-	"7pCwA1rf2y/nXm86+B7d8Mtj4q+85i94sd4iZ0SYXHuW6WRRa23vP53Sn9Eqjddrcb1m0sq+3ZOx+MAS",
-	"nO2bpNN1MlEuhL1eQupiSTJABWdK6h0tdcnP2tnf4SxBCHdUqqCXbIvo1ks04vY5lliFhAQq46Dcw+im",
-	"jPjIOPRmwTggzAHlKnQ0ZTj4HJMMn4WOvs+HTSdEvBaS5Fj2g9WwkF5CRATCFIF7LQZVjd5Tg4erhEyJ",
-	"UOgOBlpIMomzD2pcZPdQPWtVNtpMRDu4CSvZGrUVmt6x9Y7XulW5EEyb6ZBWhqW9+Cow5kC7JaYWOguE",
-	"hWAJ0al1U9+6JMKXmI1KAgQlURERcggdQqET+N2IcTuiiaH28EstyWbIActIsrol/FI2gpesCzEvM6Rm",
-	"yMAkVebae1YoKeTM7kaMz9apMtLLPNc5kJiQDsT0XcGRgdoTz3OQfDVIBz0KYSkhL6RAOU7BKqSKadqf",
-	"3x/Q9aJ842CungVeI6CrXrRBnXo7Bc770x5CYppintoAxSmKLiqFn5OyUo4EzkpZlHIt6FCMdoDrHpUG",
-	"aLHzNOiJRTti14DBQqHr0otdhbifylyHrtYdbgZlbjtbRUl6DOwc09kOOp58YtJx0/HkmG6r/x2aQEn9",
-	"fqF+v9Fip36+VD9Nmtj+55X6j83Uqt8/6t9fSVGY55UvPptuT19MX05fTX88aYnDdHK5ocZtnGOut7AV",
-	"kT8xeeQZ/dBHb2+cFvCITKYOBfWXmXxyUiOZZ+7eShVLvrBgxTkWtrDaBRa0optaRY+cV1EmztN/BgpG",
-	"OOQizHiAF4RiV1HTsF9mAePF6251g+L6eHUCXHZAUE8GXy84nHdU9XM4J6wUgyC0Z6FgRFhYNjyLQg/r",
-	"hHIICePpCDjcDhz0SWpgpzWS1zAPCBkQJSaxxrh/jPoz5lmwJ5gzazWcwXSsph13HcFKkrU5Jyo6v9p3",
-	"fjHveFysjzAip6HtjLHiYW1WT9Xx6C0RuCQynlLy4cslkVqJ2R0aycliATyCTzNoCdmk4dLovNI5ztYp",
-	"iZMXANRN6wx8vEpq7FkgbdNNCZaG2t5UDaCaMUPUDfgsmqk56qyJcU8aVY3zqtI8LDFsRPG+eCbCT5zR",
-	"oLpGH41wU7nNoqHIMIAfEy5zUHF/9634iGWyjG/K25DZbCIJ/QbS9eK1kCGoym59pQpwYssqk6WudDMR",
-	"Wmf0qJ4bR7H/WNaFDiItalj50CYZ2uE2fohipa2lQUnX5yi0LuWw5tPfWMM1nKab+Ie6Xj9O+fdBiGbo",
-	"bqv7fYkEtvmB6xblmLp/0bvoAVlBoAv1w6eZR1VIRZjsWgmR3DHMGjkRUx3jPjO6DDdzB4O9oTv2CP+p",
-	"t9rUz5/UzwPMJcEZCoZFHcXpT3fqKv7TbQBafNyTE0/aG7uNwbb5ep5jy3X0u5WFJZ5L4Md8ySMb2HTK",
-	"pMTia3gYRZvZAvic8VwoXWmqzROkZNOVuvckWDDvS7BivihzJVjK7hVYCH8Si+U5rovjYPYxydNfiVzu",
-	"RmfcM3kIDxkZOEGNRA0XW1IZ09wOtdYU/8CiAh+UZSqLwkpZTRAvyi+ApgPVnmEVry5OSdxX+fIUG9TG",
-	"i1MGSXiD6v2LZeCzoJTFa7zTWMH4r4x/1WegfOG43jzztfkO6g8i4IsWaBJZks+F3T8Vehc0Ur6i4G6i",
-	"PVMSXQpTzO2OCyAOc+BAExAoI18B/fk7STdNcH+llhhrSTOfXPH9JvpoK4fsBkK9KAuReXVoI14IT7LP",
-	"tGMzOjhlKoCmCNRoRJn6rgSbRBujVV6s5PGk8Lol6WE+ta7AWvibdEsb+P86suozVfrAuaupsstr3+yo",
-	"dM+ymM5thyhubBBE1YsU6yrKi0dj910JRe0wut0jURzipvCsg7WyJwnC5jXlxnju0axScVVw7A9T88Jk",
-	"OmEUbPXhaHltjTgx5xr2/EGFMYFHm1xiE+0HJ+5nraNGk8Hj6S2XZMRh3KYNWOs07m2cPfB8frtHD3gj",
-	"xB4O2ezYK+0HROLSSE8dFTiWFGEROUrdzm9qYLGwT/3t4pZajt1aM+0DmFFd5WpdeV9doO6PBCW4kGbv",
-	"tp4DXifZOwixS5+MPVdQHfV3Xlozs3sSlCH7xEvrA+p9S2Ja9zLI6deKAXxV5fZPf33x48vt7Z9/DqYk",
-	"VP70Kh7ICUhKTuRKhfK5dcYK8oV9NbtdZ4A58DcOECvwt9I3gNC2Qg+oYC+l1PUhZ1iQZLeUuhdQNVr9",
-	"tzn4SmdX5sxts+JEL6JtLPAvJjF6h3Oc4sl0UvLMvid2trYWRC7Ls82E5VsrJiVe5mnLP5nsHrz38Sxn",
-	"WeaOm+SMEnvgbB8vSlsNsakj2QRsuYJF4u3Bh42Xm7M+BFK8KDcYX+g/ts4ydraVY0K3Przfe/3p6PWm",
-	"QU0SqWtf1YxBRcXO5MXmbHOmzWIBFBdksjN5qf+ly2OXemEUaL17p34sYq1aDkFyAuda/jLnPWdZsO1H",
-	"5BIx5+9UJ27OVkZVGJ/X7jV45/19al1Ms+MnXPMC29uroxS+GlJV/w2OrPVHWmP8FzZqdL1N1Yg3ggYq",
-	"7SL+N5p+FXUtFTtaZLgyxM6mISdK35iCGL3EL2azRukBLorM+m9b/xHG/a7gxYqbe2KFOlPIJRDuYtFG",
-	"c4FRxq11BKi33sVh19anV20JDreKHYWMoNvmM2sQabDgMoZBvLbTKFBXiG7oGkrbxFUO6c81/zpR73hB",
-	"3vqumOLqj5bnf6xsDe1jlmpb2H7HOuBZRp+WjBrCBhkrq6XHCe7Wd1dm3i3Db8Ckj9OeE1/4TKd+Kiwq",
-	"r7wutG9B1g+krSuzDXs2LCvritXdiEhw/m6Yv32lY5Sf3dMbcfWr2au752jzNTqmNtsOD06cnH1qMXfj",
-	"2NXa0rTlKty2vidVqdmti1kzBG4JW1Dn9oAlbtp9xqieHjGtO8Il0/V28cZ3NcKv1f3uWQPckhDuNU5k",
-	"PlJF0Mo03Zo62LJHJntVgi8uZrxR/ruO/H9giwcq+wNjdefHEeN0k9wR42yf2BEjTYfb66mnYNEemnrq",
-	"EyPFJQ9OjXxwJa2PQYN4Se0207eoP3S53NZ31+T1pgpFJ8H1Vvc6quVIQvGsXm6gXgYTFaYN7kNTRGMw",
-	"t82Hn5XWY1Na3argLtVXdYCjwDJ2E8PeEtOF1WGhj1bH29c39quxX4oUS2hosiOXb3zUcVKpP612aEbR",
-	"6iFoAX2A9R8sXd0gqFr/oE/8VHA8hqp//FVcdY1WNrO7l/b39BxnJPWng+85xeMq5h+wqvuIaYmzbOUE",
-	"A7tqnKp8xmdcbkXnpaBrFjudsX3zPOhkVGGiSzeIcKWq2arq1lJXYBaI7x73WJKpz2nKdXi3YhXDBjfi",
-	"y7EBQsWNlXMwmNZ/jgKuGwU8+8cP2T+el1nWkIgbbxHow6/as2FCxg4RATaVaBQuvI3Q9xQhpkyUP3cY",
-	"dn2oy6XCf/XAjcNteINhI7yhi9tsbLzqOhEd71Xmaqw30fs5Kjg7JymkU8Rotgrq0S9IlqEzsMF3ujn+",
-	"OpW790MfnmSt2p7PtQTpznJgg+buUSe+qqjsSSXJng3po0003cSa3nkmqT+H9EjSR8+JmudEzVNJ1FxT",
-	"TbCi2+d+w3gCytdfITVQOd/uErpaQ4DIlRN1pfAFeE6o1wtPLzPzsHjGk7u9YL1cMuYkQr1DwriSZdsN",
-	"MVqwvL5p0B1WRqytu9/19o4F3PhIwBBsqQ/5xy/kXNzvYYP+KuY2C9xGMbO+ziVylu7+W4QWtfZLfWgH",
-	"jZoi0WzQBLQG9CnWYPsul+7Cn0DRmDYKYzI7kBdyhepX+GiX1N94Z6Wsrk0MkE9wYduIXNu83Jqnt1YD",
-	"/3FnE8e4eNu3gHJ35xIKF9nKG/3R7UueELsbRqvSkPV2QQ2Wd3Z1y3S96TSvB1WvDeVubUi4lK5TDk44",
-	"E8KdcggVb0sIqgY1N/WwWktjcNFGCfkjrzFD9e1ea/eG+08bzINryMZ1n37da1Lscq5jUUzDo9i9PmFD",
-	"JFH1BlLzONqu0Z4oaMM0dCDIodTTcPnRiqmlatwSebGU43xeJXtBW3DTMsTK5ZBMvgW5m2X7u2+/2Obn",
-	"N7NMd5XJa7R2f2ruiAtBuhjhu7uH7srwQQaxbtwHwHNMTQUCh5yZk5x1Dqhu2hcroaSwXaOggN/UTRkV",
-	"2vor8SK88yp+b2K1xtkKGTqk95mVedh1B7rtEqZI3xUSNHBrOrrjjjQNHRmsuxaxPZd7O8TUx0m3bbEX",
-	"IKW5HT9o13j97oA3uyjhhnHk+pduBuhm9oqIHoz91Qq2vw3m+rYsczXrmhfA+hspYrfS3tX9nz3XfVaf",
-	"/xQdFL8FpCBzWAIV5NxSsHZN7bDJGm4k4lSPvYOzdhQ9msEdoXr0kr2r7i59LApozSP7waXot3PPckvM",
-	"2/fLk3QfS9xxq2yKJa7dKusYZezs/tbasQ0DApSeogC2buINLc4a0jeme0AVU/ScZ9Y9PZMyw3zNbZZQ",
-	"Mv8A1+CP7ipwG4eJnxKHvwUZP8Ab6Usxgs+B+gruoUSuvx3VxUKNGAnTFOE0FYhI1/jPlPQGPUAjluc1",
-	"deXd97WP2DA7d1uc5xuXvt9vtgyeum6MrtbOJiAZBV9lt1A8gTtuglm/E+PYHoxX169EuMPyxiBFHe+H",
-	"uF7l4aOUfysuTXkcbdg4uA2BDnkPKob0Zk2turTPhTzUkP+IHMit7OzAhYfa3i2BC1t+hnMIxXh4pyQA",
-	"+1ze85QTSUZwqk3O9/vjBFLZ7VGVvP/a/fjBW3nsmiHjcZHdkZrlMQd0d5IUsh2whSHO+AyQW7N2M1+d",
-	"bi0gUaD1gvVY2FoFoEHhCadEHGU890aLCWLNgT+ylMzJzaTAV7D+IYJwK0WmnTznNq2vzXcn9+7t3al8",
-	"Nm8ZenIyZZjZr/lIO6O7oN9SnKeBqUgvLFmtVw0GEtYK+UwH8sfqKj4He8/B3v3WJdHU30Fz3bjPbsL0",
-	"KADTe11fO+z3ftyVbhyJJSuz1K5KlTWvbzDgJGFc38EjmVYOWm2Aeo1RD6zHOGskBWH0SJo7sB+hna4I",
-	"3agJMg9c0k5f+yLjwWTXxpqDfR+R5HNE94UtFrbSRHjGNFepxWVuCTiTy759gpJTgcywyC6B5oPqnoNY",
-	"KPdOv+vPX91Z7ZCZ56alQ83LMeCygEQpdbALUw+gIflqP93RqHUKxtbfGHrnKrZIxCDBDzjLlU4rxYb6",
-	"VCzJWaavi1FvawlsXjTh6R6t/fpo5x2kv4RLuVVkmDQo768CmfwJvXv94QCleFGeKoYw05+VJKuVkhzT",
-	"P6Ev/zp4HQxc4HIBx9T/47u9qOLvx5Ptze1Xm7PjyVTDOVXK9e/HkxezF682Ztsbs+0v2y92ZrOd2ezf",
-	"x5Ppgp2Gb77YPp5coe1jPWWFW1lIksOpuz9V36cqCE3ALZj2COtoNt4JEW48evnTbNacMcWLU2ViTn2D",
-	"mFN37KW6l71qHhMciVF/izoqPcBCtHqG/diJn+lXcmpuJf7SuJvYoaOcMD2wA68akChKtRF/68RmAI2z",
-	"lZWpDjzM67ZUpomCfvjdvP/344lwdzteoRevfn45MFqLvOatHwdGJtVlk1for5Ev7fnK9neJOFHdv1+1",
-	"Ftb7PH7tf416REQ4pqvP2X4/nLr9dPs45ty29G2lxLzmUuExXErn2D/Ivco22oE2r9Su0ujBVUfa2asu",
-	"OfrtRLlzwX1F+h/KZzPaxziHDedCKdLdg/eVMTX3An0333a1s7X1fcmEvNrCBdk6fzGZTty9blqbL72X",
-	"bElqapf0v5vUeMeErN3jZee8mtaK5BwgfadSdV+o/akvLNJ0OPEUageYzi4Zs4UpXrjLksw1zlYF1quX",
-	"bRm/dlXaJwEaQG1XTQUpqJPRFSpqmowtRFBrFNw1V5vI1C61JzvSBjwwsE37q4+Zue9qe0R2BusHtOHf",
-	"0NZb8AFjXp1c/X8AAAD//wwsIL01tQAA",
+	"H4sIAAAAAAAC/+x9aVPkONLwX1HUbsTsxltA0d0zu0PEfmChD97og4WeZ2J34CGEnVWlbVtySzJQ08F/",
+	"f0KnZVs+iqMHCL5RWE6lU3krlfo2SVheMApUisnOt0mBOc5BAte/9nffviEZfMQ5qJ8piISTQhJGJzsT",
+	"uQREcQ6IzZH6e3/3LZqTDCbTCVHPCyyXk+mE6pcncwdnOuHwtSQc0smO5CVMJyJZQo7VBH/mMJ/sTP60",
+	"VSG1ZZ6KrRCX6+upwi2OVwOnODr0lqiEaByV9CBt43GwH2CxwUuKGEc/ZFiCkD8gydACpH6cMyERhwSo",
+	"dEPjSKd4Yea6BeIGQIj5MWCeLO8H/68l8FX0A26M8KhF76bh4MLLVaHGCckJXZh5sYTPJIc3nOXtmYXE",
+	"XKIUS5AkBzRnXEmBBPW6Q0UgQtHB8Sf0959m22pIjiW6JHKJ1Du/MwodBJtzlqvpRxPsF0quFK5C4ryo",
+	"Yf+ZtXEHmt4X5pLdEu93gCNC9bHMz4Grlc4IBaHYkIMsOUWKVHr5z2FBKFXfYPkhVEoNLJdqkhDHnFCS",
+	"l/lkZ3vqOIFQCQvgGqn3JCeyjdUHfKXeQrQLu47pMw2uNr+BNNnZns1ms+kQPp/mcwERhN4TCg4byZDh",
+	"UQ44VWTRlPrL9sY5FpD+tQM1ZiCvQZtDvIgIZoEXENCFSMg1XeYgkyX6SwpzXGYSEYG2u1BRIGqI2Jc0",
+	"IkNIAY/j1USpAI40riFKL2dTlOMrjd1s1omfnSOK4o9qEcNFHUT5CHIm4SNLB9Qc1+MQVQPjiPEKUhS3",
+	"ScYSnE2mEZ13LLEsRVTbyVJ0aNrG9GbsaBVgpzSzQzGs54WEIq7khXt/PUV/LDngiIr/dQlyaSTJKhsh",
+	"U1ZKZRCFTIFzlLGF6CSDhjqeDHq4wuczJtmNVKDS68PKTyrwowX82o3UXLG3JFlqDHJEHYLEKZZYmxSM",
+	"EjU24JWCswK4JGD4y/kEo12BqfFSI9x56L1XVGAhIFXEUVSooaBM2v8//vTRmrMo/1ds81votdiJT/0r",
+	"7Py/kEiF0x6jKTF4tNDikLinSC6xRHkpJDoHJLAkYk4gRecwZxwQL43pwpq7FYN10S3pnu/1VcFBCDUb",
+	"4yhZQvJFEQIucFYao9z44OkEOGc8Akn9G+UghFKNxLBU9S1EIMokykFGYV4VkEhIowjqJ4iDUKqWNQFb",
+	"VNXoCOAcy2QZg+sFtQbsEos6iueMZYBpa6ErksYWWMUSrRn31KKpyCdhdE4WJddIq18SE72SKcwJNYhg",
+	"mipEtGy05cBo5cMO1t63VskHaEiRCESDmdUaqSURBSREMxb2TjlKOHTStDZbc/J3ZY7phvIf8HkGKHgY",
+	"WIIfBCpKXjAB+kPPYYkvCOOxyRaclUXEa2ELkuAM6cfWgeOgIg4tu0LrE8YXmJLf9YfgzE0pYtPQqAlx",
+	"s7TjxBaALj3zngjNtNViKGDCyHaCqRLtSgF5V1rTH1Knp4lw8anyQCImyWOEOceridXAaZlBN0p2hKIe",
+	"eDUgLBfSBbpcAq0wEktWZmqthnHrtVkOrQjKEi96KKie6mVNsIQF4+R3rf1oWg9FxBpUagi1ZoIOed4H",
+	"ZQOj0qYeGLZriDahRtKMHD0wGc7wqj2tiqvUFEJbIe0wXGIincnRwYGxOZWtaZr/76wggF508wzQC8IZ",
+	"zYFKdIE5UVPqrxLgPwquIClbXzVe0L6ThlpimmbAP9EhCXvnB6q3iJBHIIGqGfbxSvQ5iSleOR8RE4rU",
+	"u4zrj7A+a3upM7bYJxFvYJ9wSCTjK6Tcbf2tGhhdKFja1RRxe321m0hyAUclFWOi54TRpOQ8SCgJhLOM",
+	"XUYUVBt9P50KI9adT7ld1WSEGv5BXVIRNzG/UPK1BERStURzAlzTyiVJL4lcEoqIFIaPHoXlKQIfVsT8",
+	"IPes7uDmlUjiSodharTOWPtS+dZPwyaKOGN6fDUPKo9dazGtvMcvZX9wCcVjM9JvSGxt3W6DSUYqWbKp",
+	"iV77jBcjwkwfD/WQxDxHQBNWUgkcUpSWmhAmNfO1BCHXErB550aLIgCqZeNdVN8CarLzVVw+HFAfl3mO",
+	"ueHKUhRA06HASs1PBKpGD8ZVwd6PWoEGmuHEnvA9vBAn0sf4TpQN8XcmHBZwpSN4KYGrN/73N7zx++7G",
+	"f2YbP59tnP6/P8foub/79i0n6YGESFpIPdHZQy0bF0SUODOi4RSd9UKYM7urFke6/7eAH9cSbTYZkGpG",
+	"O1/p5PtYmf/IUnC5tTbb0UFq2jRbf47Ebqu4z+lYvlFLdyerdlTSwLnHWfZpPtn5bT2B6AwK2prG23ej",
+	"uq2F9xZvs7XulKUg+lad0JRckLTEWR1mI+06lgFiS8/oHqYJZGPfZ/T1ldn9GDf6DSZZyWH8C8dlkoAY",
+	"/T0DLol3lcJhnd5JuM95l/5JU070urfF43Q6wGxsHjhQhCZZqfdy6olNAz0uex271L2uquUyuMJ5kekN",
+	"K624byiQTrLazqP3vVufeifpYuXmiSWku5GdsqM3e+jly5c/a5Wqdx+NOxjyg3s/anHZIpaHlkuXenaR",
+	"UV+CalSxQXdQcFRSvYNbdKW/xya+9RRA5ZiiBjOynTKIwxrW/MPwvpZQ3nwRL7FABkIMNmds1FercX04",
+	"VnCGv3gIllZBN/9g+3oHZLu7N2ZDzo1/j8+HjcVxMLSp/BrEaVB9Gm60WH+i2kIMwIaUqQm3kcaY7/E6",
+	"vr3xFihwkhhvHnEQBaMCkH2vveOSDkqrnmjPGqi0K724mxpzgTM7tRsZQd1uvkR8hSXj0r7vBg25aYnZ",
+	"C3bDO0m1F919NrtBCoZ2TxIsXcCjoPiwSFkMWuba82f8nKQpKP4+x+lZFRhRJs/mrKSp3pxUtgRnZ+71",
+	"kuJSLlWgqflXvbnAEi7xSu/o5kzCmbJ1/gWcccDp6sxun1n41S/3HK6IkKH9rWTiXZiKayU3ggSwso9w",
+	"oXSVzd4JFPp6bbYZ5WS5yBxGuFhu7Hycg+WGi3HulRl+HWGNd4AzuTyyYhLRSnUB8p7EUr9nNyKBpgUj",
+	"tC1eoqPk4NMFcJxlDkq9AkEAv4CQ48yolWYi93dsub3i7HFHNGwXa7UglIV+0pZL85p5HOTdo/nDC+Ai",
+	"mlF3SNgBre/tl3OvNx18j2745THxV17zZ7xYb5EzIkyuPct0sqi1tt8/ndKf0SqN12txvWHSyr7dk7F4",
+	"zxKc7Zuk000yUS6EvVlC6nJJMkAFZ0rqHS11yc/a2d/hLEEId1SqoJdsi+jWSzTi9jmWWIWEBCrjoNzD",
+	"6KaM+MA49GbBOCDMAeUqdDRlOPgCkwyfh46+z4dNJ0S8FpLkWPaD1bCQXkJEBMIUgXstBlWN3lODh6uE",
+	"TIlQ6A4GWkgyibP3alxk91A9a1U22kxEO7gJK9katRWa3rH1jte6VbkQTJvpkFaGpb34KjDmQLslphY6",
+	"C4SFYAnRqXVT37okwpeYjUoCBCVRERFyCB1BoRP43YhxO6KJofbwSy3JZsghy0iyuiP8UjaCl6wLMS8z",
+	"pGbIwCRV5tp7Vigp5MzuRozP1qky0ss81zmQmJAOxPRdwZGB2hPPc5B8NUgHPQphKSEvpEA5TsEqpIpp",
+	"2p/fH9D1onzrYK6eBV4joKtetEGdejsFzvvTHkJimmKe2gDFKYouKoWfk7JSjgTOSlmUci3oUIx2gOse",
+	"lQZosfM06IlFO2LXgMFCoevSi12FuB/LXIeu1h1uBmVuO1tFSXoM7JzQ2Q46mXxk0nHTyeSEbqv/HZlA",
+	"Sf1+oX6/0WKnfr5UP02a2P7nlfqPzdSq3z/q319IUZjnlS8+m25PX0xfTl9NfzxticN0crWhxm1cYK63",
+	"sBWRPzJ57Bn9yEdvb5wW8IhMpg4F9ZeZfHJaI5ln7t5KFUu+sGDFORa2sNoFFrSim1pFj5xXUSbO038G",
+	"CkY45CLMeIgXhGJXUdOwX2YB48XrbnWD4vp4dQJcdUBQTwZfLzhcdFT1c7ggrBSDILRnoWBEWFg2PItC",
+	"D+uEcgQJ4+kIONwOHPRJamCnNZLXMA8IGRAlJrHGuH+I+jPmWbAnmDNrNZzBdKymHXcdwUqStTknKjq/",
+	"2nd+Me94XKyPMCKnoe2MseJhbVadLc9x8oXN5+pPRsFuqrXcWYp0sT0qBegyC131lpeZJEVGzCK92JzF",
+	"XNp2GCwkyxFcGSVNcIYsCgG8cMdwnrEws21Z81oRpFYxPXo7B66IjKfDfOh1RaRWwHZ3SXKyWACP0LIZ",
+	"cIUs3nDHdE7sAmfrlPPJSwDqpnXOSbzCa+w5Ju2PmPIxDbW9IVwvvDqwaB9D0g3efVv4FX9JcCFq67zg",
+	"7FIu/xqdyWAztI6BNEbzWcedlUPuSaP2c17V44eFmI1chy8xikgdZzSoQdIHSNxUbkttKH4O4MdUkDnO",
+	"ub/7VnzAMlnGSxdsYsFstQn9BtJV9bXAKqhdb32lCgNjKyyTpa4HNHFsZ4ytnht3uv/w2qUOtS1qWEUa",
+	"JmXc4Vy/j2KlfQqDkq5iUmhdyWH7oL+xhms4TTfxj/SphjjlD4JA1tDdnoHwhSTYZlFuWrpkTkeI3kUP",
+	"yAoCXaofPhk/qo4swmQ3ShvljmHWyByZGiL3mdFluJ3THOyg3bPf/C+9Ial+/qR+HmKuVV8wLOpOT3+6",
+	"V4f6X26b1OLjnpx60t7auQ6KC9bzr1sOtt/TLSzx3DZHzOM+tuFfp0xKLL6ER3a0QS+AK/9CKF1pavIT",
+	"pGTTHQjoSUNh3peGxnxR5kqwlIUtsBD+vBrLc1wXx8EcbZKnvxK53I3OuGeyNR4yMnCCSpIaLrbwNKa5",
+	"HWqtKf6JRQU+KF5VFoWVspogfnShAJoO1MSGtc66hCdxX+WLeGzoHy/hGSThLc44XC4D7wilLF4Jn8bK",
+	"6n9l/Is+KebL6/UWoz/B4KD+IAK+aIEmkSX5VNhdZqH3iiNFPgruJtozheOlMCXv7lAF4jAHDjQBgTLy",
+	"BdCfv5F006RArtUSYy1p5pMrvt9EH2x9ld1mqZeuITKvjrbEjwuQ7BPt2LIPzuIKoCkCNRpRpr4rwSYd",
+	"yWiVPSx5PHW+buF+mHWuK7AW/iYp1Qb+P46s+uSZPpbvKs/s8to3O84DZFlM57YDOTc2CDXrpZx1FeXF",
+	"o1GjoISidmTf7iQpDnFTeNbBWtmTBGHzmnJjPPdoVqm4Kjgcial5YTINwsnR8toacWqCkD1/nGNMiNMm",
+	"l9hE+0FfglnrQNZk8BB/yyUZcWS5aQPWOrN8Fyc0PJ/f7QEN3khEDIdsduy19gMiEXCk85AKUUuKsIgc",
+	"OG9ngTWwWNin/nZxS20nwloz7QOYUV1FfV3ZcV3G7w9OJbiQZoe7nilfJyU+CLFLn4w9fVE1RHBeWjP/",
+	"fRqkXnx6qvUB9e4uMa17Fex81EomfO3p9k9/e/Hjy+3tn38OpiRU/vQqHsgJSEpO5EqF8rl1xgrymX0x",
+	"e4LngDnwNw4QK/DX0rfJ0LZCD6hgL6XUVTTnWJBkt5S6Y1I1Wv23Ofha53HmzG1G40Qvom2/8G8mMXqH",
+	"c5ziyXRS8sy+J3a2thZELsvzzYTlWysmJV7macs/meweHvh4lrMsc4dyckaJPZa3jxelrRnZ1JFsArao",
+	"wyLx9vD9xkudiutEIMWLcoPxhf5j6zxj51s5JnTr/cHe64/HrzcNapJIXSGsZgzqTnYmLzZnmzNtFgug",
+	"uCCTnclL/S9dRLzUC6NA6z1O9WMRa2hzBJITuNDylznvOcuCzVEil4g5f6c6l3S+MqrC+Lx2R8Y77wep",
+	"dTHNvqhwLR5sB7SOAwPVkKpGcnBkrYvUGuM/s1Gj6828RrwRtJlpp13faPpV1LVU7Ggk4oo1O1urnCp9",
+	"Y8qG9BK/mM0aBRq4KDLrv239Vxj3u4IXKwHviRXqTCGXQLiLRRstGEYZt9ZBqd6qIIddW59etyU43FB3",
+	"FDKCblv0rEGkwbLUGAbxClijQF25vqFrKG0TV1+lP9f861S94wV565tiius/Wp7/ubKVxo9Zqm35/z3r",
+	"gGcZfVoyaggbZKyslh4nuFvfXDF+twy/AZM+TnvOxeFznfqpsKi88rrQvgVZP7a3rsw27NmwrKwrVvcj",
+	"IsEpxWH+9vWgUX52T2/F1a9mr+6fo83X6JjabDs8OHFy9qnF3I3DaWtL05arA9z6llQFeXcuZs0QuCVs",
+	"QTXgA5a4afdJrHp6xDQ4CZdMVyXG2wPWCL9Wj8BnDXBHQrjXOLf6SBVBK9N0Z+pgyx4s7VUJvgSb8UaR",
+	"9Dry/54tHqjsD4zV/TFHjNOthEeMs910R4w0fYBvpp6CRXto6qlPjBSXPDg18t4V/j4GDeIltdtM36H+",
+	"0EWFW99cK9zbKhSdBNdb3euolmMJxbN6uYV6GUxUmGbBD00RjcHctmh+VlqPTWl1q4L7VF/VMZcCy9h9",
+	"FXtLTBdWh4U+Wh1vX9/Yr8Z+KVIsoaHJjl2+8VHHSaX+tNrRIkWrh6AF9DHff7J0dYugav3jUPGz0/EY",
+	"qv7x13HVNVrZzO5f2g/oBc5I6s9Qf+cUjztX8IBV3QdMS5xlKycY2FXjVOUzPuNyJzovBV2z2OmM7Zvn",
+	"Qb+nChNdukGEK1XNVlVPm7oCs0B8j73Hkkx9TlOuw7sVqxg2uBVfjg0QKm6snIPBtP5zFHDTKODZP37I",
+	"/vG8zLKGRNx6i0AfEdaeDRMydogIsKlEo3DpbYS+zQkxZaL86cywN0ZdLhX+qwduHO7CGwzbBQ5db2dj",
+	"41XXufF4RzdXY72JDuao4OyCpJBOEaPZKqhHvyRZhs7BBt/p5vhLZ+7fD314krVqez43EqR7y4ENmrtH",
+	"nfiqorInlSR7NqSPNtF0G2t675mk/hzSI0kfPSdqnhM1TyVRc0M1wYpun/sN4wkoX3+F1EDlfLur+moN",
+	"ASIXc9SVwmfgOaFeLzy9zMzD4hlP7vaC9XLJmJMI9Q4J40qWbc/IaMHy+qZB96EZsbbuFty7OxZw6yMB",
+	"Q7ClPuQfv7Z08X0PG/RXMbdZ4C6KmfWlN5GzdN+/kWpRa1LVh3bQzioSzQatUmtAn2INtu8F6q5FChSN",
+	"aaMwJrMDeSFXqH7RkXZJ/b2AVsrq2sQA+QiXto3Ijc3LnXl6a11zMO5s4hgXb/sOUO7uXELhMlt5oz+6",
+	"fckTYnfDaFUast4uqMHyzq5uma43neb1sOq1odytDQlX0nXKwQlnQrhTDqHibQlB1aDmth5Wa2kMLtoo",
+	"IX/kNWaovn7X2r3hLt0G8+CytnE9ul/3mhS7nOtYFNPwKHb7UdgQSVS9gdQ8jrZrtCcK2jANHQhyKPW0",
+	"pX60YmqpGrdEXizlOJ9XyV7QPN20DLFyOSSTb0HuZtn+7tvPtkX87SzTfWXyGg3wn5o74kKQLkb45m7r",
+	"uzZ8kEGsZ/kh8BxTU4HAIWfmJGedA1wkDEishJLCdo2CAn5bN2VUaOsvDozwzqv47ZLVGmcrZOiQfs+s",
+	"zMOuO9BtlzBF+kaVoIFb09Edd6Rp6Mhg3bWI7bl8t0NMfZx01xZ7AVLTNg3bNd68O+DtrpO4ZRy5/tWk",
+	"AbqZvUijB2N/AYXtb4O5vlPMXGC75jW5/t6O2N2993VLas+lqNXnP0UHxW8BKcgclkAFubAUrF3mO2yy",
+	"hhuJONVjbyqtHUWPZnBHqB69ZO+qG14fiwJa88h+cHX83dxG3RLz9i38JN3HEnfcvZtiiWt37zpGGTu7",
+	"v9t3bMOAAKWnKICt+4pDi7OG9I3pHlDFFD3nmXVPz6TMMF9zmyWUzD/ANfijuwrcxWHip8Thb0HGD/BG",
+	"+lKM4HOgvoJ7KJHr75B1sVAjRsI0RThNBSLSNf4zJb1BD9CI5XlNXXn399pHbJid+y3O841LD/abLYOn",
+	"rhujq7WzCUhGwVfZLRRP4I77ctbvxDi2B+P1zSsR7rG8MUhRx/shrld5+Cjl34pLUx5HGzYObkOgQ96D",
+	"iiG9WVOrLu1zIY805D8iB3InOztw6aG2d0vg0paf4RxCMR7eKQnAPpf3POVEkhGcapPzYH+cQCq7PaqS",
+	"99+7H957K49dM2Q8LrI7VrM85oDuXpJCtgO2MMQZnwFya9Zu5qvTrQUkCrResB4LW6sANCg84ZSIo4zn",
+	"3mgxQaw58AeWkjm5nRT4CtY/RBDupMi0k+fcpvWN+e70u3t79yqfzVuGnpxMGWb2az7Szugu6HcU52lg",
+	"KtILS1brVYOBhLVCPtOB/LG6is/B3nOw933rkmjq76C5adxnN2F6FIDpva4vZ/Z7P+5KN47EkpVZalel",
+	"yprXNxhwkjCu7+CRTCsHrTZAvcaoB9ZjnDWSgjB6LM1N4Y/QTleEbtQEmQcuaaevfZHxYLJrY83B/h6R",
+	"5HNE95ktFrbSRHjGNFepxWVuCTiTy759gpJTgcywyC6B5oPqnoNYKPdOv+vPX91b7ZCZ57alQ83LMeCq",
+	"gEQpdbALUw+gIfliP93RqHUKxtbfGHrnKrZIxCDBDznLlU4rxYb6VCzJeaavi1FvawlsXjTh6R6t/fpg",
+	"5x2kv4QruVVkmDQo768CmfwJvXv9/hCleFGeKYYw05+XJKuVkpzQP6HP/z58HQxc4HIBJ9T/45u9qOIf",
+	"J5Ptze1Xm7OTyVTDOVPK9R8nkxezF682Ztsbs+3P2y92ZrOd2ew/J5Ppgp2Fb77YPplco+0TPWWFW1lI",
+	"ksOZu+NU39wqCE3ALZj2COtoNt4JEW48evnTbNacMcWLM2ViznyDmDN37KW6vb5qHhMciVF/izoqPcBC",
+	"tHqG/diJn+lXcmbubv7cuMHZoaOcMD2wA68akChKtRF/78RmAI3zlZWpDjzM67ZUpomCfvjNvP+Pk4lw",
+	"dzteoxevfn45MFqLvOatHwdGJtVlk9fob5Ev7fnK9neJOFHdv1+1Ftb7PH7tf416REQ4pqvP2X4/nLr9",
+	"dPsk5ty29G2lxLzmUuExXEnn2D/Ivco22oE2r9Su0ujBVUfa2asuOfrtVLlzwX1F+h/KZzPaR0Qu79aK",
+	"dPfwoDKm5l6gb+bbrne2tr4tmZDXW7ggWxcvJtOJu9dNa/Ol95ItSU3tkv53kxrvmJC1e7zsnNfTWpGc",
+	"A6TvVKruC7U/9YVFmg6nnkLtANPZJWO2MMULd1mSucbZqsB69bIt49euSvskQAOo7aqpIAV1MrpCRU2T",
+	"sYUIao2Cu+ZqE5napfZkx9qABwa2aX/1MTP3XW2PyM5g/YA2/Fvaegs+YMzr0+v/CwAA//+H5fLHW7YA",
+	"AA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/v2/api.yaml
+++ b/api/v2/api.yaml
@@ -1980,6 +1980,16 @@ components:
         limit:
           type: integer
           description: "Maximum number of times to repeat the step"
+        backoff:
+          oneOf:
+            - type: boolean
+              description: "When true, uses default multiplier of 2.0"
+            - type: number
+              format: float
+              description: "Custom exponential backoff multiplier"
+        maxIntervalSec:
+          type: integer
+          description: "Maximum interval in seconds (caps exponential growth)"
         condition:
           $ref: "#/components/schemas/Condition"
         exitCode:

--- a/docs/index.md
+++ b/docs/index.md
@@ -175,6 +175,8 @@ steps:
     command: python load.py
     retryPolicy:
       limit: 3
+      intervalSec: 2
+      backoff: true      # Exponential backoff
 
 ---
 name: transform-data

--- a/docs/writing-workflows/error-handling.md
+++ b/docs/writing-workflows/error-handling.md
@@ -4,9 +4,11 @@ Build resilient workflows with retries, handlers, and notifications.
 
 ## Retry Policies
 
+### Basic Retry
+
 ```yaml
 steps:
-  # Basic retry
+  # Basic retry with fixed interval
   - name: flaky-api
     command: curl https://api.example.com
     retryPolicy:
@@ -21,6 +23,45 @@ steps:
       intervalSec: 30
       exitCodes: [429, 503]  # Rate limit or unavailable
 ```
+
+### Exponential Backoff
+
+Increase retry intervals exponentially to avoid overwhelming failed services:
+
+```yaml
+steps:
+  # Exponential backoff with default multiplier (2.0)
+  - name: api-with-backoff
+    command: curl https://api.example.com/data
+    retryPolicy:
+      limit: 5
+      intervalSec: 2
+      backoff: true        # true = 2.0 multiplier
+      # Intervals: 2s, 4s, 8s, 16s, 32s
+      
+  # Custom backoff multiplier
+  - name: gentle-backoff
+    command: ./check-service.sh
+    retryPolicy:
+      limit: 4
+      intervalSec: 1
+      backoff: 1.5         # Custom multiplier
+      # Intervals: 1s, 1.5s, 2.25s, 3.375s
+      
+  # Backoff with max interval cap
+  - name: capped-backoff
+    command: ./sync-data.sh
+    retryPolicy:
+      limit: 10
+      intervalSec: 1
+      backoff: 2.0
+      maxIntervalSec: 30   # Cap at 30 seconds
+      # Intervals: 1s, 2s, 4s, 8s, 16s, 30s, 30s, 30s...
+```
+
+**Backoff Formula**: `interval * (backoff ^ attemptCount)`
+
+**Note**: Backoff values must be greater than 1.0 for exponential growth.
 
 ## Continue On Conditions
 

--- a/internal/digraph/builder.go
+++ b/internal/digraph/builder.go
@@ -844,6 +844,29 @@ func buildRetryPolicy(_ BuildContext, def stepDef, step *Step) error {
 		if def.RetryPolicy.ExitCode != nil {
 			step.RetryPolicy.ExitCodes = def.RetryPolicy.ExitCode
 		}
+
+		// Parse backoff field
+		if def.RetryPolicy.Backoff != nil {
+			switch v := def.RetryPolicy.Backoff.(type) {
+			case bool:
+				if v {
+					step.RetryPolicy.Backoff = 2.0 // Default multiplier when true
+				}
+			case int:
+				step.RetryPolicy.Backoff = float64(v)
+			case int64:
+				step.RetryPolicy.Backoff = float64(v)
+			case float64:
+				step.RetryPolicy.Backoff = v
+			default:
+				return wrapError("retryPolicy.Backoff", v, fmt.Errorf("invalid type: %T", v))
+			}
+		}
+
+		// Parse maxIntervalSec
+		if def.RetryPolicy.MaxIntervalSec > 0 {
+			step.RetryPolicy.MaxInterval = time.Second * time.Duration(def.RetryPolicy.MaxIntervalSec)
+		}
 	}
 	return nil
 }
@@ -962,6 +985,29 @@ func buildRepeatPolicy(_ BuildContext, def stepDef, step *Step) error {
 		}
 	}
 	step.RepeatPolicy.ExitCode = rpDef.ExitCode
+
+	// Parse backoff field
+	if rpDef.Backoff != nil {
+		switch v := rpDef.Backoff.(type) {
+		case bool:
+			if v {
+				step.RepeatPolicy.Backoff = 2.0 // Default multiplier when true
+			}
+		case int:
+			step.RepeatPolicy.Backoff = float64(v)
+		case int64:
+			step.RepeatPolicy.Backoff = float64(v)
+		case float64:
+			step.RepeatPolicy.Backoff = v
+		default:
+			return fmt.Errorf("invalid value for backoff: '%v'. It must be a boolean or number", v)
+		}
+	}
+
+	// Parse maxIntervalSec
+	if rpDef.MaxIntervalSec > 0 {
+		step.RepeatPolicy.MaxInterval = time.Second * time.Duration(rpDef.MaxIntervalSec)
+	}
 
 	return nil
 }

--- a/internal/digraph/builder.go
+++ b/internal/digraph/builder.go
@@ -861,6 +861,12 @@ func buildRetryPolicy(_ BuildContext, def stepDef, step *Step) error {
 			default:
 				return wrapError("retryPolicy.Backoff", v, fmt.Errorf("invalid type: %T", v))
 			}
+			
+			// Validate backoff value
+			if step.RetryPolicy.Backoff > 0 && step.RetryPolicy.Backoff <= 1.0 {
+				return wrapError("retryPolicy.Backoff", step.RetryPolicy.Backoff, 
+					fmt.Errorf("backoff must be greater than 1.0 for exponential growth"))
+			}
 		}
 
 		// Parse maxIntervalSec
@@ -1001,6 +1007,12 @@ func buildRepeatPolicy(_ BuildContext, def stepDef, step *Step) error {
 			step.RepeatPolicy.Backoff = v
 		default:
 			return fmt.Errorf("invalid value for backoff: '%v'. It must be a boolean or number", v)
+		}
+		
+		// Validate backoff value
+		if step.RepeatPolicy.Backoff > 0 && step.RepeatPolicy.Backoff <= 1.0 {
+			return fmt.Errorf("backoff must be greater than 1.0 for exponential growth, got: %v", 
+				step.RepeatPolicy.Backoff)
 		}
 	}
 

--- a/internal/digraph/definition.go
+++ b/internal/digraph/definition.go
@@ -144,19 +144,23 @@ type continueOnDef struct {
 
 // repeatPolicyDef defines the repeat policy for a step.
 type repeatPolicyDef struct {
-	Repeat      any    `yaml:"repeat,omitempty"`      // Flag to indicate if the step should be repeated, can be bool (legacy) or string ("while" or "until")
-	IntervalSec int    `yaml:"intervalSec,omitempty"` // Interval in seconds to wait before repeating the step
-	Limit       int    `yaml:"limit,omitempty"`       // Maximum number of times to repeat the step
-	Condition   string `yaml:"condition,omitempty"`   // Condition to check before repeating
-	Expected    string `yaml:"expected,omitempty"`    // Expected output to match before repeating
-	ExitCode    []int  `yaml:"exitCode,omitempty"`    // List of exit codes to consider for repeating the step
+	Repeat         any    `yaml:"repeat,omitempty"`         // Flag to indicate if the step should be repeated, can be bool (legacy) or string ("while" or "until")
+	IntervalSec    int    `yaml:"intervalSec,omitempty"`    // Interval in seconds to wait before repeating the step
+	Limit          int    `yaml:"limit,omitempty"`          // Maximum number of times to repeat the step
+	Condition      string `yaml:"condition,omitempty"`      // Condition to check before repeating
+	Expected       string `yaml:"expected,omitempty"`       // Expected output to match before repeating
+	ExitCode       []int  `yaml:"exitCode,omitempty"`       // List of exit codes to consider for repeating the step
+	Backoff        any    `yaml:"backoff,omitempty"`        // Accepts bool or float
+	MaxIntervalSec int    `yaml:"maxIntervalSec,omitempty"` // Maximum interval in seconds
 }
 
 // retryPolicyDef defines the retry policy for a step.
 type retryPolicyDef struct {
-	Limit       any   `yaml:"limit,omitempty"`
-	IntervalSec any   `yaml:"intervalSec,omitempty"`
-	ExitCode    []int `yaml:"exitCode,omitempty"`
+	Limit          any   `yaml:"limit,omitempty"`
+	IntervalSec    any   `yaml:"intervalSec,omitempty"`
+	ExitCode       []int `yaml:"exitCode,omitempty"`
+	Backoff        any   `yaml:"backoff,omitempty"` // Accepts bool or float
+	MaxIntervalSec int   `yaml:"maxIntervalSec,omitempty"`
 }
 
 // smtpConfigDef defines the SMTP configuration.

--- a/internal/digraph/scheduler/scheduler.go
+++ b/internal/digraph/scheduler/scheduler.go
@@ -759,7 +759,13 @@ func (sc *Scheduler) shouldRetryNode(ctx context.Context, node *Node, execErr er
 
 	// Set the node status to none so that it can be retried
 	node.IncRetryCount()
-	time.Sleep(node.retryPolicy.Interval)
+	interval := calculateBackoffInterval(
+		node.Step().RetryPolicy.Interval,
+		node.Step().RetryPolicy.Backoff,
+		node.Step().RetryPolicy.MaxInterval,
+		node.GetRetryCount()-1, // -1 because we just incremented
+	)
+	time.Sleep(interval)
 	node.SetRetriedAt(time.Now())
 	node.SetStatus(NodeStatusRunning)
 	return true
@@ -930,7 +936,13 @@ func (sc *Scheduler) prepareNodeForRepeat(ctx context.Context, node *Node, progr
 		sc.setLastError(nil) // clear last error if we are repeating
 	}
 	logger.Info(ctx, "Step will be repeated", "step", node.Name(), "interval", step.RepeatPolicy.Interval)
-	time.Sleep(getNextRetryTime(node))
+	interval := calculateBackoffInterval(
+		step.RepeatPolicy.Interval,
+		step.RepeatPolicy.Backoff,
+		step.RepeatPolicy.MaxInterval,
+		node.State().DoneCount,
+	)
+	time.Sleep(interval)
 	node.SetRepeated(true) // mark as repeated
 	logger.Info(ctx, "Repeating step", "step", node.Name())
 
@@ -939,14 +951,13 @@ func (sc *Scheduler) prepareNodeForRepeat(ctx context.Context, node *Node, progr
 	}
 }
 
-func getNextRetryTime(node *Node) time.Duration {
-	policy := node.Step().RepeatPolicy
-	if policy.Backoff > 0 {
-		sleeptime := float64(policy.Interval) * math.Pow(policy.Backoff, float64(node.State().DoneCount))
-		if policy.MaxInterval > 0 && time.Duration(sleeptime) > policy.MaxInterval {
-			return policy.MaxInterval
+func calculateBackoffInterval(interval time.Duration, backoff float64, maxInterval time.Duration, attemptCount int) time.Duration {
+	if backoff > 0 {
+		sleeptime := float64(interval) * math.Pow(backoff, float64(attemptCount))
+		if maxInterval > 0 && time.Duration(sleeptime) > maxInterval {
+			return maxInterval
 		}
 		return time.Duration(sleeptime)
 	}
-	return policy.Interval
+	return interval
 }

--- a/internal/digraph/step.go
+++ b/internal/digraph/step.go
@@ -135,6 +135,10 @@ type RetryPolicy struct {
 	IntervalSecStr string `json:"intervalSecStr,omitempty"`
 	// ExitCodes is the list of exit codes that should trigger a retry.
 	ExitCodes []int `json:"exitCode,omitempty"`
+	// Backoff is the exponential backoff multiplier (e.g., 2.0 for doubling).
+	Backoff float64 `json:"backoff,omitempty"`
+	// MaxInterval is the maximum interval cap for exponential backoff.
+	MaxInterval time.Duration `json:"maxInterval,omitempty"`
 }
 
 // RepeatMode is the type for the repeat mode.
@@ -156,8 +160,10 @@ type RepeatPolicy struct {
 	Interval time.Duration `json:"interval,omitempty"`
 	// Limit is the maximum number of times to repeat the step.
 	Limit int `json:"limit,omitempty"`
-	// Exponential backoff to let retry in exponential time,accepted values true/ false
-	ExponentialBackoff bool `json:"exponentialBackoff,omitempty"`
+	// Backoff is the exponential backoff multiplier (e.g., 2.0 for doubling).
+	Backoff float64 `json:"backoff,omitempty"`
+	// MaxInterval is the maximum interval cap for exponential backoff.
+	MaxInterval time.Duration `json:"maxInterval,omitempty"`
 	// Condition is the condition object to be met for the repeat.
 	Condition *Condition `json:"condition,omitempty"`
 	// ExitCode is the list of exit codes that should trigger a repeat.
@@ -182,7 +188,8 @@ func (r *RepeatPolicy) UnmarshalJSON(data []byte) error {
 	r.Limit = aux.Limit
 	r.Condition = aux.Condition
 	r.ExitCode = aux.ExitCode
-	r.ExponentialBackoff = aux.ExponentialBackoff
+	r.Backoff = aux.Backoff
+	r.MaxInterval = aux.MaxInterval
 
 	// If RepeatMode is already set, we're done (new format)
 	if r.RepeatMode != "" {

--- a/internal/integration/backoff_test.go
+++ b/internal/integration/backoff_test.go
@@ -1,0 +1,193 @@
+package integration_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dagu-org/dagu/internal/digraph/scheduler"
+	"github.com/dagu-org/dagu/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryPolicy_WithExponentialBackoff(t *testing.T) {
+	th := test.Setup(t, test.WithDAGsDir(test.TestdataPath(t, "integration")))
+
+	// Load DAG with retry backoff
+	dag := th.DAG(t, filepath.Join("integration", "retry-with-backoff.yaml"))
+	agent := dag.Agent()
+
+	// Record start time
+	startTime := time.Now()
+
+	// Run with timeout
+	ctx, cancel := context.WithTimeout(agent.Context, 30*time.Second)
+	defer cancel()
+
+	// Run the DAG (it will fail due to retry limit)
+	_ = agent.Run(ctx)
+
+	// Get the latest status
+	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	// Verify the step failed after retries
+	require.Len(t, status.Nodes, 1)
+	assert.Equal(t, scheduler.NodeStatusError, status.Nodes[0].Status)
+	assert.Equal(t, "failing-step", status.Nodes[0].Step.Name)
+
+	// Verify it retried exactly 3 times
+	assert.Equal(t, 3, status.Nodes[0].RetryCount, "Step should have retried exactly 3 times")
+
+	// Verify total time is approximately correct
+	// Expected: initial + 1s + 2s + 4s = 7s minimum
+	totalTime := time.Since(startTime)
+	assert.GreaterOrEqual(t, totalTime, 7*time.Second, "Total time should be at least 7 seconds")
+}
+
+func TestRetryPolicy_WithBackoffBoolean(t *testing.T) {
+	th := test.Setup(t, test.WithDAGsDir(test.TestdataPath(t, "integration")))
+
+	// Load DAG with boolean backoff
+	dag := th.DAG(t, filepath.Join("integration", "retry-with-backoff-bool.yaml"))
+	agent := dag.Agent()
+
+	// Record start time
+	startTime := time.Now()
+
+	// Run with timeout
+	ctx, cancel := context.WithTimeout(agent.Context, 30*time.Second)
+	defer cancel()
+
+	// Run the DAG (it will fail due to retry limit)
+	_ = agent.Run(ctx)
+
+	// Get the latest status
+	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	// Verify the step failed after retries
+	require.Len(t, status.Nodes, 1)
+	assert.Equal(t, scheduler.NodeStatusError, status.Nodes[0].Status)
+	assert.Equal(t, 3, status.Nodes[0].RetryCount)
+
+	// Verify timing (backoff: true should use 2.0 multiplier)
+	// Expected: initial + 1s + 2s + 4s = 7s minimum
+	totalTime := time.Since(startTime)
+	assert.GreaterOrEqual(t, totalTime, 7*time.Second, "Total time should be at least 7 seconds")
+}
+
+func TestRetryPolicy_WithMaxInterval(t *testing.T) {
+	th := test.Setup(t, test.WithDAGsDir(test.TestdataPath(t, "integration")))
+
+	// Load DAG with max interval cap
+	dag := th.DAG(t, filepath.Join("integration", "retry-with-backoff-max.yaml"))
+	agent := dag.Agent()
+
+	// Record start time
+	startTime := time.Now()
+
+	// Run with timeout
+	ctx, cancel := context.WithTimeout(agent.Context, 30*time.Second)
+	defer cancel()
+
+	// Run the DAG (it will fail due to retry limit)
+	_ = agent.Run(ctx)
+
+	// Get the latest status
+	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	// Verify it retried 5 times
+	require.Len(t, status.Nodes, 1)
+	assert.Equal(t, 5, status.Nodes[0].RetryCount)
+
+	// Verify timing with max interval cap
+	// backoff: 3.0, intervalSec: 1, maxIntervalSec: 5
+	// Expected intervals: 1s, 3s, 5s (capped), 5s (capped), 5s (capped)
+	// Total: initial + 1 + 3 + 5 + 5 + 5 = 19s minimum
+	totalTime := time.Since(startTime)
+	assert.GreaterOrEqual(t, totalTime, 19*time.Second, "Total time should be at least 19 seconds")
+	// Should not exceed 25 seconds (with some tolerance)
+	assert.LessOrEqual(t, totalTime, 25*time.Second, "Total time should not exceed 25 seconds")
+}
+
+func TestRepeatPolicy_WithExponentialBackoff(t *testing.T) {
+	th := test.Setup(t, test.WithDAGsDir(test.TestdataPath(t, "integration")))
+
+	// Load DAG with repeat backoff
+	dag := th.DAG(t, filepath.Join("integration", "repeat-with-backoff.yaml"))
+	agent := dag.Agent()
+
+	// Record start time
+	startTime := time.Now()
+
+	// Run with timeout
+	ctx, cancel := context.WithTimeout(agent.Context, 30*time.Second)
+	defer cancel()
+
+	err := agent.Run(ctx)
+	require.NoError(t, err, "DAG should complete successfully")
+
+	// Verify successful completion
+	dag.AssertLatestStatus(t, scheduler.StatusSuccess)
+
+	// Get the latest status
+	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	// Verify it repeated exactly 4 times
+	require.Len(t, status.Nodes, 1)
+	assert.Equal(t, scheduler.NodeStatusSuccess, status.Nodes[0].Status)
+	assert.Equal(t, 4, status.Nodes[0].DoneCount, "Step should have executed exactly 4 times")
+
+	// Verify timing
+	// Expected intervals: initial, then 1s, 2s, 4s = 7s minimum
+	totalTime := time.Since(startTime)
+	assert.GreaterOrEqual(t, totalTime, 7*time.Second, "Total time should be at least 7 seconds")
+}
+
+func TestRepeatPolicy_WithMaxInterval(t *testing.T) {
+	th := test.Setup(t, test.WithDAGsDir(test.TestdataPath(t, "integration")))
+
+	// Load DAG with max interval cap
+	dag := th.DAG(t, filepath.Join("integration", "repeat-with-backoff-max.yaml"))
+	agent := dag.Agent()
+
+	// Record start time
+	startTime := time.Now()
+
+	// Run with timeout
+	ctx, cancel := context.WithTimeout(agent.Context, 30*time.Second)
+	defer cancel()
+
+	err := agent.Run(ctx)
+	require.NoError(t, err, "DAG should complete successfully")
+
+	// Verify successful completion
+	dag.AssertLatestStatus(t, scheduler.StatusSuccess)
+
+	// Get the latest status
+	status, err := th.DAGRunMgr.GetLatestStatus(th.Context, dag.DAG)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+
+	// Verify it repeated exactly 5 times
+	require.Len(t, status.Nodes, 1)
+	assert.Equal(t, 5, status.Nodes[0].DoneCount, "Step should have executed exactly 5 times")
+
+	// Verify timing with max interval cap
+	// backoff: 3.0, intervalSec: 1, maxIntervalSec: 5
+	// Expected intervals: initial, then 1s, 3s, 5s (capped), 5s (capped)
+	// Total: initial + 1 + 3 + 5 + 5 = 14s minimum
+	totalTime := time.Since(startTime)
+	assert.GreaterOrEqual(t, totalTime, 14*time.Second, "Total time should be at least 14 seconds")
+	// Should not exceed 20 seconds (with some tolerance)
+	assert.LessOrEqual(t, totalTime, 20*time.Second, "Total time should not exceed 20 seconds")
+}

--- a/internal/testdata/digraph/repeat_policy_backoff.yaml
+++ b/internal/testdata/digraph/repeat_policy_backoff.yaml
@@ -1,0 +1,10 @@
+steps:
+  - name: "test_repeat_backoff"
+    command: "echo test"
+    repeatPolicy:
+      repeat: while
+      intervalSec: 5
+      backoff: 1.5
+      maxIntervalSec: 60
+      limit: 10
+      exitCode: [1]

--- a/internal/testdata/digraph/repeat_policy_backoff_bool.yaml
+++ b/internal/testdata/digraph/repeat_policy_backoff_bool.yaml
@@ -1,0 +1,11 @@
+steps:
+  - name: "test_repeat_backoff_bool"
+    command: "echo test"
+    repeatPolicy:
+      repeat: until
+      intervalSec: 2
+      backoff: true
+      maxIntervalSec: 20
+      limit: 5
+      condition: "echo done"
+      expected: "done"

--- a/internal/testdata/digraph/retry_policy_backoff.yaml
+++ b/internal/testdata/digraph/retry_policy_backoff.yaml
@@ -1,0 +1,8 @@
+steps:
+  - name: "test_backoff"
+    command: "echo test"
+    retryPolicy:
+      limit: 5
+      intervalSec: 2
+      backoff: 2.0
+      maxIntervalSec: 30

--- a/internal/testdata/digraph/retry_policy_backoff_bool.yaml
+++ b/internal/testdata/digraph/retry_policy_backoff_bool.yaml
@@ -1,0 +1,8 @@
+steps:
+  - name: "test_backoff_bool"
+    command: "echo test"
+    retryPolicy:
+      limit: 3
+      intervalSec: 1
+      backoff: true
+      maxIntervalSec: 10

--- a/internal/testdata/integration/repeat-with-backoff-max.yaml
+++ b/internal/testdata/integration/repeat-with-backoff-max.yaml
@@ -1,0 +1,13 @@
+name: repeat-with-backoff-max
+steps:
+  - name: repeat-step
+    command: |
+      echo "Execution at $(date +%s.%N)"
+      exit 0
+    repeatPolicy:
+      repeat: while
+      limit: 5
+      intervalSec: 1
+      backoff: 3.0
+      maxIntervalSec: 5  # Cap at 5 seconds
+      exitCode: [0]  # Repeat while exit code is 0

--- a/internal/testdata/integration/repeat-with-backoff.yaml
+++ b/internal/testdata/integration/repeat-with-backoff.yaml
@@ -1,0 +1,12 @@
+name: repeat-with-backoff
+steps:
+  - name: repeat-step
+    command: |
+      echo "Execution at $(date +%s.%N)"
+      exit 0
+    repeatPolicy:
+      repeat: while
+      limit: 4
+      intervalSec: 1
+      backoff: 2.0
+      exitCode: [0]  # Repeat while exit code is 0

--- a/internal/testdata/integration/retry-with-backoff-bool.yaml
+++ b/internal/testdata/integration/retry-with-backoff-bool.yaml
@@ -1,0 +1,11 @@
+name: retry-with-backoff-bool
+steps:
+  - name: failing-step
+    command: |
+      echo "Attempt at $(date +%s.%N)"
+      exit 1
+    retryPolicy:
+      limit: 3
+      intervalSec: 1
+      backoff: true  # Should use default 2.0 multiplier
+      exitCode: [1]

--- a/internal/testdata/integration/retry-with-backoff-max.yaml
+++ b/internal/testdata/integration/retry-with-backoff-max.yaml
@@ -1,0 +1,12 @@
+name: retry-with-backoff-max
+steps:
+  - name: failing-step
+    command: |
+      echo "Attempt at $(date +%s.%N)"
+      exit 1
+    retryPolicy:
+      limit: 5
+      intervalSec: 1
+      backoff: 3.0
+      maxIntervalSec: 5  # Cap at 5 seconds
+      exitCode: [1]

--- a/internal/testdata/integration/retry-with-backoff.yaml
+++ b/internal/testdata/integration/retry-with-backoff.yaml
@@ -1,0 +1,11 @@
+name: retry-with-backoff
+steps:
+  - name: failing-step
+    command: |
+      echo "Attempt at $(date +%s.%N)"
+      exit 1
+    retryPolicy:
+      limit: 3
+      intervalSec: 1
+      backoff: 2.0
+      exitCode: [1]

--- a/schemas/dag.schema.json
+++ b/schemas/dag.schema.json
@@ -498,6 +498,23 @@
               ],
               "description": "Seconds to wait between retry attempts"
             },
+            "backoff": {
+              "oneOf": [
+                {
+                  "type": "boolean",
+                  "description": "When true, uses default multiplier of 2.0"
+                },
+                {
+                  "type": "number",
+                  "description": "Custom exponential backoff multiplier"
+                }
+              ],
+              "description": "Exponential backoff multiplier for retry delays"
+            },
+            "maxIntervalSec": {
+              "type": "integer",
+              "description": "Maximum interval in seconds (caps exponential growth)"
+            },
             "exitCode": {
               "type": "array",
               "items": {
@@ -531,6 +548,23 @@
               "type": "integer",
               "minimum": 1,
               "description": "Maximum number of times this step will be executed. Once reached, the step stops repeating regardless of other conditions."
+            },
+            "backoff": {
+              "oneOf": [
+                {
+                  "type": "boolean",
+                  "description": "When true, uses default multiplier of 2.0"
+                },
+                {
+                  "type": "number",
+                  "description": "Custom exponential backoff multiplier"
+                }
+              ],
+              "description": "Exponential backoff multiplier for repeat delays"
+            },
+            "maxIntervalSec": {
+              "type": "integer",
+              "description": "Maximum interval in seconds (caps exponential growth)"
             },
             "condition": {
               "type": "string",


### PR DESCRIPTION
Users need exponential backoff to avoid overwhelming failed services with constant retry intervals. They have to manually implement increasing delays or risk causing cascading failures.

As a solution, this PR adds a `backoff` field to retry and repeat policies that automatically increases intervals exponentially, with an optional `maxIntervalSec` cap.

Follow-up to: #1093

**Changes**
- Added `backoff` field (float64) to RetryPolicy and RepeatPolicy structs
- Added `maxIntervalSec` field to cap exponential growth
- Implemented backoff calculation with formula: `interval * (backoff ^ attemptCount)`
- Support for boolean backoff (`true` = 2.0 default multiplier)
- Added validation that backoff must be > 1.0
- Updated API schemas (v1 and v2) and JSON schema
- Added comprehensive integration tests
- Updated documentation across all relevant files

**Example**
```yaml
steps:
  - name: api-call
    command: curl https://api.example.com
    retryPolicy:
      limit: 5
      intervalSec: 2
      backoff: true        # true = 2.0 multiplier
      maxIntervalSec: 60   # Cap at 60 seconds
      # Intervals: 2s, 4s, 8s, 16s, 32s → 60s
      
  - name: wait-for-service
    command: nc -z localhost 8080
    repeatPolicy:
      repeat: while
      exitCode: [1]        # While connection fails
      intervalSec: 1
      backoff: 1.5         # Custom multiplier
      maxIntervalSec: 30
      # Intervals: 1s, 1.5s, 2.25s, 3.375s...
```