### PR TITLE
feat: rename `queue.maxActiveRuns` to `queue.maxConcurrency`

### DIFF
--- a/docs/configurations/advanced.md
+++ b/docs/configurations/advanced.md
@@ -45,16 +45,16 @@ queues:
   enabled: true
   config:
     - name: "cpu-intensive"
-      maxActiveRuns: 2    # CPU cores
+      maxConcurrency: 2    # CPU cores
       
     - name: "io-intensive"
-      maxActiveRuns: 20   # High I/O
+      maxConcurrency: 20   # High I/O
       
     - name: "batch"
-      maxActiveRuns: 1    # Sequential
+      maxConcurrency: 1    # Sequential
       
     - name: "default"
-      maxActiveRuns: 5
+      maxConcurrency: 5
 ```
 
 Per-DAG queue:

--- a/docs/configurations/reference.md
+++ b/docs/configurations/reference.md
@@ -67,11 +67,11 @@ queues:
   enabled: true          # Default: true
   config:
     - name: "critical"
-      maxActiveRuns: 5   # Maximum concurrent DAG runs
+      maxConcurrency: 5   # Maximum concurrent DAG runs
     - name: "batch"
-      maxActiveRuns: 1
+      maxConcurrency: 1
     - name: "default"
-      maxActiveRuns: 2
+      maxConcurrency: 2
 
 # Remote Nodes
 remoteNodes:

--- a/docs/configurations/server.md
+++ b/docs/configurations/server.md
@@ -91,11 +91,11 @@ queues:
   enabled: true                 # Enable queue system (default: true)
   config:
     - name: "critical"
-      maxActiveRuns: 5          # Maximum concurrent DAG runs
+      maxConcurrency: 5          # Maximum concurrent DAG runs
     - name: "batch"
-      maxActiveRuns: 1
+      maxConcurrency: 1
     - name: "default"
-      maxActiveRuns: 2
+      maxConcurrency: 2
 
 # Remote Nodes
 remoteNodes:
@@ -278,11 +278,11 @@ queues:
   enabled: true
   config:
     - name: "critical"
-      maxActiveRuns: 5
+      maxConcurrency: 5
     - name: "batch"
-      maxActiveRuns: 1
+      maxConcurrency: 1
     - name: "default"
-      maxActiveRuns: 2
+      maxConcurrency: 2
 ```
 
 ## Base Configuration

--- a/docs/features/queues.md
+++ b/docs/features/queues.md
@@ -10,10 +10,10 @@ Dagu's queue system helps you:
 - Prioritize critical workflows
 - Prevent system overload
 
-**Additional Note: Queue-level vs DAG-level `maxActiveRuns`:**
+**Additional Note: Queue-level `maxConcurrency` vs DAG-level `maxActiveRuns`:**
 
-At the queue level, `maxActiveRuns` is enforced by the scheduler process.  
-- If a queue has a defined `maxActiveRuns`, any DAG assigned to that queue can run in parallel up to the queue’s limit, regardless of its own DAG-level `maxActiveRuns`.  
+At the queue level, `maxConcurrency` is enforced by the scheduler process.  
+- If a queue has a defined `maxConcurrency`, any DAG assigned to that queue can run in parallel up to the queue’s limit, regardless of its own DAG-level `maxActiveRuns`.  
 - If a DAG is not assigned to a queue (i.e., no `queue: <string>` is set), it follows its own `maxActiveRuns` setting (default: `1`).  
 
 When starting a DAG run (via API or CLI) that belongs to a queue and has `maxActiveRuns > 0`, the system checks the sum of:  
@@ -60,11 +60,11 @@ queues:
   enabled: true
   config:
     - name: "critical"
-      maxActiveRuns: 5      # 5 critical jobs concurrently
+      maxConcurrency: 5      # 5 critical jobs concurrently
     - name: "batch"
-      maxActiveRuns: 1      # One batch job at a time
+      maxConcurrency: 1      # One batch job at a time
     - name: "reporting"
-      maxActiveRuns: 3      # 3 reports concurrently
+      maxConcurrency: 3      # 3 reports concurrently
 ```
 
 ## Default Queue via Base Config

--- a/docs/writing-workflows/examples.md
+++ b/docs/writing-workflows/examples.md
@@ -1129,9 +1129,9 @@ queues:
   enabled: true
   config:
     - name: "critical"
-      maxActiveRuns: 5
+      maxConcurrency: 5
     - name: "batch"
-      maxActiveRuns: 1
+      maxConcurrency: 1
 
 # DAG file
 queue: "critical"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -582,11 +582,11 @@ queues:
   enabled: true
   config:
     - name: "globalQueue"
-      maxActiveRuns: 5
+      maxConcurrency: 5
     - name: "highPriorityQueue"
-      maxActiveRuns: 2
+      maxConcurrency: 2
     - name: "lowPriorityQueue"
-      maxActiveRuns: 10
+      maxConcurrency: 10
 `
 	err := os.WriteFile(configFile, []byte(configContent), 0600)
 	require.NoError(t, err)
@@ -623,7 +623,7 @@ queues:
   enabled: false
   config:
     - name: "testQueue"
-      maxActiveRuns: 3
+      maxConcurrency: 3
 `
 	err := os.WriteFile(configFile, []byte(configContent), 0600)
 	require.NoError(t, err)

--- a/internal/config/definition.go
+++ b/internal/config/definition.go
@@ -243,8 +243,10 @@ type queuesDef struct {
 
 // queueConfigDef represents individual queue configuration
 type queueConfigDef struct {
-	Name          string `mapstructure:"name"`
-	MaxActiveRuns int    `mapstructure:"maxActiveRuns"`
+	Name string `mapstructure:"name"`
+	// Deprecated: use maxConcurrency
+	MaxActiveRuns  *int `mapstructure:"maxActiveRuns"`
+	MaxConcurrency int  `mapstructure:"maxConcurrency"`
 }
 
 // coordinatorDef holds the configuration for the coordinator service.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -251,10 +251,15 @@ func (l *ConfigLoader) buildConfig(def Definition) (*Config, error) {
 	if def.Queues != nil {
 		cfg.Queues.Enabled = def.Queues.Enabled
 		for _, queueDef := range def.Queues.Config {
-			cfg.Queues.Config = append(cfg.Queues.Config, QueueConfig{
+			queueConfig := QueueConfig{
 				Name:          queueDef.Name,
-				MaxActiveRuns: queueDef.MaxActiveRuns,
-			})
+				MaxActiveRuns: queueDef.MaxConcurrency,
+			}
+			// For backward compatibility
+			if queueDef.MaxActiveRuns != nil {
+				queueConfig.MaxActiveRuns = *queueDef.MaxActiveRuns
+			}
+			cfg.Queues.Config = append(cfg.Queues.Config, queueConfig)
 		}
 	}
 


### PR DESCRIPTION
To avoid confusion, rename queue level `maxActiveRuns` to `maxConcurrency`.

Deprecated:
```yaml
queues:
  enabled: true
  config:
    - name: "cpu-intensive"
      maxActiveRuns: 2
```

New:
```yaml
queues:
  enabled: true
  config:
    - name: "cpu-intensive"
      maxConcurrency: 2
```