### PR TITLE
Add health check endpoint for scheduler

### DIFF
--- a/design/20_implemented/scheduler-health-check-requirements.md
+++ b/design/20_implemented/scheduler-health-check-requirements.md
@@ -1,0 +1,174 @@
+# Scheduler Health Check Design
+
+## Overview
+
+This design document outlines the implementation of an HTTP health check endpoint for the Dagu scheduler component. The health check will enable external monitoring systems (e.g., Kubernetes, monitoring tools) to verify that the scheduler is running and healthy.
+
+## Requirements
+
+1. **HTTP Health Endpoint**: Expose a `/health` endpoint that returns scheduler status
+2. **Standalone Operation**: Only runs when scheduler is started via `dagu scheduler` command
+3. **No Interference**: Does not run when using `dagu start-all` command
+4. **Graceful Shutdown**: Properly handles system signals alongside the scheduler
+5. **Configurable Port**: Default port 8090, configurable via config file
+6. **Simple Response**: Returns JSON with status field
+
+## Design
+
+### Configuration
+
+Add scheduler-specific configuration to the config structure:
+
+```yaml
+scheduler:
+  port: 8090  # Default health check port
+```
+
+### Architecture
+
+The health check server will be:
+- A lightweight HTTP server running in a separate goroutine
+- Started only when the scheduler command is executed directly
+- Integrated with the scheduler's lifecycle (start/stop)
+- Using the same signal handling pattern as the main scheduler
+
+### Health Check Response
+
+```json
+{
+  "status": "healthy"
+}
+```
+
+The endpoint will return:
+- **200 OK** with `{"status": "healthy"}` when scheduler is running
+- **503 Service Unavailable** if scheduler is shutting down
+
+### Implementation Components
+
+#### 1. Configuration Changes
+
+**File**: `internal/config/config.go`
+
+Add scheduler configuration section:
+```go
+type SchedulerConfig struct {
+    Port int `yaml:"port" mapstructure:"port" default:"8090"`
+}
+
+type Config struct {
+    // ... existing fields ...
+    Scheduler SchedulerConfig `yaml:"scheduler" mapstructure:"scheduler"`
+}
+```
+
+#### 2. Health Server Implementation
+
+**New File**: `internal/scheduler/health.go`
+
+Create a dedicated health server that:
+- Runs on the configured port
+- Exposes `/health` endpoint
+- Shares lifecycle with scheduler
+- Uses Chi router for consistency
+
+#### 3. Scheduler Integration
+
+**File**: `internal/scheduler/scheduler.go`
+
+Modify the scheduler to:
+- Start health server in `Start()` method
+- Stop health server in `Stop()` method
+- Track health server lifecycle
+
+#### 4. Command Integration
+
+**File**: `internal/cmd/scheduler.go`
+
+Ensure health server only starts when:
+- Running `dagu scheduler` command
+- NOT running via `dagu start-all`
+
+### Signal Handling
+
+The health server will:
+1. Share the scheduler's context for cancellation
+2. Shutdown gracefully when scheduler stops
+3. Use the same shutdown timeout pattern
+
+### Error Handling
+
+1. **Port Already in Use**: Log error and continue scheduler operation
+2. **Server Start Failure**: Log error but don't fail scheduler startup
+3. **Graceful Shutdown**: Ensure clean shutdown even if health server fails
+
+## Implementation Plan
+
+### Phase 1: Configuration
+1. Add scheduler config structure
+2. Update config loader
+3. Add default values
+
+### Phase 2: Health Server
+1. Create health server implementation
+2. Add `/health` endpoint handler
+3. Implement graceful shutdown
+
+### Phase 3: Integration
+1. Integrate with scheduler lifecycle
+2. Update scheduler command
+3. Ensure proper signal handling
+
+### Phase 4: Testing
+1. Unit tests for health server
+2. Integration tests for scheduler with health check
+3. Signal handling tests
+
+## Security Considerations
+
+1. **No Authentication**: Health endpoint is public (standard practice)
+2. **Minimal Information**: Only return status, no sensitive data
+3. **Local Only by Default**: Bind to localhost unless configured otherwise
+
+## Monitoring Integration
+
+The health endpoint enables:
+1. **Kubernetes Probes**: Liveness and readiness checks
+2. **Load Balancers**: Health verification
+3. **Monitoring Tools**: Uptime tracking
+4. **Alerting**: Detect scheduler failures
+
+Example Kubernetes configuration:
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8090
+  initialDelaySeconds: 10
+  periodSeconds: 30
+```
+
+## Future Considerations
+
+While not in initial scope, future enhancements could include:
+- Detailed health metrics (queue size, last run time)
+- Readiness vs liveness distinction
+- Metrics endpoint for Prometheus
+- Health check for scheduler components (file watcher, queue reader)
+
+## Testing Strategy
+
+1. **Unit Tests**:
+   - Health endpoint response
+   - Server lifecycle
+   - Configuration loading
+
+2. **Integration Tests**:
+   - Scheduler with health server
+   - Signal handling
+   - Port configuration
+
+3. **Manual Testing**:
+   - `dagu scheduler` starts health server
+   - `dagu start-all` does not start health server
+   - Graceful shutdown works correctly

--- a/docs/configurations/reference.md
+++ b/docs/configurations/reference.md
@@ -109,6 +109,10 @@ worker:
     certFile: ""          # Client certificate (mTLS)
     keyFile: ""           # Client key
     caFile: ""            # CA for server verification
+
+# Scheduler
+scheduler:
+  port: 8090              # Health check port (0 to disable)
 ```
 
 ## Environment Variables
