### PR TITLE
fix: handle orphaned running DAGs after unexpected restarts

### DIFF
--- a/internal/dagrun/manager_test.go
+++ b/internal/dagrun/manager_test.go
@@ -158,6 +158,63 @@ steps:
 		err := cli.UpdateStatus(ctx, root, status)
 		require.Error(t, err)
 	})
+	t.Run("OrphanedRunningStatus", func(t *testing.T) {
+		// Test that when a DAG is marked as running but has no alive process,
+		// GetLatestStatus correctly updates it to error status
+		dag := th.DAG(t, `steps:
+  - name: "1"
+    command: "sleep 10"
+`)
+		ctx := th.Context
+
+		// Start a DAG run
+		err := th.DAGRunMgr.StartDAGRunAsync(ctx, dag.DAG, dagrun.StartOptions{})
+		require.NoError(t, err)
+
+		// Wait for it to start running
+		time.Sleep(100 * time.Millisecond)
+
+		// Get the latest status - should be running
+		dagRunStatus, err := th.DAGRunMgr.GetLatestStatus(ctx, dag.DAG)
+		require.NoError(t, err)
+		require.Equal(t, status.Running.String(), dagRunStatus.Status.String())
+
+		// Now simulate the process dying by removing the process file
+		// First, stop the DAG to kill the process
+		err = th.DAGRunMgr.Stop(ctx, dag.DAG, dagRunStatus.DAGRunID)
+		require.NoError(t, err)
+
+		// Wait for process to be cleaned up
+		time.Sleep(100 * time.Millisecond)
+
+		// Manually update the status back to running to simulate orphaned state
+		dagRunRef := digraph.NewDAGRunRef(dag.Name, dagRunStatus.DAGRunID)
+		attempt, err := th.DAGRunStore.FindAttempt(ctx, dagRunRef)
+		require.NoError(t, err)
+
+		// Force status to running
+		runningStatus := dagRunStatus
+		runningStatus.Status = status.Running
+		err = attempt.Open(ctx)
+		require.NoError(t, err)
+		err = attempt.Write(ctx, runningStatus)
+		require.NoError(t, err)
+		err = attempt.Close(ctx)
+		require.NoError(t, err)
+
+		// Now when we get the latest status, it should detect the process is dead
+		// and update the status to error
+		dagRunStatus, err = th.DAGRunMgr.GetLatestStatus(ctx, dag.DAG)
+		require.NoError(t, err)
+		require.Equal(t, status.Error.String(), dagRunStatus.Status.String())
+
+		// Verify the status was persisted as error
+		attempt, err = th.DAGRunStore.FindAttempt(ctx, dagRunRef)
+		require.NoError(t, err)
+		persistedStatus, err := attempt.ReadStatus(ctx)
+		require.NoError(t, err)
+		require.Equal(t, status.Error.String(), persistedStatus.Status.String())
+	})
 }
 
 func TestClient_RunDAG(t *testing.T) {

--- a/internal/models/proc.go
+++ b/internal/models/proc.go
@@ -14,6 +14,8 @@ type ProcStore interface {
 	// CountAlive retrieves the number of processes associated with a given DAG name.
 	// It only counts the processes that are alive.
 	CountAlive(ctx context.Context, name string) (int, error)
+	// IsRunAlive checks if a specific DAG run is currently alive.
+	IsRunAlive(ctx context.Context, dagRun digraph.DAGRunRef) (bool, error)
 }
 
 // ProcHandle represents a process that is associated with a dag-run.

--- a/internal/persistence/filedagrun/attempt.go
+++ b/internal/persistence/filedagrun/attempt.go
@@ -443,7 +443,7 @@ func (att *Attempt) RequestCancel(ctx context.Context) error {
 	}
 	cancelFile := filepath.Join(dir, CancelRequestedFlag)
 	if _, err := os.Stat(cancelFile); err == nil {
-		return fmt.Errorf("cancel request already exists: %w", ErrStatusFileOpen)
+		return nil
 	}
 	if err := os.WriteFile(cancelFile, []byte{}, 0600); err != nil {
 		return fmt.Errorf("failed to create cancel request file: %w", err)

--- a/internal/persistence/fileproc/store_test.go
+++ b/internal/persistence/fileproc/store_test.go
@@ -49,3 +49,111 @@ func TestStore(t *testing.T) {
 	require.NoError(t, err, "failed to count proc files")
 	require.Equal(t, 0, count, "expected 0 proc files")
 }
+
+func TestStore_IsRunAlive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	store := New(baseDir)
+
+	t.Run("NoProcessFile", func(t *testing.T) {
+		dagRun := digraph.DAGRunRef{
+			Name: "test-dag",
+			ID:   "run-123",
+		}
+
+		// Test when no process file exists
+		alive, err := store.IsRunAlive(ctx, dagRun)
+		require.NoError(t, err)
+		require.False(t, alive)
+	})
+
+	t.Run("AliveProcess", func(t *testing.T) {
+		dagRun := digraph.DAGRunRef{
+			Name: "test-dag",
+			ID:   "run-456",
+		}
+
+		// Create a process and start heartbeat
+		proc, err := store.Acquire(ctx, dagRun)
+		require.NoError(t, err)
+
+		// Give a moment for the heartbeat to start
+		time.Sleep(time.Millisecond * 50)
+
+		// Check if the run is alive
+		alive, err := store.IsRunAlive(ctx, dagRun)
+		require.NoError(t, err)
+		require.True(t, alive)
+
+		// Stop the process
+		err = proc.Stop(ctx)
+		require.NoError(t, err)
+
+		// Check again - should be false now
+		alive, err = store.IsRunAlive(ctx, dagRun)
+		require.NoError(t, err)
+		require.False(t, alive)
+	})
+
+	t.Run("DifferentRunID", func(t *testing.T) {
+		// Create a process for one run ID
+		dagRun1 := digraph.DAGRunRef{
+			Name: "test-dag-3",
+			ID:   "run-789",
+		}
+		proc1, err := store.Acquire(ctx, dagRun1)
+		require.NoError(t, err)
+
+		// Give a moment for the heartbeat to start
+		time.Sleep(time.Millisecond * 50)
+
+		// Check for a different run ID
+		dagRun2 := digraph.DAGRunRef{
+			Name: "test-dag-3",
+			ID:   "run-999",
+		}
+		alive, err := store.IsRunAlive(ctx, dagRun2)
+		require.NoError(t, err)
+		require.False(t, alive)
+
+		// Check the original run is still alive
+		alive, err = store.IsRunAlive(ctx, dagRun1)
+		require.NoError(t, err)
+		require.True(t, alive)
+
+		// Cleanup
+		err = proc1.Stop(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("StaleProcess", func(t *testing.T) {
+		// Create a store with very short stale time for testing
+		shortStore := &Store{
+			baseDir:   baseDir,
+			staleTime: time.Millisecond * 100,
+		}
+
+		dagRun := digraph.DAGRunRef{
+			Name: "test-dag-stale",
+			ID:   "run-stale",
+		}
+
+		// Create a process
+		proc, err := shortStore.Acquire(ctx, dagRun)
+		require.NoError(t, err)
+
+		// Stop the heartbeat immediately
+		err = proc.Stop(ctx)
+		require.NoError(t, err)
+
+		// Wait for the process to become stale
+		time.Sleep(time.Millisecond * 150)
+
+		// Check if the run is alive (should be false and file should be cleaned up)
+		alive, err := shortStore.IsRunAlive(ctx, dagRun)
+		require.NoError(t, err)
+		require.False(t, alive)
+	})
+}


### PR DESCRIPTION
## Overview

When Dagu or Docker restarts unexpectedly during DAG execution, DAGs can remain stuck in "running" state indefinitely. This prevents new scheduled runs from starting and requires manual database intervention to resolve.

This PR implements automatic recovery for orphaned running DAGs by checking if the underlying process is still alive.

Issue: #1103
Feedback from: @AyHa1810

## Changes

- Added `IsRunAlive` method to `ProcStore` interface to check if specific DAG runs have alive processes
- Implemented safe type assertions with proper error handling in the file-based process store
- Added `checkAndUpdateStaleRunningStatus` helper method that automatically updates orphaned running DAGs to error status
- Updated status retrieval methods to check process liveness before returning running status
- Added comprehensive test coverage for the orphaned running status scenario
- Fixed UI to only calculate duration dynamically for running DAGs (replaced magic number with `Status.Running` constant)

## How it works

1. When retrieving DAG status, if the status is "running", the system now checks if the process is actually alive
2. Process liveness is determined by checking for process files with matching run IDs and verifying they're not stale (heartbeat within 45 seconds)
3. If no alive process is found, the status is automatically updated to "error" with a finished timestamp
4. This ensures orphaned running DAGs don't block new scheduled runs

## Testing

Added comprehensive tests including:
- `TestProcGroup_IsRunAlive` - Tests process liveness checks at the proc group level
- `TestStore_IsRunAlive` - Tests process liveness checks at the store level  
- `OrphanedRunningStatus` test in `manager_test.go` - End-to-end test of the recovery mechanism

## Example

Before this fix:
- DAG stuck in "running" after restart
- New scheduled runs blocked
- Manual intervention required

After this fix:
- System automatically detects orphaned running DAGs
- Updates status to "error" 
- New scheduled runs can proceed normally