### PR TITLE
fix: preserve previous DAG state when dequeuing

### DIFF
--- a/internal/agent/dbclient_test.go
+++ b/internal/agent/dbclient_test.go
@@ -240,9 +240,16 @@ func (m *mockDAGStore) IsSuspended(ctx context.Context, fileName string) bool {
 	return args.Bool(0)
 }
 
+var _ models.DAGRunStore = (*mockDAGRunStore)(nil)
+
 // mockDAGRunStore implements models.DAGRunStore
 type mockDAGRunStore struct {
 	mock.Mock
+}
+
+// RemoveDAGRun implements models.DAGRunStore.
+func (m *mockDAGRunStore) RemoveDAGRun(ctx context.Context, dagRun digraph.DAGRunRef) error {
+	panic("unimplemented")
 }
 
 func (m *mockDAGRunStore) CreateAttempt(ctx context.Context, dag *digraph.DAG, ts time.Time, dagRunID string, opts models.NewDAGRunAttemptOptions) (models.DAGRunAttempt, error) {
@@ -357,4 +364,14 @@ func (m *mockDAGRunAttempt) GetOutputs() *executor.SyncMap {
 		m.outputs = &executor.SyncMap{}
 	}
 	return m.outputs
+}
+
+func (m *mockDAGRunAttempt) Hide(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockDAGRunAttempt) Hidden() bool {
+	args := m.Called()
+	return args.Bool(0)
 }

--- a/internal/cmd/dequeue_test.go
+++ b/internal/cmd/dequeue_test.go
@@ -1,10 +1,15 @@
 package cmd_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dagu-org/dagu/internal/cmd"
+	"github.com/dagu-org/dagu/internal/digraph"
+	"github.com/dagu-org/dagu/internal/digraph/status"
 	"github.com/dagu-org/dagu/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDequeueCommand(t *testing.T) {
@@ -24,4 +29,50 @@ func TestDequeueCommand(t *testing.T) {
 		Args:        []string{"dequeue", "--dag-run", "dequeue:test-DAG"},
 		ExpectedOut: []string{"Dequeued dag-run"},
 	})
+}
+
+func TestDequeueCommand_PreservesState(t *testing.T) {
+	th := test.SetupCommand(t)
+	ctx := context.Background()
+
+	// Create a DAG
+	dag := th.DAG(t, "cmd/dequeue_preserves_state.yaml")
+
+	// First run the DAG successfully
+	th.RunCommand(t, cmd.CmdStart(), test.CmdTest{
+		Name: "RunDAG",
+		Args: []string{"start", "--run-id", "success-run", dag.Location},
+	})
+
+	// Wait for it to complete
+	attempt, err := th.DAGRunStore.FindAttempt(ctx, digraph.DAGRunRef{
+		Name: "dequeue_preserves_state",
+		ID:   "success-run",
+	})
+	require.NoError(t, err)
+
+	dagStatus, err := attempt.ReadStatus(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, status.Success, dagStatus.Status)
+
+	// Now enqueue a new run
+	th.RunCommand(t, cmd.CmdEnqueue(), test.CmdTest{
+		Name: "Enqueue",
+		Args: []string{"enqueue", "--run-id", "queued-run", dag.Location},
+	})
+
+	// Dequeue it
+	th.RunCommand(t, cmd.CmdDequeue(), test.CmdTest{
+		Name:        "Dequeue",
+		Args:        []string{"dequeue", "--dag-run", "dequeue_preserves_state:queued-run"},
+		ExpectedOut: []string{"Dequeued dag-run"},
+	})
+
+	// Verify the latest visible attempt shows success
+	latestAttempt, err := th.DAGRunStore.LatestAttempt(ctx, "dequeue_preserves_state")
+	require.NoError(t, err)
+
+	latestStatus, err := latestAttempt.ReadStatus(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, status.Success, latestStatus.Status, "Latest visible status should be Success")
 }

--- a/internal/integration/parallel_test.go
+++ b/internal/integration/parallel_test.go
@@ -872,7 +872,7 @@ steps:
 		require.Contains(t, results, `"failed": 1`)
 
 		// Only successful output should be captured