@@ -178,6 +182,9 @@ All options support `DAGU_` prefix.
 - `DAGU_WORKER_TLS_KEY` - Client key for mTLS
 - `DAGU_WORKER_TLS_CA` - CA certificate for server verification
 - `DAGU_WORKER_SKIP_TLS_VERIFY` - Skip TLS certificate verification
+
+### Scheduler
+- `DAGU_SCHEDULER_PORT` - Health check server port (default: `8090`)
 
 ### Legacy Environment Variables (Deprecated)
 These variables are maintained for backward compatibility but should not be used in new deployments:

--- a/docs/features/scheduling.md
+++ b/docs/features/scheduling.md
@@ -12,6 +12,20 @@ dagu scheduler
 
 Or use `dagu start-all` to run both scheduler and web server.
 
+### Health Check Monitoring
+
+The scheduler provides an optional HTTP health check endpoint for monitoring:
+
+```yaml
+# config.yaml
+scheduler:
+  port: 8090  # Health check port (set to 0 to disable)
+```
+
+When enabled, access the health endpoint at `http://localhost:8090/health`.
+
+**Note**: The health check only runs when using `dagu scheduler` directly, not with `dagu start-all`.
+
 ## Basic Scheduling
 
 Schedule workflows with cron expressions:

--- a/internal/cmd/startall.go
+++ b/internal/cmd/startall.go
@@ -70,6 +70,8 @@ func runStartAll(ctx *Context, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize scheduler: %w", err)
 	}
+	// Disable health server when running from start-all
+	scheduler.DisableHealthServer()
 
 	server, err := ctx.NewServer()
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,9 @@ type Config struct {
 	// Worker defines the worker configuration.
 	Worker Worker
 
+	// Scheduler defines the scheduler configuration.
+	Scheduler Scheduler
+
 	// Warnings contains a list of warnings generated during the configuration loading process.
 	Warnings []string
 }
