### PR TITLE
Add refresh buttons to Dashboard, DAG-runs and DAG-definitions pages

### DIFF
--- a/ui/src/components/ui/refresh-button.tsx
+++ b/ui/src/components/ui/refresh-button.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { Button } from './button';
+import { cn } from '../../lib/utils';
+
+interface RefreshButtonProps {
+  onRefresh: () => void | Promise<void>;
+  className?: string;
+  disabled?: boolean;
+}
+
+export const RefreshButton: React.FC<RefreshButtonProps> = ({
+  onRefresh,
+  className,
+  disabled = false,
+}) => {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true);
+    try {
+      await onRefresh();
+    } finally {
+      // Brief visual feedback
+      setTimeout(() => setIsRefreshing(false), 500);
+    }
+  };
+
+  return (
+    <Button
+      size="sm"
+      onClick={handleRefresh}
+      disabled={disabled || isRefreshing}
+      className={cn("p-2", className)}
+      title="Refresh"
+    >
+      <RefreshCw
+        size={16}
+        className={cn(
+          isRefreshing && "animate-spin"
+        )}
+      />
+    </Button>
+  );
+};

--- a/ui/src/features/dags/components/dag-list/DAGListHeader.tsx
+++ b/ui/src/features/dags/components/dag-list/DAGListHeader.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
 import Title from '../../../../ui/Title';
 import { CreateDAGButton } from '../common';
+import { RefreshButton } from '../../../../components/ui/refresh-button';
 
-const DAGListHeader: React.FC = () => (
+interface DAGListHeaderProps {
+  onRefresh?: () => void | Promise<void>;
+}
+
+const DAGListHeader: React.FC<DAGListHeaderProps> = ({ onRefresh }) => (
   <div className="flex flex-row items-center justify-between mb-2">
     <Title className="text-xl mb-0">DAG Definitions</Title>
-    <CreateDAGButton />
+    <div className="flex gap-2">
+      <CreateDAGButton />
+      {onRefresh && <RefreshButton onRefresh={onRefresh} />}
+    </div>
   </div>
 );
 

--- a/ui/src/pages/dag-runs/index.tsx
+++ b/ui/src/pages/dag-runs/index.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { Status } from '../../api/v2/schema';
 import { Button } from '../../components/ui/button';
+import { RefreshButton } from '../../components/ui/refresh-button';
 import { DateRangePicker } from '../../components/ui/date-range-picker';
 import { Input } from '../../components/ui/input';
 import {
@@ -312,6 +313,7 @@ function DAGRuns() {
             <Search size={16} className="mr-1" />
             Search
           </Button>
+          <RefreshButton onRefresh={() => mutate()} />
         </div>
         <DateRangePicker
           fromDate={fromDate}

--- a/ui/src/pages/dags/index.tsx
+++ b/ui/src/pages/dags/index.tsx
@@ -2,6 +2,7 @@ import { debounce } from 'lodash';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { components, PathsDagsGetParametersQuerySort, PathsDagsGetParametersQueryOrder } from '../../api/v2/schema';
+import { RefreshButton } from '../../components/ui/refresh-button';
 import { AppBarContext } from '../../contexts/AppBarContext';
 import { useUserPreferences } from '../../contexts/UserPreference';
 import { DAGErrors } from '../../features/dags/components/dag-editor';
@@ -151,7 +152,7 @@ function DAGs() {
 
   return (
     <div className="flex flex-col">
-      <DAGListHeader />
+      <DAGListHeader onRefresh={refreshFn} />
 
       {/* Content */}
       <div className="w-full">

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { RefreshButton } from '@/components/ui/refresh-button';
 import { AppBarContext } from '../contexts/AppBarContext';
 import { useConfig } from '../contexts/ConfigContext';
 import DashboardTimeChart from '../features/dashboard/components/DashboardTimechart';
@@ -83,7 +84,7 @@ function Dashboard(): React.ReactElement | null {
     });
   };
 
-  const { data, error, isLoading } = useQuery('/dag-runs', {
+  const { data, error, isLoading, mutate } = useQuery('/dag-runs', {
     params: {
       query: {
         remoteNode: appBarContext.selectedRemoteNode || 'local',
@@ -274,7 +275,6 @@ function Dashboard(): React.ReactElement | null {
                 )}
               </div>
               <Button
-                variant="outline"
                 size="sm"
                 onClick={() => {
                   const now = dayjs();
@@ -288,10 +288,13 @@ function Dashboard(): React.ReactElement | null {
                       : now.endOf('day');
                   handleDateChange(startOfDay.unix(), endOfDay.unix());
                 }}
-                className="h-7 px-2 text-xs"
+                className="px-4"
               >
                 Today
               </Button>
+              <RefreshButton 
+                onRefresh={() => mutate()} 
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Adds manual refresh buttons to the Dashboard, DAG Runs, and DAG Definitions pages for immediate data updates. Created a reusable RefreshButton component to avoid code duplication and ensure consistent styling across all pages.