### PR TITLE
fix: prevent exit code 0 from incorrectly triggering continuation for skipped steps

### DIFF
--- a/internal/digraph/scheduler/node.go
+++ b/internal/digraph/scheduler/node.go
@@ -169,6 +169,7 @@ func (n *Node) ShouldContinue(ctx context.Context) bool {
 		if continueOn.Failure {
 			return true
 		}
+
 	case status.NodeCancel:
 		return false
 
@@ -176,6 +177,7 @@ func (n *Node) ShouldContinue(ctx context.Context) bool {
 		if continueOn.Skipped {
 			return true
 		}
+		return false
 
 	case status.NodePartialSuccess:
 		// Partial success is treated like success for continue on

--- a/internal/digraph/scheduler/node_test.go
+++ b/internal/digraph/scheduler/node_test.go
@@ -990,6 +990,17 @@ func TestNodeShouldContinue(t *testing.T) {
 			},
 			expectContinue: true,
 		},
+
+		{
+			name:       "don't continue on skipped when continueOn.skipped is false, even with exit code 0 in exitCode",
+			nodeStatus: status.NodeSkipped,
+			exitCode:   0,
+			continueOnSettings: digraph.ContinueOn{
+				Skipped:  false,
+				ExitCode: []int{0, 1, 2},
+			},
+			expectContinue: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug where skipped nodes were being considered for `continueOn.exitCode` matching.

## Why is this needed?
It addresses issue https://github.com/dagu-org/dagu/issues/1076.