### PR TITLE
removed harcoded value of 10000 in models.NewPaginator

### DIFF
--- a/internal/frontend/api/v2/dags.go
+++ b/internal/frontend/api/v2/dags.go
@@ -317,7 +317,8 @@ func (a *API) ListDAGs(ctx context.Context, request api.ListDAGsRequestObject) (
 
 	// For complex sorting, we need to fetch all DAGs first
 	// Use a large paginator to get all DAGs
-	allDagsPaginator := models.NewPaginator(1, 10000)
+	maxInt := int(^uint(0) >> 1)
+	allDagsPaginator := models.NewPaginator(1, maxInt)
 	result, errList, err := a.dagStore.List(ctx, models.ListDAGsOptions{
 		Paginator: &allDagsPaginator,
 		Name:      valueOf(request.Params.Name),

--- a/internal/models/paginator.go
+++ b/internal/models/paginator.go
@@ -16,7 +16,8 @@ type Paginator struct {
 
 func NewPaginator(page, perPage int) Paginator {
 	page = max(page, 1)
-	if perPage > maxPerPage {
+	maxInt := int(^uint(0) >> 1)
+	if perPage > maxPerPage && perPage != maxInt {
 		perPage = maxPerPage
 	}
 	if perPage == 0 {


### PR DESCRIPTION
hardcoding value 10000 generates issue and only shows top 200 dags while listing.

https://github.com/dagu-org/dagu/blob/111594fdd6186db2643f65661cabcc751f944702/internal/frontend/api/v2/dags.go#L320


changed this value of 10000 with 
`maxInt := int(^uint(0) >> 1)` 