-		outputsValue := strings.Split(value.(string), `"outputs":`)[1]
+		outputsValue := strings.SplitN(value.(string), `"outputs": [`, 2)[1]
 		require.Contains(t, outputsValue, "Output for success")
 		require.NotContains(t, outputsValue, `"Output for fail"`)
 

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -101,7 +101,7 @@ type mockDAGRunStore struct {
 }
 
 // RemoveDAGRun implements models.DAGRunStore.
-func (m *mockDAGRunStore) RemoveDAGRun(ctx context.Context, dagRun digraph.DAGRunRef) error {
+func (m *mockDAGRunStore) RemoveDAGRun(_ context.Context, _ digraph.DAGRunRef) error {
 	panic("unimplemented")
 }
 

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -94,8 +94,15 @@ func (m *mockDAGStore) IsSuspended(ctx context.Context, fileName string) bool {
 	return args.Bool(0)
 }
 
+var _ models.DAGRunStore = (*mockDAGRunStore)(nil)
+
 type mockDAGRunStore struct {
 	mock.Mock
+}
+
+// RemoveDAGRun implements models.DAGRunStore.
+func (m *mockDAGRunStore) RemoveDAGRun(ctx context.Context, dagRun digraph.DAGRunRef) error {
+	panic("unimplemented")
 }
 
 func (m *mockDAGRunStore) CreateAttempt(ctx context.Context, dag *digraph.DAG, ts time.Time, dagRunID string, opts models.NewDAGRunAttemptOptions) (models.DAGRunAttempt, error) {

--- a/internal/models/dagrun.go
+++ b/internal/models/dagrun.go
@@ -42,6 +42,8 @@ type DAGRunStore interface {
 	// The name means the DAG name, renaming it will allow user to manage those runs
 	// with the new DAG name.
 	RenameDAGRuns(ctx context.Context, oldName, newName string) error
+	// RemoveDAGRun removes a dag-run record by its reference.
+	RemoveDAGRun(ctx context.Context, dagRun digraph.DAGRunRef) error
 }
 
 // ListDAGRunStatusesOptions contains options for listing runs
@@ -126,4 +128,9 @@ type DAGRunAttempt interface {
 	RequestCancel(ctx context.Context) error
 	// CancelRequested checks if a cancellation has been requested for this attempt.
 	CancelRequested(ctx context.Context) (bool, error)
+	// Hide marks the attempt as hidden from normal operations.
+	// This is useful for preserving previous state visibility when dequeuing.
+	Hide(ctx context.Context) error
+	// Hidden returns true if the attempt is hidden from normal operations.
+	Hidden() bool
 }

--- a/internal/models/dagrun_test.go
+++ b/internal/models/dagrun_test.go
@@ -127,6 +127,16 @@ func (m *mockDAGRunAttempt) CancelRequested(ctx context.Context) (bool, error) {
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *mockDAGRunAttempt) Hide(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockDAGRunAttempt) Hidden() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
 // Tests
 
 func TestListDAGRunStatusesOptions(t *testing.T) {

--- a/internal/persistence/filedagrun/attempt_test.go
+++ b/internal/persistence/filedagrun/attempt_test.go
@@ -386,6 +386,32 @@ func TestSafeRename(t *testing.T) {
 	assert.Equal(t, "new content", string(content))
 }
 
+func TestAttempt_HideAndIsHidden(t *testing.T) {
+	ctx := context.Background()
+
+	// Create attempt
+	dir := createTempDir(t)
+	statusFile := filepath.Join(dir, "status.dat")
+	att, err := NewAttempt(statusFile, nil)
+	require.NoError(t, err)
+
+	// Initially not hidden
+	assert.False(t, att.Hidden())
+
+	// Can't hide when open
+	require.NoError(t, att.Open(ctx))
+	assert.ErrorIs(t, att.Hide(ctx), ErrStatusFileOpen)
+
+	// Can hide after close
+	require.NoError(t, att.Close(ctx))
+	require.NoError(t, att.Hide(ctx))
+	assert.True(t, att.Hidden())
+
+	// Idempotent
+	require.NoError(t, att.Hide(ctx))
+	assert.True(t, att.Hidden())
+}
+
 // createTempDir creates a temporary directory for testing
 func createTempDir(t *testing.T) string {
 	t.Helper()

--- a/internal/persistence/filedagrun/dataroot.go
+++ b/internal/persistence/filedagrun/dataroot.go
@@ -515,17 +515,20 @@ func listDirsSorted(path string, reverse bool, pattern *regexp.Regexp) ([]string
 	if err != nil {
 		return nil, err
 	}
+
 	var dirs []string
 	if pattern != nil {
 		for _, entry := range entries {
-			if entry.IsDir() && pattern.MatchString(entry.Name()) {
-				dirs = append(dirs, entry.Name())
+			name := entry.Name()
+			if entry.IsDir() && pattern.MatchString(name) {
+				dirs = append(dirs, name)
 			}
 		}
 	} else {
 		for _, entry := range entries {
+			name := entry.Name()
 			if entry.IsDir() {
-				dirs = append(dirs, entry.Name())
+				dirs = append(dirs, name)
 			}
 		}
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -247,6 +247,12 @@ func (s *Scheduler) handleQueue(ctx context.Context, ch chan models.QueuedItem, 
 				goto SEND_RESULT
 			}
 
+			if attempt.Hidden() {
+				logger.Info(ctx, "DAG run is hidden, marking as discard", "data", data)
+				result = models.QueuedItemProcessingResultDiscard
+				goto SEND_RESULT
+			}
+
 			dag, err = attempt.ReadDAG(ctx)
 			if err != nil {
 				logger.Error(ctx, "Failed to read dag", "err", err, "data", data)

--- a/internal/testdata/cmd/dequeue_preserves_state.yaml
+++ b/internal/testdata/cmd/dequeue_preserves_state.yaml
@@ -1,0 +1,4 @@
+name: dequeue_preserves_state
+steps:
+  - name: step1
+    command: echo "success"

--- a/ui/src/pages/dag-runs/dag-run/index.tsx
+++ b/ui/src/pages/dag-runs/dag-run/index.tsx
@@ -22,7 +22,7 @@ function DAGRunDetailsPage() {
     : '/dag-runs/{name}/{dagRunId}';
 
   // Fetch DAG-run details
-  const { data, mutate } = useQuery(
+  const { data, error, mutate } = useQuery(
     endpoint,
     {
       params: {
@@ -47,6 +47,41 @@ function DAGRunDetailsPage() {
   const refreshFn = React.useCallback(() => {
     setTimeout(() => mutate(), 500);
   }, [mutate]);
+
+  // Handle 404 error for dequeued DAG runs
+  if (error) {
+    const statusCode = (error as any)?.response?.status;
+    if (statusCode === 404) {
+      return (
+        <div className="container mx-auto">
+          <div className="bg-slate-100 dark:bg-slate-800 rounded-lg p-6 m-4">
+            <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-200 mb-2">
+              DAG Run Not Found
+            </h2>
+            <p className="text-slate-600 dark:text-slate-400">
+              This DAG run may have been dequeued or removed. The previous state is no longer available.
+            </p>
+            <p className="text-sm text-slate-500 dark:text-slate-500 mt-2">
+              DAG: {name} | Run ID: {dagRunId}
+            </p>
+          </div>
+        </div>
+      );
+    }
+    // For other errors, show a generic error message
+    return (
+      <div className="container mx-auto">
+        <div className="bg-red-50 dark:bg-red-900/20 rounded-lg p-6 m-4">
+          <h2 className="text-lg font-semibold text-red-800 dark:text-red-200 mb-2">
+            Error Loading DAG Run
+          </h2>
+          <p className="text-red-600 dark:text-red-400">
+            {(error as any)?.message || 'Failed to load DAG run details'}
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   if (!data) {
     return null;


### PR DESCRIPTION
When a DAG run is dequeued, it now preserves the previous successful state visibility instead of showing only 'Canceled'.

Issue: #1117

**Changes:**
- Added Hide() and Hidden() methods to DAGRunAttempt interface
- Implemented directory-based hiding using dot prefix convention
- Updated dequeue command to cancel and hide attempts
- Fixed UI to show proper error message for 404 errors on dequeued runs