### PR TITLE
feat: add zombie DAG run detection to scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ For a detailed list of changes, bug fixes, and new features, please refer to the
 
 | Environment Variable | Default | Description |
 |---------------------|---------|-------------|
+| `DAGU_SCHEDULER_PORT` | `8090` | Health check server port |
+| `DAGU_SCHEDULER_LOCK_STALE_THRESHOLD` | `30s` | Scheduler lock stale threshold |
+| `DAGU_SCHEDULER_LOCK_RETRY_INTERVAL` | `5s` | Lock retry interval |
+| `DAGU_SCHEDULER_ZOMBIE_DETECTION_INTERVAL` | `45s` | Zombie DAG detection interval (0 to disable) |
 | `DAGU_QUEUE_ENABLED` | `true` | Enable queue system |
 
 ### Worker Configuration

--- a/docs/configurations/reference.md
+++ b/docs/configurations/reference.md
@@ -113,6 +113,7 @@ scheduler:
   port: 8090              # Health check port (0 to disable)
   lockStaleThreshold: "30s"  # Time after which a scheduler lock is considered stale
   lockRetryInterval: "5s"   # Interval between lock acquisition attempts
+  zombieDetectionInterval: "45s"  # Interval for detecting zombie DAG runs (0 to disable)
 ```
 
 ## Environment Variables
@@ -186,6 +187,7 @@ All options support `DAGU_` prefix.
 - `DAGU_SCHEDULER_PORT` - Health check server port (default: `8090`)
 - `DAGU_SCHEDULER_LOCK_STALE_THRESHOLD` - Time after which a scheduler lock is considered stale (default: `30s`)
 - `DAGU_SCHEDULER_LOCK_RETRY_INTERVAL` - Interval between lock acquisition attempts (default: `5s`)
+- `DAGU_SCHEDULER_ZOMBIE_DETECTION_INTERVAL` - Interval for detecting zombie DAG runs (default: `45s`, `0` to disable)
 
 ### Legacy Environment Variables (Deprecated)
 These variables are maintained for backward compatibility but should not be used in new deployments:

--- a/docs/features/scheduling.md
+++ b/docs/features/scheduling.md
@@ -42,6 +42,21 @@ When enabled, access the health endpoint at `http://localhost:8090/health`.
 
 **Note**: The health check only runs when using `dagu scheduler` directly, not with `dagu start-all`.
 
+### Zombie Detection
+
+The scheduler automatically detects and cleans up "zombie" DAG runs - processes marked as running but no longer alive (e.g., due to system crashes or force kills):
+
+```yaml
+# config.yaml
+scheduler:
+  zombieDetectionInterval: 45s  # Check interval (default: 45s, set to 0 to disable)
+```
+
+When a zombie is detected, its status is automatically updated from "running" to "error". This ensures:
+- Accurate status reporting
+- Queue slots are freed for new runs
+- No manual intervention required
+
 ## Basic Scheduling
 
 Schedule workflows with cron expressions:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -296,6 +296,11 @@ type Scheduler struct {
 	// SchedulerLockRetryInterval is the interval between lock acquisition attempts.
 	// Default is 5 seconds.
 	LockRetryInterval time.Duration
+
+	// ZombieDetectionInterval is the interval between checks for zombie DAG runs.
+	// A zombie DAG run is one marked as running but whose process is no longer alive.
+	// Set to 0 to disable zombie detection. Default is 45 seconds.
+	ZombieDetectionInterval time.Duration
 }
 
 // Peer holds the certificate and TLS configuration for peer connections over gRPC.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -64,6 +64,7 @@ scheduler:
   port: 7890
   lockStaleThreshold: 50s
   lockRetryInterval: 10s