@@ -283,4 +286,9 @@ type Worker struct {
 	Insecure        bool              // Use insecure connection (h2c) - must be explicitly enabled
 	SkipTLSVerify   bool              // Skip TLS certificate verification
 	Labels          map[string]string // Worker labels for capability matching
+}
+
+// Scheduler represents the scheduler configuration
+type Scheduler struct {
+	Port int // Health check server port (default: 8090)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -60,6 +60,8 @@ remoteNodes:
 tls:
   certFile: "/path/to/cert.pem"
   keyFile: "/path/to/key.pem"
+scheduler:
+  port: 7890
 `
 	err := os.WriteFile(configFile, []byte(configContent), 0600)
 	require.NoError(t, err)
@@ -114,6 +116,9 @@ tls:
 	assert.Equal(t, "/var/dagu/data/dag-runs", cfg.Paths.DAGRunsDir)
 	assert.Equal(t, "/var/dagu/queue", cfg.Paths.QueueDir)
 	assert.Equal(t, "/var/dagu/proc", cfg.Paths.ProcDir)
+
+	// Verify scheduler settings.
+	assert.Equal(t, 7890, cfg.Scheduler.Port)
 
 	// Verify UI settings.
 	assert.Equal(t, "Test Dagu", cfg.UI.NavbarTitle)
@@ -645,3 +650,4 @@ queues:
 	// Verify environment variable overrides config file
 	assert.False(t, cfg.Queues.Enabled)
 }
+

--- a/internal/config/definition.go
+++ b/internal/config/definition.go
@@ -81,6 +81,9 @@ type Definition struct {
 	// Worker contains configuration for the worker.
 	Worker *workerDef `mapstructure:"worker"`
 
+	// Scheduler contains configuration for the scheduler.
+	Scheduler *schedulerDef `mapstructure:"scheduler"`
+
 	// SchedulerLockStaleThreshold is the time after which a scheduler lock is considered stale.
 	// Default is 30 seconds.
 	SchedulerLockStaleThreshold string `mapstructure:"schedulerLockStaleThreshold"`
@@ -285,4 +288,10 @@ type workerDef struct {
 
 	// CAFile is the path to the CA certificate file for server verification.
 	CAFile string `mapstructure:"caFile"`
+}
+
+// schedulerDef holds the configuration for the scheduler.
+type schedulerDef struct {
+	// Port is the port number for the health check server.
+	Port int `mapstructure:"port"`
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -319,6 +319,14 @@ func (l *ConfigLoader) buildConfig(def Definition) (*Config, error) {
 		}
 	}
 
+	// Set scheduler configuration
+	if def.Scheduler != nil {
+		cfg.Scheduler.Port = def.Scheduler.Port
+	} else {
+		// Set default scheduler port only if scheduler config was not provided at all
+		cfg.Scheduler.Port = 8090
+	}
+
 	// Incorporate legacy field values, which may override existing settings.
 	l.LoadLegacyFields(&cfg, def)
 	// Load legacy environment variable overrides.
@@ -599,6 +607,8 @@ func (l *ConfigLoader) bindEnvironmentVariables() {
 	l.bindEnv("worker.certFile", "WORKER_TLS_CERT_FILE")
 	l.bindEnv("worker.keyFile", "WORKER_TLS_KEY_FILE")
 	l.bindEnv("worker.caFile", "WORKER_TLS_CA_FILE")
+	// Scheduler configuration
+	l.bindEnv("scheduler.port", "SCHEDULER_PORT")
 }
 
 // bindEnv constructs the full environment variable name using the app prefix and binds it to the given key.

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -87,6 +87,9 @@ func TestConfigLoader_EnvironmentVariableBindings(t *testing.T) {
 		"DAGU_WORKER_TLS_CERT_FILE":    "/test/worker/cert.pem",
 		"DAGU_WORKER_TLS_KEY_FILE":     "/test/worker/key.pem",
 		"DAGU_WORKER_TLS_CA_FILE":      "/test/worker/ca.pem",
+
+		// Scheduler configuration
+		"DAGU_SCHEDULER_PORT": "9999",
 	}
 
 	// Save and clear existing environment variables
@@ -185,6 +188,9 @@ func TestConfigLoader_EnvironmentVariableBindings(t *testing.T) {
 	assert.Equal(t, "/test/worker/cert.pem", cfg.Worker.TLS.CertFile)
 	assert.Equal(t, "/test/worker/key.pem", cfg.Worker.TLS.KeyFile)
 	assert.Equal(t, "/test/worker/ca.pem", cfg.Worker.TLS.CAFile)
+
+	// Scheduler configuration
+	assert.Equal(t, 9999, cfg.Scheduler.Port)
 }
 
 func TestConfigLoader_CoordinatorSigningKey(t *testing.T) {

--- a/internal/scheduler/health.go
+++ b/internal/scheduler/health.go
@@ -1,0 +1,90 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/dagu-org/dagu/internal/logger"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// HealthServer represents the health check HTTP server for the scheduler
+type HealthServer struct {
+	server *http.Server
+	port   int
+}
+
+// HealthResponse represents the health check response
+type HealthResponse struct {
+	Status string `json:"status"`
+}
+
+// NewHealthServer creates a new health check server
+func NewHealthServer(port int) *HealthServer {
+	return &HealthServer{
+		port: port,
+	}
+}
+
+// Start starts the health check server
+func (h *HealthServer) Start(ctx context.Context) error {
+	if h.port == 0 {
+		return nil // Health check server disabled
+	}
+
+	router := chi.NewRouter()
+	router.Use(middleware.RequestID)
+	router.Use(middleware.RealIP)
+	router.Use(middleware.Recoverer)
+
+	router.Get("/health", h.healthHandler)
+
+	h.server = &http.Server{
+		Addr:              fmt.Sprintf(":%d", h.port),
+		Handler:           router,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	// Start server in a goroutine
+	go func() {
+		logger.Info(ctx, "Starting scheduler health check server", "port", h.port)
+		if err := h.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error(ctx, "Health check server error", "err", err)
+		}
+	}()
+
+	return nil
+}
+
+// Stop gracefully stops the health check server
+func (h *HealthServer) Stop(ctx context.Context) error {
+	if h.server == nil {
+		return nil
+	}
+
+	logger.Info(ctx, "Stopping scheduler health check server")
+
+	// Give the server 5 seconds to shutdown gracefully
+	shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	return h.server.Shutdown(shutdownCtx)
+}
+
+// healthHandler handles the /health endpoint
+func (h *HealthServer) healthHandler(w http.ResponseWriter, _ *http.Request) {
+	response := HealthResponse{
+		Status: "healthy",
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		// Log error but don't write anything else to avoid corrupting response
+		logger.Error(context.Background(), "Failed to encode health response", "err", err)
+	}
+}

--- a/internal/scheduler/health_test.go
+++ b/internal/scheduler/health_test.go
@@ -1,0 +1,60 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthServer(t *testing.T) {
+	t.Run("StartStop", func(t *testing.T) {
+		hs := NewHealthServer(8091)
+		ctx := context.Background()
+
+		// Start the server
+		err := hs.Start(ctx)
+		require.NoError(t, err)
+
+		// Give it a moment to start
+		time.Sleep(100 * time.Millisecond)
+
+		// Make a request to the health endpoint
+		resp, err := http.Get("http://localhost:8091/health")
+		require.NoError(t, err)
+		defer func() {
+			err := resp.Body.Close()
+			assert.NoError(t, err)
+		}()
+
+		// Check the response
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+		var healthResp HealthResponse
+		err = json.NewDecoder(resp.Body).Decode(&healthResp)
+		require.NoError(t, err)
+		assert.Equal(t, "healthy", healthResp.Status)
+
+		// Stop the server
+		err = hs.Stop(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("DisabledWhenPortIsZero", func(t *testing.T) {
+		hs := NewHealthServer(0)
+		ctx := context.Background()
+
+		// Start should succeed but not actually start a server
+		err := hs.Start(ctx)
+		require.NoError(t, err)
+
+		// Stop should also succeed
+		err = hs.Stop(ctx)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
**Overview:**
Users need to monitor scheduler health status for production deployments. They currently have no way to check if the scheduler is running properly.

This PR adds a simple HTTP health check endpoint to the scheduler that monitoring tools can use.

Issue: #1120

**Changes:**
- Add `scheduler.port` configuration field (default: 8090)
- Implement `/health` endpoint that returns `{"status": "healthy"}`
- Health server only runs with `dagu scheduler` command, not `dagu start-all`
- Support `DAGU_SCHEDULER_PORT` environment variable
- Can disable health check by setting port to 0

**Example:**
```yaml
# config.yaml
scheduler:
  port: 8090  # Health check port (default)
```

```bash
# Start scheduler with health check
dagu scheduler

# Check health
curl http://localhost:8090/health
# Returns: {"status": "healthy"}
```