### PR TITLE
UI improvements: Simplify DAG execution and add manual sidebar toggle

### DIFF
--- a/ui/src/features/dags/components/common/DAGActions.tsx
+++ b/ui/src/features/dags/components/common/DAGActions.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/tooltip'; // Import Shadcn Tooltip
 import dayjs from '@/lib/dayjs';
 import StatusChip from '@/ui/StatusChip';
-import { Play, RefreshCw, Square, Clock } from 'lucide-react'; // Import lucide icons
+import { Play, RefreshCw, Square } from 'lucide-react'; // Import lucide icons
 import React from 'react';
 import { components } from '../../../../api/v2/schema';
 import { AppBarContext } from '../../../../contexts/AppBarContext';
@@ -57,7 +57,6 @@ function DAGActions({
 }: Props) {
   const appBarContext = React.useContext(AppBarContext);
   const config = useConfig();
-  const [isStartModal, setIsStartModal] = React.useState(false);
   const [isEnqueueModal, setIsEnqueueModal] = React.useState(false);
   const [isStopModal, setIsStopModal] = React.useState(false);
   const [isRetryModal, setIsRetryModal] = React.useState(false);
@@ -76,7 +75,6 @@ function DAGActions({
 
   // Determine which buttons should be enabled based on current status
   const buttonState = {
-    start: status?.status != 1, // Disable only when running (1)
     enqueue: true, // Always allow enqueuing
     stop: status?.status == 1,
     retry: status?.status != 1 && status?.status != 5 && status?.dagRunId != '', // Disable when running (1) or queued (5)
@@ -91,38 +89,6 @@ function DAGActions({
       <div
         className={`flex items-center ${displayMode === 'compact' ? 'space-x-1' : 'space-x-2'}`}
       >
-        {/* Start Button */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            {displayMode === 'compact' ? (
-              <Button
-                variant="ghost"
-                size="icon"
-                disabled={!buttonState['start']}
-                onClick={() => setIsStartModal(true)}
-                className="h-8 w-8 disabled:text-gray-400 dark:disabled:text-gray-600 cursor-pointer"
-              >
-                <Play className="h-4 w-4" />
-                <span className="sr-only">Start</span>
-              </Button>
-            ) : (
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!buttonState['start']}
-                onClick={() => setIsStartModal(true)}
-                className="h-8 disabled:text-gray-400 dark:disabled:text-gray-600 cursor-pointer"
-              >
-                <Play className="mr-2 h-4 w-4" />
-                Start
-              </Button>
-            )}
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Start DAG execution</p>
-          </TooltipContent>
-        </Tooltip>
-
         {/* Enqueue Button */}
         <Tooltip>
           <TooltipTrigger asChild>
@@ -134,7 +100,7 @@ function DAGActions({
                 onClick={() => setIsEnqueueModal(true)}
                 className="h-8 w-8 disabled:text-gray-400 dark:disabled:text-gray-600 cursor-pointer"
               >
-                <Clock className="h-4 w-4" />
+                <Play className="h-4 w-4" />
                 <span className="sr-only">Enqueue</span>
               </Button>
             ) : (
@@ -145,13 +111,13 @@ function DAGActions({
                 onClick={() => setIsEnqueueModal(true)}
                 className="h-8 disabled:text-gray-400 dark:disabled:text-gray-600 cursor-pointer"
               >
-                <Clock className="mr-2 h-4 w-4" />
+                <Play className="mr-2 h-4 w-4" />
                 Enqueue
               </Button>
             )}
           </TooltipTrigger>
           <TooltipContent>
-            <p>Enqueue DAG execution</p>
+            <p>Start DAG execution</p>
           </TooltipContent>
         </Tooltip>
 
@@ -471,41 +437,6 @@ function DAGActions({
             )}
           </div>
         </ConfirmModal>
-        <StartDAGModal
-          dag={dag}
-          visible={isStartModal}
-          action="start"
-          onSubmit={async (params, dagRunId) => {
-            setIsStartModal(false);
-            const body: { params: string; dagRunId?: string } = { params };
-            if (dagRunId) {
-              body.dagRunId = dagRunId;
-            }
-            const { error } = await client.POST('/dags/{fileName}/start', {
-              params: {
-                path: {
-                  fileName: fileName,
-                },
-                query: {
-                  remoteNode: appBarContext.selectedRemoteNode || 'local',
-                },
-              },
-              body,
-            });
-            if (error) {
-              alert(error.message || 'An error occurred');
-              return;
-            }
-            reloadData();
-            // Navigate to status tab after execution
-            if (navigateToStatusTab) {
-              navigateToStatusTab();
-            }
-          }}
-          dismissModal={() => {
-            setIsStartModal(false);
-          }}
-        />
         <StartDAGModal
           dag={dag}
           visible={isEnqueueModal}

--- a/ui/src/features/dags/components/dag-execution/StartDAGModal.tsx
+++ b/ui/src/features/dags/components/dag-execution/StartDAGModal.tsx
@@ -116,7 +116,7 @@ function StartDAGModal({
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <DialogTitle>
-            {action === 'enqueue' ? 'Enqueue the DAG' : 'Start the DAG'}
+            Start the DAG
           </DialogTitle>
         </DialogHeader>
 

--- a/ui/src/layouts/Layout.tsx
+++ b/ui/src/layouts/Layout.tsx
@@ -78,8 +78,11 @@ type LayoutProps = {
 // Main Content component including Sidebar and AppBar logic
 function Content({ title, navbarColor, children }: LayoutProps) {
   const [scrolled, setScrolled] = React.useState(false);
-  // Sidebar is always visible in collapsed state by default on desktop
-  const [isSidebarExpanded, setIsSidebarExpanded] = React.useState(false);
+  // Sidebar state with localStorage persistence
+  const [isSidebarExpanded, setIsSidebarExpanded] = React.useState(() => {
+    const saved = localStorage.getItem('sidebarExpanded');
+    return saved ? saved === 'true' : false;
+  });
   // Mobile sidebar state (hidden by default)
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = React.useState(false);
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -93,6 +96,16 @@ function Content({ title, navbarColor, children }: LayoutProps) {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  // Save sidebar state to localStorage when it changes
+  React.useEffect(() => {
+    localStorage.setItem('sidebarExpanded', isSidebarExpanded.toString());
+  }, [isSidebarExpanded]);
+
+  // Toggle sidebar function
+  const toggleSidebar = () => {
+    setIsSidebarExpanded(!isSidebarExpanded);
+  };
+
   return (
     <div className="flex h-screen w-screen overflow-hidden bg-background">
       {/* Desktop Sidebar - Hidden on mobile, visible in collapsed state on desktop */}
@@ -104,17 +117,16 @@ function Content({ title, navbarColor, children }: LayoutProps) {
           'shadow-lg',
           // Hidden on mobile, visible on desktop
           'hidden md:block',
-          'z-40 transition-all duration-50 ease-in-out',
+          'z-40 transition-all duration-200 ease-in-out',
           isSidebarExpanded ? 'w-60' : sidebarWidthCollapsed
         )}
-        onMouseEnter={() => setIsSidebarExpanded(true)}
-        onMouseLeave={() => setIsSidebarExpanded(false)}
       >
         {/* Simplified flex column layout */}
         <div className="flex flex-col h-full">
           <nav className="flex-1">
             <MainListItems
               isOpen={isSidebarExpanded}
+              onToggle={toggleSidebar}
               // Don't collapse sidebar on navigation to prevent jarring transition
             />
           </nav>

--- a/ui/src/menu.tsx
+++ b/ui/src/menu.tsx
@@ -1,7 +1,7 @@
 import logoDark from '@/assets/images/logo_dark.png';
 import { useConfig } from '@/contexts/ConfigContext';
 import { cn } from '@/lib/utils'; // Assuming cn utility is available
-import { BarChart2, GitBranch, List, Search, Server } from 'lucide-react';
+import { BarChart2, GitBranch, List, Search, Server, PanelLeft } from 'lucide-react';
 import * as React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
@@ -25,40 +25,78 @@ function Icon({
   );
 }
 
-// Define props for mainListItems to accept isOpen and onNavItemClick
+// Define props for mainListItems to accept isOpen, onNavItemClick, and onToggle
 type MainListItemsProps = {
   isOpen?: boolean;
   onNavItemClick?: () => void;
+  onToggle?: () => void;
 };
 
 // Main navigation items structure - now accepts isOpen prop
 export const mainListItems = React.forwardRef<
   HTMLDivElement,
   MainListItemsProps
->(({ isOpen = false, onNavItemClick }, ref) => {
+>(({ isOpen = false, onNavItemClick, onToggle }, ref) => {
   // Get version from config at the top level of the component
   const config = useConfig();
 
+  // State for hover
+  const [isHovered, setIsHovered] = React.useState(false);
+
   return (
     <div ref={ref} className="flex flex-col h-full">
-      {/* Fixed height header with absolute positioning for fixed logo */}
+      {/* Fixed height header with menu toggle button */}
       <div className="h-12 relative mb-2">
-        {/* Fixed position logo that doesn't move */}
-        <div className="absolute left-3 top-1/2 transform -translate-y-1/2 w-6 h-6 flex items-center justify-center z-10">
-          <img
-            src={logoDark}
-            alt="Dagu Logo"
-            className="w-6 h-6 object-contain"
-          />
-        </div>
+        {/* When collapsed: Show Dagu icon, switch to panel icon on hover */}
+        {!isOpen && (
+          <button
+            onClick={() => {
+              setIsHovered(false);
+              onToggle?.();
+            }}
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+            className="absolute left-3 top-1/2 transform -translate-y-1/2 w-6 h-6 flex items-center justify-center z-10 transition-all duration-200 cursor-pointer"
+            aria-label="Toggle sidebar"
+          >
+            {isHovered ? (
+              <PanelLeft size={20} className="text-primary-foreground hover:text-primary-foreground/70" />
+            ) : (
+              <img
+                src={logoDark}
+                alt="Dagu Logo"
+                className="w-6 h-6 object-contain"
+              />
+            )}
+          </button>
+        )}
 
-        {/* Text container with instant hide/show */}
+        {/* When expanded: Dagu logo on left, panel icon on right */}
         {isOpen && (
-          <div className="absolute inset-0 flex items-center pl-12">
-            <span className="font-bold tracking-wide select-none text-xl text-primary-foreground">
-              Dagu
-            </span>
-          </div>
+          <>
+            <div className="absolute left-3 top-1/2 transform -translate-y-1/2 w-6 h-6 flex items-center justify-center z-10">
+              <img
+                src={logoDark}
+                alt="Dagu Logo"
+                className="w-6 h-6 object-contain"
+              />
+            </div>
+            <div className="absolute inset-0 flex items-center pl-12">
+              <span className="font-bold tracking-wide select-none text-xl text-primary-foreground">
+                Dagu
+              </span>
+            </div>
+            <button
+              onClick={() => {
+              setIsHovered(false);
+              onToggle?.();
+            }}
+              className="absolute right-3 top-1/2 transform -translate-y-1/2 w-6 h-6 flex items-center justify-center z-10 text-primary-foreground/40 hover:text-primary-foreground/70 transition-all duration-200 cursor-pointer"
+              aria-label="Toggle sidebar"
+            >
+              <PanelLeft size={20} />
+            </button>
+          </>
         )}
       </div>
       {/* Navigation */}
@@ -133,7 +171,7 @@ function NavItem({ to, icon, text, isOpen, onClick }: NavItemProps) {
           to={to}
           onClick={onClick}
           className={cn(
-            'block h-9 flex items-center text-xs font-medium rounded-lg transition-all duration-50 ease-in-out pl-10 pr-3',
+            'block h-9 flex items-center text-xs font-medium rounded-lg transition-all duration-200 ease-in-out pl-10 pr-3',
             isActive
               ? 'text-primary-foreground bg-primary-foreground/10' // Active: subtle background
               : 'text-primary-foreground hover:text-primary-foreground hover:bg-primary-foreground/5' // Inactive: lighter green for better contrast
@@ -160,7 +198,7 @@ function NavItem({ to, icon, text, isOpen, onClick }: NavItemProps) {
           to={to}
           onClick={onClick}
           className={cn(
-            'flex items-center justify-center w-8 h-8 text-xs font-medium rounded-lg transition-all duration-50 ease-in-out',
+            'flex items-center justify-center w-8 h-8 text-xs font-medium rounded-lg transition-all duration-200 ease-in-out',
             isActive
               ? 'text-primary-foreground bg-primary-foreground/10' // Active: subtle background
               : 'text-primary-foreground hover:text-primary-foreground hover:bg-primary-foreground/5'


### PR DESCRIPTION
This PR addresses two UI improvement requests from user feedback to enhance the user experience.

Issue: #1110 and #1104
Feedback-from: @ghansham and @ghansham_san

**Changes:**
- Removed the Start button from DAG actions, keeping only Enqueue button with play icon
- Replaced automatic hover-based sidebar expansion with manual toggle control
- Added localStorage persistence for sidebar state
- Implemented smooth transitions (200ms) for better UX
- Added interactive toggle button that shows Dagu icon when collapsed, panel icon on hover

**Why:**
1. The Start button didn't respect queue configuration while Enqueue did, causing confusion
2. The sidebar's automatic hover expansion was too sensitive and annoying for users
3. Users wanted more control over the UI layout with persistent preferences

**Example:**
Before: Two buttons (Start/Enqueue) with different behaviors, sidebar expanding on every hover
After: Single Enqueue button that respects queue config, sidebar with manual toggle that remembers state