+  zombieDetectionInterval: 60s
 `
 	err := os.WriteFile(configFile, []byte(configContent), 0600)
 	require.NoError(t, err)
@@ -124,6 +125,7 @@ scheduler:
 	// Default scheduler lock settings should be applied
 	assert.Equal(t, 50*time.Second, cfg.Scheduler.LockStaleThreshold)
 	assert.Equal(t, 10*time.Second, cfg.Scheduler.LockRetryInterval)
+	assert.Equal(t, 60*time.Second, cfg.Scheduler.ZombieDetectionInterval)
 
 	// Verify new distributed execution fields have defaults
 	assert.Equal(t, "", cfg.Coordinator.Host)
@@ -173,6 +175,7 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	assert.Equal(t, 8090, cfg.Scheduler.Port)
 	assert.Equal(t, 30*time.Second, cfg.Scheduler.LockStaleThreshold)
 	assert.Equal(t, 5*time.Second, cfg.Scheduler.LockRetryInterval)
+	assert.Equal(t, 45*time.Second, cfg.Scheduler.ZombieDetectionInterval)
 
 	// Worker defaults
 	assert.Equal(t, 100, cfg.Worker.MaxActiveRuns)

--- a/internal/config/definition.go
+++ b/internal/config/definition.go
@@ -285,4 +285,8 @@ type schedulerDef struct {
 	// LockRetryInterval is the interval between lock acquisition attempts.
 	// Default is 5 second.
 	LockRetryInterval string `mapstructure:"lockRetryInterval"`
+
+	// ZombieDetectionInterval is the interval between checks for zombie DAG runs.
+	// Default is 45 seconds. Set to 0 to disable.
+	ZombieDetectionInterval string `mapstructure:"zombieDetectionInterval"`
 }

--- a/internal/config/zombie_config_test.go
+++ b/internal/config/zombie_config_test.go
@@ -1,0 +1,144 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dagu-org/dagu/internal/config"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZombieDetectionConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		configYAML       string
+		expectedInterval time.Duration
+		expectWarning    bool
+	}{
+		{
+			name: "default value when not specified",
+			configYAML: `
+host: "0.0.0.0"
+port: 8080
+`,
+			expectedInterval: 45 * time.Second,
+			expectWarning:    false,
+		},
+		{
+			name: "custom interval",
+			configYAML: `
+host: "0.0.0.0"
+port: 8080
+scheduler:
+  zombieDetectionInterval: 2m
+`,
+			expectedInterval: 2 * time.Minute,
+			expectWarning:    false,
+		},
+		{
+			name: "disabled with zero",
+			configYAML: `
+host: "0.0.0.0"
+port: 8080
+scheduler:
+  zombieDetectionInterval: 0s
+`,
+			expectedInterval: 0, // Should be 0 to disable
+			expectWarning:    false,
+		},
+		{
+			name: "invalid duration format",
+			configYAML: `
+host: "0.0.0.0"
+port: 8080
+scheduler:
+  zombieDetectionInterval: invalid
+`,
+			expectedInterval: 0, // Parsing fails, remains 0
+			expectWarning:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper between tests
+			viper.Reset()
+
+			// Create temp config file
+			tempDir := t.TempDir()
+			configFile := filepath.Join(tempDir, "config.yaml")
+			err := os.WriteFile(configFile, []byte(tt.configYAML), 0600)
+			require.NoError(t, err)
+
+			// Load config
+			cfg, err := config.Load(config.WithConfigFile(configFile))
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+
+			// Check zombie detection interval
+			assert.Equal(t, tt.expectedInterval, cfg.Scheduler.ZombieDetectionInterval)
+
+			// Check for warnings
+			if tt.expectWarning {
+				assert.NotEmpty(t, cfg.Warnings)
+				found := false
+				for _, warning := range cfg.Warnings {
+					if contains(warning, "zombieDetectionInterval") {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "Expected warning about zombieDetectionInterval")
+			}
+		})
+	}
+}
+
+func TestZombieDetectionEnvVar(t *testing.T) {
+	// Reset viper between tests
+	viper.Reset()
+
+	// Set environment variable with DAGU prefix
+	os.Setenv("DAGU_SCHEDULER_ZOMBIE_DETECTION_INTERVAL", "90s")
+	defer os.Unsetenv("DAGU_SCHEDULER_ZOMBIE_DETECTION_INTERVAL")
+
+	// Create minimal config
+	tempDir := t.TempDir()
+	configFile := filepath.Join(tempDir, "config.yaml")
+	configContent := `
+host: "0.0.0.0"
+port: 8080
+`
+	err := os.WriteFile(configFile, []byte(configContent), 0600)
+	require.NoError(t, err)
+
+	// Load config
+	cfg, err := config.Load(config.WithConfigFile(configFile))
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	// Check that env var overrides default
+	assert.Equal(t, 90*time.Second, cfg.Scheduler.ZombieDetectionInterval)
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && s[0:len(s)] != "" &&
+		len(substr) > 0 &&
+		(s == substr ||
+			(len(s) > len(substr) && s[:len(substr)] == substr) ||
+			(len(s) > len(substr) && s[len(s)-len(substr):] == substr) ||
+			containsMiddle(s, substr))
+}
+
+func containsMiddle(s, substr string) bool {
+	for i := 1; i < len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/zombie_env_test.go
+++ b/internal/config/zombie_env_test.go
@@ -1,0 +1,77 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dagu-org/dagu/internal/config"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZombieDetectionEnvVarPrecedence(t *testing.T) {
+	tests := []struct {
+		name             string
+		configYAML       string
+		envValue         string
+		expectedInterval time.Duration
+	}{
+		{
+			name: "env var overrides default",
+			configYAML: `
+host: "0.0.0.0"
+port: 8080
+`,
+			envValue:         "90s",
+			expectedInterval: 90 * time.Second,
+		},
+		{
+			name: "env var overrides config file",
+			configYAML: `
+host: "0.0.0.0"
+port: 8080
+scheduler:
+  zombieDetectionInterval: 30s
+`,
+			envValue:         "120s",
+			expectedInterval: 120 * time.Second,
+		},
+		{
+			name: "env var set to disable",
+			configYAML: `
+host: "0.0.0.0"
+port: 8080
+`,
+			envValue:         "0s",
+			expectedInterval: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper between tests
+			viper.Reset()
+
+			// Set environment variable with DAGU prefix
+			os.Setenv("DAGU_SCHEDULER_ZOMBIE_DETECTION_INTERVAL", tt.envValue)
+			defer os.Unsetenv("DAGU_SCHEDULER_ZOMBIE_DETECTION_INTERVAL")
+
+			// Create temp config file
+			tempDir := t.TempDir()
+			configFile := filepath.Join(tempDir, "config.yaml")
+			err := os.WriteFile(configFile, []byte(tt.configYAML), 0600)
+			require.NoError(t, err)
+
+			// Load config
+			cfg, err := config.Load(config.WithConfigFile(configFile))
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+
+			// Check zombie detection interval
+			assert.Equal(t, tt.expectedInterval, cfg.Scheduler.ZombieDetectionInterval)
+		})
+	}
+}

--- a/internal/scheduler/zombie_detector.go
+++ b/internal/scheduler/zombie_detector.go
@@ -1,0 +1,151 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/dagu-org/dagu/internal/digraph"
+	"github.com/dagu-org/dagu/internal/digraph/status"
+	"github.com/dagu-org/dagu/internal/logger"
+	"github.com/dagu-org/dagu/internal/models"
+)
+
+// ZombieDetector finds and cleans up zombie DAG runs
+type ZombieDetector struct {
+	dagRunStore models.DAGRunStore
+	procStore   models.ProcStore
+	interval    time.Duration
+}
+
+// NewZombieDetector creates a new zombie detector
+func NewZombieDetector(
+	dagRunStore models.DAGRunStore,
+	procStore models.ProcStore,
+	interval time.Duration,
+) *ZombieDetector {
+	if interval <= 0 {
+		interval = 45 * time.Second
+	}
+	return &ZombieDetector{
+		dagRunStore: dagRunStore,
+		procStore:   procStore,
+		interval:    interval,
+	}
+}
+
+// Start begins the zombie detection loop
+func (z *ZombieDetector) Start(ctx context.Context) {
+	ticker := time.NewTicker(z.interval)
+	defer ticker.Stop()
+
+	running := atomic.Bool{}
+
+	for {
+		select {
+		case <-ticker.C:
+			if running.CompareAndSwap(false, true) {
+				go func() {
+					defer running.Store(false)
+					defer func() {
+						if r := recover(); r != nil {
+							logger.Error(ctx, "Zombie detection check panicked", "panic", r)
+						}
+					}()
+					z.detectAndCleanZombies(ctx)
+				}()
+			} else {
+				logger.Warn(ctx, "Skipping zombie detection, previous check still running")
+			}
+		case <-ctx.Done():
+			logger.Info(ctx, "Stopping zombie detector")
+			return
+		}
+	}
+}
+
+// detectAndCleanZombies finds all running DAG runs and checks if they're actually alive
+func (z *ZombieDetector) detectAndCleanZombies(ctx context.Context) {
+	// Query all running DAG runs
+	statuses, err := z.dagRunStore.ListStatuses(ctx,
+		models.WithStatuses([]status.Status{status.Running}))
+	if err != nil {
+		logger.Error(ctx, "Failed to list running DAG runs", "err", err)
+		return
+	}
+
+	logger.Debug(ctx, "Checking for zombie DAG runs", "count", len(statuses))
+
+	for _, st := range statuses {
+		if err := z.checkAndCleanZombie(ctx, st); err != nil {
+			logger.Error(ctx, "Failed to check zombie status",
+				"name", st.Name, "dagRunID", st.DAGRunID, "err", err)
+		}
+	}
+}
+
+// checkAndCleanZombie checks if a single DAG run is a zombie and cleans it up
+func (z *ZombieDetector) checkAndCleanZombie(ctx context.Context, st *models.DAGRunStatus) error {
+	// Find the attempt for this status
+	dagRunRef := digraph.NewDAGRunRef(st.Name, st.DAGRunID)
+	attempt, err := z.dagRunStore.FindAttempt(ctx, dagRunRef)
+	if err != nil {
+		return fmt.Errorf("find attempt: %w", err)
+	}
+
+	// Read the DAG to get queue proc name
+	dag, err := attempt.ReadDAG(ctx)
+	if err != nil {
+		return fmt.Errorf("read dag: %w", err)
+	}
+
+	// Check if process is alive
+	procRef := digraph.DAGRunRef{
+		Name: dag.QueueProcName(),
+		ID:   st.DAGRunID,
+	}
+	alive, err := z.procStore.IsRunAlive(ctx, procRef)
+	if err != nil {
+		return fmt.Errorf("check alive: %w", err)
+	}
+
+	if alive {
+		return nil
+	}
+
+	// Process is zombie, update status to error
+	logger.Info(ctx, "Found zombie DAG run, updating to error status",
+		"name", st.Name, "dagRunID", st.DAGRunID)
+
+	// Update the status to error
+	st.Status = status.Error
+	st.FinishedAt = time.Now().Format(time.RFC3339)
+	for _, n := range st.Nodes {
+		if n.Status == status.NodeRunning {
+			n.Status = status.NodeError
+			n.Error = "process terminated unexpectedly - zombie process detected"
+		}
+	}
+
+	if err := z.updateStatus(ctx, attempt, *st); err != nil {
+		return fmt.Errorf("update status: %w", err)
+	}
+
+	return nil
+}
+
+// updateStatus updates the status of a DAG run attempt
+func (z *ZombieDetector) updateStatus(ctx context.Context,
+	attempt models.DAGRunAttempt, status models.DAGRunStatus) error {
+	if err := attempt.Open(ctx); err != nil {
+		return fmt.Errorf("open attempt: %w", err)
+	}
+	defer attempt.Close(ctx)
+
+	if err := attempt.Write(ctx, status); err != nil {
+		return fmt.Errorf("write status: %w", err)
+	}
+
+	return nil
+}

--- a/internal/scheduler/zombie_detector_test.go
+++ b/internal/scheduler/zombie_detector_test.go
@@ -1,0 +1,488 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dagu-org/dagu/internal/digraph"
+	"github.com/dagu-org/dagu/internal/digraph/status"
+	"github.com/dagu-org/dagu/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestNewZombieDetector(t *testing.T) {
+	t.Parallel()
+
+	dagRunStore := &mockDAGRunStore{}
+	procStore := &mockProcStore{}
+
+	// Test with default interval
+	detector := NewZombieDetector(dagRunStore, procStore, 0)
+	assert.NotNil(t, detector)
+	assert.Equal(t, 45*time.Second, detector.interval)
+
+	// Test with custom interval
+	detector = NewZombieDetector(dagRunStore, procStore, 60*time.Second)
+	assert.NotNil(t, detector)
+	assert.Equal(t, 60*time.Second, detector.interval)
+}
+
+func TestZombieDetector_detectAndCleanZombies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("no running DAGs", func(t *testing.T) {
+		t.Parallel()
+
+		dagRunStore := &mockDAGRunStore{}
+		procStore := &mockProcStore{}
+		detector := NewZombieDetector(dagRunStore, procStore, time.Second)
+
+		// No running DAGs
+		dagRunStore.On("ListStatuses", ctx, mock.Anything).Return([]*models.DAGRunStatus{}, nil)
+
+		detector.detectAndCleanZombies(ctx)
+
+		dagRunStore.AssertExpectations(t)
+		procStore.AssertExpectations(t)
+	})
+
+	t.Run("running DAG is alive", func(t *testing.T) {
+		t.Parallel()
+
+		dagRunStore := &mockDAGRunStore{}
+		procStore := &mockProcStore{}
+		detector := NewZombieDetector(dagRunStore, procStore, time.Second)
+
+		// One running DAG
+		runningStatus := &models.DAGRunStatus{
+			Name:     "test-dag",
+			DAGRunID: "run-123",
+			Status:   status.Running,
+		}
+		dagRunStore.On("ListStatuses", ctx, mock.Anything).Return([]*models.DAGRunStatus{runningStatus}, nil)
+
+		// Mock attempt
+		attempt := &mockDAGRunAttempt{}
+		dagRunRef := digraph.NewDAGRunRef("test-dag", "run-123")
+		dagRunStore.On("FindAttempt", ctx, dagRunRef).Return(attempt, nil)
+
+		// Mock DAG
+		dag := &digraph.DAG{Name: "test-dag"}
+		attempt.On("ReadDAG", ctx).Return(dag, nil)
+
+		// Process is alive
+		procRef := digraph.DAGRunRef{
+			Name: dag.QueueProcName(),
+			ID:   "run-123",
+		}
+		procStore.On("IsRunAlive", ctx, procRef).Return(true, nil)
+
+		detector.detectAndCleanZombies(ctx)
+
+		// Should not update status since process is alive
+		attempt.AssertNotCalled(t, "Open", ctx)
+		attempt.AssertNotCalled(t, "Write", ctx, mock.Anything)
+		attempt.AssertNotCalled(t, "Close", ctx)
+
+		dagRunStore.AssertExpectations(t)
+		procStore.AssertExpectations(t)
+		attempt.AssertExpectations(t)
+	})
+
+	t.Run("running DAG is zombie", func(t *testing.T) {
+		t.Parallel()
+
+		dagRunStore := &mockDAGRunStore{}
+		procStore := &mockProcStore{}
+		detector := NewZombieDetector(dagRunStore, procStore, time.Second)
+
+		// One running DAG
+		runningStatus := &models.DAGRunStatus{
+			Name:     "test-dag",
+			DAGRunID: "run-123",
+			Status:   status.Running,
+		}
+		dagRunStore.On("ListStatuses", ctx, mock.Anything).Return([]*models.DAGRunStatus{runningStatus}, nil)
+
+		// Mock attempt
+		attempt := &mockDAGRunAttempt{}
+		dagRunRef := digraph.NewDAGRunRef("test-dag", "run-123")
+		dagRunStore.On("FindAttempt", ctx, dagRunRef).Return(attempt, nil)
+
+		// Mock DAG
+		dag := &digraph.DAG{Name: "test-dag"}
+		attempt.On("ReadDAG", ctx).Return(dag, nil)
+
+		// Process is NOT alive (zombie)
+		procRef := digraph.DAGRunRef{
+			Name: dag.QueueProcName(),
+			ID:   "run-123",
+		}
+		procStore.On("IsRunAlive", ctx, procRef).Return(false, nil)
+
+		// Expect status update
+		attempt.On("Open", ctx).Return(nil)
+		attempt.On("Write", ctx, mock.MatchedBy(func(s models.DAGRunStatus) bool {
+			return s.Status == status.Error && s.FinishedAt != ""
+		})).Return(nil)
+		attempt.On("Close", ctx).Return(nil)
+
+		detector.detectAndCleanZombies(ctx)
+
+		dagRunStore.AssertExpectations(t)
+		procStore.AssertExpectations(t)
+		attempt.AssertExpectations(t)
+	})
+
+	t.Run("error listing statuses", func(t *testing.T) {
+		t.Parallel()
+
+		dagRunStore := &mockDAGRunStore{}
+		procStore := &mockProcStore{}
+		detector := NewZombieDetector(dagRunStore, procStore, time.Second)
+
+		// Error listing statuses
+		dagRunStore.On("ListStatuses", ctx, mock.Anything).Return([]*models.DAGRunStatus(nil), errors.New("db error"))
+
+		// Should handle error gracefully
+		detector.detectAndCleanZombies(ctx)
+
+		dagRunStore.AssertExpectations(t)
+		procStore.AssertExpectations(t)
+	})
+}
+
+func TestZombieDetector_Start(t *testing.T) {
+	dagRunStore := &mockDAGRunStore{}
+	procStore := &mockProcStore{}
+	detector := NewZombieDetector(dagRunStore, procStore, 50*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Set up expectations
+	callCount := atomic.Int32{}
+	dagRunStore.On("ListStatuses", ctx, mock.Anything).Return([]*models.DAGRunStatus{}, nil).Run(func(args mock.Arguments) {
+		callCount.Add(1)
+	})
+
+	// Start detector in background
+	go detector.Start(ctx)
+
+	// Wait for at least 2 ticks
+	time.Sleep(150 * time.Millisecond)
+
+	// Cancel context to stop
+	cancel()
+
+	// Give it time to stop
+	time.Sleep(50 * time.Millisecond)
+
+	// Should have been called at least twice
+	assert.GreaterOrEqual(t, callCount.Load(), int32(2))
+
+	dagRunStore.AssertExpectations(t)
+}
+
+func TestZombieDetector_checkAndCleanZombie_errors(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("error finding attempt", func(t *testing.T) {
+		t.Parallel()
+
+		dagRunStore := &mockDAGRunStore{}
+		procStore := &mockProcStore{}
+		detector := NewZombieDetector(dagRunStore, procStore, time.Second)
+
+		status := &models.DAGRunStatus{
+			Name:     "test-dag",
+			DAGRunID: "run-123",
+			Status:   status.Running,
+		}
+
+		dagRunRef := digraph.NewDAGRunRef("test-dag", "run-123")
+		dagRunStore.On("FindAttempt", ctx, dagRunRef).Return((*mockDAGRunAttempt)(nil), errors.New("not found"))
+
+		err := detector.checkAndCleanZombie(ctx, status)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "find attempt")
+
+		dagRunStore.AssertExpectations(t)
+	})
+
+	t.Run("error reading DAG", func(t *testing.T) {
+		t.Parallel()
+
+		dagRunStore := &mockDAGRunStore{}
+		procStore := &mockProcStore{}
+		detector := NewZombieDetector(dagRunStore, procStore, time.Second)
+
+		status := &models.DAGRunStatus{
+			Name:     "test-dag",
+			DAGRunID: "run-123",
+			Status:   status.Running,
+		}
+
+		attempt := &mockDAGRunAttempt{}
+		dagRunRef := digraph.NewDAGRunRef("test-dag", "run-123")
+		dagRunStore.On("FindAttempt", ctx, dagRunRef).Return(attempt, nil)
+		attempt.On("ReadDAG", ctx).Return((*digraph.DAG)(nil), errors.New("read error"))
+
+		err := detector.checkAndCleanZombie(ctx, status)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "read dag")
+
+		dagRunStore.AssertExpectations(t)
+		attempt.AssertExpectations(t)
+	})
+
+	t.Run("error checking if alive", func(t *testing.T) {
+		t.Parallel()
+
+		dagRunStore := &mockDAGRunStore{}
+		procStore := &mockProcStore{}
+		detector := NewZombieDetector(dagRunStore, procStore, time.Second)
+
+		status := &models.DAGRunStatus{
+			Name:     "test-dag",
+			DAGRunID: "run-123",
+			Status:   status.Running,
+		}
+
+		attempt := &mockDAGRunAttempt{}
+		dagRunRef := digraph.NewDAGRunRef("test-dag", "run-123")
+		dagRunStore.On("FindAttempt", ctx, dagRunRef).Return(attempt, nil)
+
+		dag := &digraph.DAG{Name: "test-dag"}
+		attempt.On("ReadDAG", ctx).Return(dag, nil)
+
+		procRef := digraph.DAGRunRef{
+			Name: dag.QueueProcName(),
+			ID:   "run-123",
+		}
+		procStore.On("IsRunAlive", ctx, procRef).Return(false, errors.New("check error"))
+
+		err := detector.checkAndCleanZombie(ctx, status)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "check alive")
+
+		dagRunStore.AssertExpectations(t)
+		procStore.AssertExpectations(t)
+		attempt.AssertExpectations(t)
+	})
+
+	t.Run("error updating status", func(t *testing.T) {
+		t.Parallel()
+
+		dagRunStore := &mockDAGRunStore{}
+		procStore := &mockProcStore{}
+		detector := NewZombieDetector(dagRunStore, procStore, time.Second)
+
+		status := &models.DAGRunStatus{
+			Name:     "test-dag",
+			DAGRunID: "run-123",
+			Status:   status.Running,
+		}
+
+		attempt := &mockDAGRunAttempt{}
+		dagRunRef := digraph.NewDAGRunRef("test-dag", "run-123")
+		dagRunStore.On("FindAttempt", ctx, dagRunRef).Return(attempt, nil)
+
+		dag := &digraph.DAG{Name: "test-dag"}
+		attempt.On("ReadDAG", ctx).Return(dag, nil)
+
+		procRef := digraph.DAGRunRef{
+			Name: dag.QueueProcName(),
+			ID:   "run-123",
+		}
+		procStore.On("IsRunAlive", ctx, procRef).Return(false, nil)
+
+		// Fail to open attempt
+		attempt.On("Open", ctx).Return(errors.New("open error"))
+
+		err := detector.checkAndCleanZombie(ctx, status)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "update status")
+
+		dagRunStore.AssertExpectations(t)
+		procStore.AssertExpectations(t)
+		attempt.AssertExpectations(t)
+	})
+}
+
+func TestZombieDetector_concurrency(t *testing.T) {
+	t.Parallel()
+
+	dagRunStore := &mockDAGRunStore{}
+	procStore := &mockProcStore{}
+	detector := NewZombieDetector(dagRunStore, procStore, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Make detectAndCleanZombies take longer than the interval
+	slowCallCount := atomic.Int32{}
+	dagRunStore.On("ListStatuses", ctx, mock.Anything).Return([]*models.DAGRunStatus{}, nil).Run(func(args mock.Arguments) {
+		slowCallCount.Add(1)
+		time.Sleep(30 * time.Millisecond) // Slower than interval
+	})
+
+	// Start detector
+	go detector.Start(ctx)
+
+	// Let it run for a while
+	time.Sleep(100 * time.Millisecond)
+
+	// Cancel to stop
+	cancel()
+
+	// Should have skipped some calls due to concurrency protection
+	// With 100ms runtime and 10ms interval, without protection we'd expect ~10 calls
+	// With protection, we should see fewer calls
+	callCount := slowCallCount.Load()
+	t.Logf("Call count: %d", callCount)
+
+	// Should be less than what we'd expect without concurrency protection
+	assert.Less(t, callCount, int32(8))
+	assert.GreaterOrEqual(t, callCount, int32(2))
+
+	dagRunStore.AssertExpectations(t)
+}
+
+// Mock DAGRunStore
+type mockDAGRunStore struct {
+	mock.Mock
+}
+
+func (m *mockDAGRunStore) CreateAttempt(ctx context.Context, dag *digraph.DAG, ts time.Time, dagRunID string, opts models.NewDAGRunAttemptOptions) (models.DAGRunAttempt, error) {
+	args := m.Called(ctx, dag, ts, dagRunID, opts)
+	return args.Get(0).(models.DAGRunAttempt), args.Error(1)
+}
+
+func (m *mockDAGRunStore) RecentAttempts(ctx context.Context, name string, itemLimit int) []models.DAGRunAttempt {
+	args := m.Called(ctx, name, itemLimit)
+	return args.Get(0).([]models.DAGRunAttempt)
+}
+
+func (m *mockDAGRunStore) LatestAttempt(ctx context.Context, name string) (models.DAGRunAttempt, error) {
+	args := m.Called(ctx, name)
+	return args.Get(0).(models.DAGRunAttempt), args.Error(1)
+}
+
+func (m *mockDAGRunStore) ListStatuses(ctx context.Context, opts ...models.ListDAGRunStatusesOption) ([]*models.DAGRunStatus, error) {
+	args := m.Called(ctx, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.DAGRunStatus), args.Error(1)
+}
+
+func (m *mockDAGRunStore) FindAttempt(ctx context.Context, dagRun digraph.DAGRunRef) (models.DAGRunAttempt, error) {
+	args := m.Called(ctx, dagRun)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(models.DAGRunAttempt), args.Error(1)
+}
+
+func (m *mockDAGRunStore) FindChildAttempt(ctx context.Context, dagRun digraph.DAGRunRef, childDAGRunID string) (models.DAGRunAttempt, error) {
+	args := m.Called(ctx, dagRun, childDAGRunID)
+	return args.Get(0).(models.DAGRunAttempt), args.Error(1)
+}
+
+func (m *mockDAGRunStore) RemoveOldDAGRuns(ctx context.Context, name string, retentionDays int) error {
+	args := m.Called(ctx, name, retentionDays)
+	return args.Error(0)
+}
+
+func (m *mockDAGRunStore) RenameDAGRuns(ctx context.Context, oldName, newName string) error {
+	args := m.Called(ctx, oldName, newName)
+	return args.Error(0)
+}
+
+func (m *mockDAGRunStore) RemoveDAGRun(ctx context.Context, dagRun digraph.DAGRunRef) error {
+	args := m.Called(ctx, dagRun)
+	return args.Error(0)
+}
+
+// Mock ProcStore
+type mockProcStore struct {
+	mock.Mock
+}
+
+func (m *mockProcStore) Acquire(ctx context.Context, dagRun digraph.DAGRunRef) (models.ProcHandle, error) {
+	args := m.Called(ctx, dagRun)
+	return args.Get(0).(models.ProcHandle), args.Error(1)
+}
+
+func (m *mockProcStore) CountAlive(ctx context.Context, name string) (int, error) {
+	args := m.Called(ctx, name)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *mockProcStore) IsRunAlive(ctx context.Context, dagRun digraph.DAGRunRef) (bool, error) {
+	args := m.Called(ctx, dagRun)
+	return args.Bool(0), args.Error(1)
+}
+
+// Mock DAGRunAttempt
+type mockDAGRunAttempt struct {
+	mock.Mock
+}
+
+func (m *mockDAGRunAttempt) ID() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *mockDAGRunAttempt) Open(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockDAGRunAttempt) Write(ctx context.Context, status models.DAGRunStatus) error {
+	args := m.Called(ctx, status)
+	return args.Error(0)
+}
+
+func (m *mockDAGRunAttempt) Close(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockDAGRunAttempt) ReadStatus(ctx context.Context) (*models.DAGRunStatus, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*models.DAGRunStatus), args.Error(1)
+}
+
+func (m *mockDAGRunAttempt) ReadDAG(ctx context.Context) (*digraph.DAG, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*digraph.DAG), args.Error(1)
+}
+
+func (m *mockDAGRunAttempt) RequestCancel(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockDAGRunAttempt) CancelRequested(ctx context.Context) (bool, error) {
+	args := m.Called(ctx)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *mockDAGRunAttempt) Hide(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockDAGRunAttempt) Hidden() bool {
+	args := m.Called()
+	return args.Bool(0)
+}


### PR DESCRIPTION
Implements automatic detection and cleanup of zombie DAG runs - processes marked as running but whose underlying process is no longer alive.

## Changes
- Add `ZombieDetector` that periodically checks running DAG runs
- Configure via `zombieDetectionInterval` (default 45s, 0 to disable)  
- Support environment variable `DAGU_SCHEDULER_ZOMBIE_DETECTION_INTERVAL`
- Update zombie DAG runs to Error status with appropriate node error messages
- Add panic recovery and comprehensive unit tests

Related to #1130

Reported-by: jonasban