### PR TITLE
fix: ensure DAGU_HOME directory has proper permissions in Docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ FROM --platform=$TARGETPLATFORM ubuntu:24.04
 ARG USER="dagu"
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
+ARG DAGU_HOME="/var/lib/dagu"
 
 # WORKAROUND — Ubuntu 24.04 switched repo signatures to Ed25519.
 # Older base images ship an outdated ubuntu-keyring that cannot verify
@@ -81,10 +82,15 @@ RUN set -eux; \
 # Delete the default ubuntu user
 RUN userdel -f ubuntu
 
+# Create the DAGU_HOME directory and set permissions
+RUN mkdir -p "${DAGU_HOME}" && \
+    chown -R "${USER_UID}:${USER_GID}" "${DAGU_HOME}" && \
+    chmod 755 "${DAGU_HOME}"
+
 WORKDIR /home/dagu
 ENV DAGU_HOST=0.0.0.0
 ENV DAGU_PORT=8080
-ENV DAGU_HOME=/var/lib/dagu
+ENV DAGU_HOME=${DAGU_HOME}
 ENV DAGU_TZ="Etc/UTC"
 ENV PUID=${USER_UID}
 ENV PGID=${USER_GID}

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -27,6 +27,7 @@ FROM --platform=$TARGETPLATFORM alpine:3.22.1
 ARG USER="dagu"
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
+ARG DAGU_HOME="/var/lib/dagu"
 
 # Install common tools
 RUN apk update && \
@@ -54,6 +55,11 @@ RUN set -eux; \
 # Create user and set permissions
 RUN echo "dagu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/99-dagu \
     && chmod 440 /etc/sudoers.d/99-dagu
+
+# Create the DAGU_HOME directory and set permissions
+RUN mkdir -p "${DAGU_HOME}" && \
+    chown -R "${USER_UID}:${USER_GID}" "${DAGU_HOME}" && \
+    chmod 755 "${DAGU_HOME}"
 
 WORKDIR /home/dagu
 ENV DAGU_HOST=0.0.0.0

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -27,6 +27,7 @@ FROM --platform=$TARGETPLATFORM ubuntu:24.04
 ARG USER="dagu"
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
+ARG DAGU_HOME="/var/lib/dagu"
 
 # Install common tools
 ENV DEBIAN_FRONTEND=noninteractive
@@ -81,6 +82,11 @@ RUN set -eux; \
 
 # Delete the default ubuntu user
 RUN userdel -f ubuntu
+
+# Create the DAGU_HOME directory and set permissions
+RUN mkdir -p "${DAGU_HOME}" && \
+    chown -R "${USER_UID}:${USER_GID}" "${DAGU_HOME}" && \
+    chmod 755 "${DAGU_HOME}"
 
 WORKDIR /home/dagu
 ENV DAGU_HOST=0.0.0.0


### PR DESCRIPTION
**Changes**
- Fixes permission issues by creating DAGU_HOME directory with proper ownership during Docker build
- Applies fix to all Docker variants (standard, alpine, dev)

**Why**
- The `DAGU_HOME` directory (/var/lib/dagu) was not being created with proper permissions during the Docker build process. This caused permission denied errors when the dagu user attempted to write DAG files or execution data at runtime.