### PR TITLE
[#1187] fix: register configured host name instead of resolved IP

### DIFF
--- a/internal/cmd/coordinator.go
+++ b/internal/cmd/coordinator.go
@@ -141,7 +141,7 @@ func newCoordinator(ctx context.Context, cfg *config.Config, registry models.Ser
 	handler := coordinator.NewHandler()
 
 	// Create and return service
-	return coordinator.NewService(grpcServer, handler, listener, healthServer, registry, instanceID), nil
+	return coordinator.NewService(grpcServer, handler, listener, healthServer, registry, instanceID, cfg.Coordinator.Host), nil
 }
 
 // loadCoordinatorTLSCredentials loads TLS credentials for the coordinator server.

--- a/internal/test/coordinator.go
+++ b/internal/test/coordinator.go
@@ -52,7 +52,7 @@ func SetupCoordinator(t *testing.T, opts ...HelperOption) *Coordinator {
 	handler := coordinator.NewHandler()
 
 	// Create service with ServiceMonitor from helper
-	service := coordinator.NewService(grpcServer, handler, listener, healthServer, helper.ServiceRegistry, "test-coordinator")
+	service := coordinator.NewService(grpcServer, handler, listener, healthServer, helper.ServiceRegistry, "test-coordinator", "127.0.0.1")
 
 	coord := &Coordinator{
 		Helper:       helper,


### PR DESCRIPTION
The coordinator service should register its host names instead of IP addresses in the service registry so that other nodes can access them.

Issue: #1187 

