### PR TITLE
fix: proc store requires queue name when it's specified

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -245,7 +245,7 @@ func (a *Agent) Run(ctx context.Context) error {
 
 	// Create a process for heartbeat. We need to acquire proc file by queue name or dag name.
 	// This is to ensure queue scheduler can limit the number of active processes for the same queue.
-	proc, err := a.procStore.Acquire(ctx, digraph.NewDAGRunRef(a.dag.QueueName(), a.dagRunID))
+	proc, err := a.procStore.Acquire(ctx, digraph.NewDAGRunRef(a.dag.QueueProcName(), a.dagRunID))
 	if err != nil {
 		return fmt.Errorf("failed to get process: %w", err)
 	}

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -117,7 +117,7 @@ func runStart(ctx *Context, args []string) error {
 		return executeDAGRun(ctx, dag, digraph.DAGRunRef{}, dagRunID, root)
 	}
 
-	runningCount, err := ctx.ProcStore.CountAlive(ctx, dag.Name)
+	runningCount, err := ctx.ProcStore.CountAlive(ctx, dag.QueueProcName())
 	if err == nil && runningCount == 0 {
 		// If there are no running processes, we can execute the DAG-run directly
 		return executeDAGRun(ctx, dag, digraph.DAGRunRef{}, dagRunID, root)

--- a/internal/dagrun/manager.go
+++ b/internal/dagrun/manager.go
@@ -381,7 +381,7 @@ func (m *Manager) GetLatestStatus(ctx context.Context, dag *digraph.DAG) (models
 	var dagStatus *models.DAGRunStatus
 
 	// Find the proc store to check if the DAG is running
-	alive, _ := m.procStore.CountAlive(ctx, dag.Name)
+	alive, _ := m.procStore.CountAlive(ctx, dag.QueueProcName())
 	if alive > 0 {
 		items, _ := m.dagRunStore.ListStatuses(
 			ctx, models.WithName(dag.Name), models.WithStatuses([]status.Status{status.Running}),
@@ -392,7 +392,7 @@ func (m *Manager) GetLatestStatus(ctx context.Context, dag *digraph.DAG) (models
 	}
 
 	// Find the latest status by name
-	attempt, err := m.dagRunStore.LatestAttempt(ctx, dag.Name)
+	attempt, err := m.dagRunStore.LatestAttempt(ctx, dag.QueueProcName())
 	if err != nil {
 		// If the latest status is not found, return the default status
 		ret := models.InitialStatus(dag)

--- a/internal/digraph/dag.go
+++ b/internal/digraph/dag.go
@@ -195,9 +195,9 @@ func WithStep(step string) TaskOption {
 	}
 }
 
-// QueueName returns the name of the queue for this DAG.
+// QueueProcName returns the name of the queue for this DAG.
 // If the queue is not set, it returns the DAG name as the default queue name.
-func (d *DAG) QueueName() string {
+func (d *DAG) QueueProcName() string {
 	// If the queue is not set, return the default queue name.
 	if d.Queue == "" {
 		return d.Name

--- a/internal/persistence/fileproc/store_test.go
+++ b/internal/persistence/fileproc/store_test.go
@@ -37,7 +37,7 @@ func TestStore(t *testing.T) {
 	}()
 
 	// Check if the count is 1
-	count, err := store.CountAlive(ctx, dagRun.Name)
+	count, err := store.CountAlive(ctx, "test_dag")
 	require.NoError(t, err, "failed to count proc files")
 	require.Equal(t, 1, count, "expected 1 proc file")
 
@@ -45,7 +45,7 @@ func TestStore(t *testing.T) {
 	<-done
 
 	// Check if the count is 0
-	count, err = store.CountAlive(ctx, dagRun.Name)
+	count, err = store.CountAlive(ctx, "test_dag")
 	require.NoError(t, err, "failed to count proc files")
 	require.Equal(t, 0, count, "expected 0 proc files")
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -297,7 +297,7 @@ func (s *Scheduler) handleQueue(ctx context.Context, ch chan models.QueuedItem, 
 				goto SEND_RESULT
 			}
 
-			alive, err = s.procStore.CountAlive(ctx, dag.QueueName())
+			alive, err = s.procStore.CountAlive(ctx, dag.QueueProcName())
 			if err != nil {
 				logger.Error(ctx, "Failed to count alive processes", "err", err, "data", data)
 				goto SEND_RESULT


### PR DESCRIPTION
Issue: #1130
Reported by @jonasban and @ghansham

## Problem
When a user enqueues a dag from dag definition page, although initial steps are running but dag status is shown failed.

## Root cause
The `dagrun.Manager`'s `LatestStatus` method incorrectly use `DAG.Name` to retrieve running process from the process store where it needs to use `DAG.Queue` when the queue field is not empty.
https://github.com/dagu-org/dagu/blob/1e0d9451e74e83174e06d68bde8468047cda1a57/internal/dagrun/manager.go#L380-L392

It only reproduce when DAG.Queue is not emtpy.

## Changes
- Fixed it to pass DAG.Queue instead of DAG.Name
- Fixed similar places as well
- Fixed the method name `DAG.QueueName` to `DAG.QueueProcName` to be more descriptive and minimize the chance of confusion
