### PR TITLE
feat: improve check logic for `maxActiveRuns`

### DIFF
--- a/internal/cmd/enqueue.go
+++ b/internal/cmd/enqueue.go
@@ -61,10 +61,11 @@ func runEnqueue(ctx *Context, args []string) error {
 		return fmt.Errorf("failed to read queue: %w", err)
 	}
 
-	// If the DAG has a queue configured and maxActiveRuns > 0, ensure the number
+	// If the DAG has a queue configured and maxActiveRuns > 1, ensure the number
 	// of active runs in the queue does not exceed this limit.
-	// The scheduler only enforces maxActiveRuns at the global queue level.
-	if dag.Queue != "" && dag.MaxActiveRuns > 0 && len(queuedRuns) >= dag.MaxActiveRuns {
+	// No need to check if maxActiveRuns <= 1 for enqueueing as queue level
+	// maxConcurrency will be the only cap.
+	if dag.Queue != "" && dag.MaxActiveRuns > 1 && len(queuedRuns) >= dag.MaxActiveRuns {
 		// The same DAG is already in the queue
 		return fmt.Errorf("DAG %s is already in the queue (maxActiveRuns=%d), cannot enqueue", dag.Name, dag.MaxActiveRuns)
 	}

--- a/internal/cmd/retry.go
+++ b/internal/cmd/retry.go
@@ -80,6 +80,8 @@ func runRetry(ctx *Context, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to read queue: %w", err)
 		}
+		// If the DAG has a queue configured and maxActiveRuns > 0, ensure the number
+		// of active runs in the queue does not exceed this limit.
 		if dag.MaxActiveRuns > 0 && len(queuedRuns)+liveCount >= dag.MaxActiveRuns {
 			return fmt.Errorf("DAG %s is already in the queue (maxActiveRuns=%d), cannot start", dag.Name, dag.MaxActiveRuns)
 		}

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -130,7 +130,7 @@ func runStart(ctx *Context, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to read queue: %w", err)
 		}
-		if dag.Queue != "" && dag.MaxActiveRuns > 0 && len(queuedRuns)+liveCount >= dag.MaxActiveRuns {
+		if dag.Queue != "" && dag.MaxActiveRuns > 1 && len(queuedRuns)+liveCount >= dag.MaxActiveRuns {
 			return fmt.Errorf("DAG %s is already in the queue (maxActiveRuns=%d), cannot start", dag.Name, dag.MaxActiveRuns)
 		}
 
@@ -159,6 +159,8 @@ func tryExecuteDAG(ctx *Context, dag *digraph.DAG, dagRunID string, root digraph
 		return fmt.Errorf("failed to count live process for %s: %w", dag.ProcGroup(), errMaxRunReached)
 	}
 
+	// If the DAG has a queue configured and maxActiveRuns > 0, ensure the number
+	// of active runs in the queue does not exceed this limit.
 	if dag.MaxActiveRuns > 0 && runningCount >= dag.MaxActiveRuns {
 		// It's not possible to run right now.
 		return fmt.Errorf("max active run is reached (%d >= %d): %w", runningCount, dag.MaxActiveRuns, errMaxRunReached)

--- a/internal/frontend/api/v2/dagruns.go
+++ b/internal/frontend/api/v2/dagruns.go
@@ -412,7 +412,9 @@ func (a *API) RetryDAGRun(ctx context.Context, request api.RetryDAGRunRequestObj
 	if err != nil {
 		return nil, fmt.Errorf("failed to read queue: %w", err)
 	}
-	if dag.MaxActiveRuns > 0 && len(queuedRuns)+liveCount >= dag.MaxActiveRuns {
+	// If the DAG has a queue configured and maxActiveRuns > 1, ensure the number
+	// of active runs in the queue does not exceed this limit.
+	if dag.MaxActiveRuns > 1 && len(queuedRuns)+liveCount >= dag.MaxActiveRuns {
 		// The same DAG is already in the queue
 		return nil, &Error{
 			HTTPStatus: http.StatusConflict,

--- a/internal/frontend/api/v2/dagruns.go
+++ b/internal/frontend/api/v2/dagruns.go
@@ -412,9 +412,9 @@ func (a *API) RetryDAGRun(ctx context.Context, request api.RetryDAGRunRequestObj
 	if err != nil {
 		return nil, fmt.Errorf("failed to read queue: %w", err)
 	}
-	// If the DAG has a queue configured and maxActiveRuns > 1, ensure the number
+	// If the DAG has a queue configured and maxActiveRuns > 0, ensure the number
 	// of active runs in the queue does not exceed this limit.
-	if dag.MaxActiveRuns > 1 && len(queuedRuns)+liveCount >= dag.MaxActiveRuns {
+	if dag.MaxActiveRuns > 0 && len(queuedRuns)+liveCount >= dag.MaxActiveRuns {
 		// The same DAG is already in the queue
 		return nil, &Error{
 			HTTPStatus: http.StatusConflict,

--- a/internal/frontend/api/v2/dags.go
+++ b/internal/frontend/api/v2/dags.go
@@ -517,6 +517,10 @@ func (a *API) ExecuteDAG(ctx context.Context, request api.ExecuteDAGRequestObjec
 	if err != nil {
 		return nil, fmt.Errorf("failed to read queue: %w", err)
 	}
+	// If the DAG has a queue configured and maxActiveRuns > 0, ensure the number
+	// of active runs in the queue does not exceed this limit.
+	// No need to check if maxActiveRuns <= 1 for enqueueing as queue level
+	// maxConcurrency will be the only cap.
 	if dag.MaxActiveRuns > 0 && len(queuedRuns)+liveCount >= dag.MaxActiveRuns {
 		// The same DAG is already in the queue
 		return nil, &Error{
@@ -626,7 +630,7 @@ func (a *API) EnqueueDAGDAGRun(ctx context.Context, request api.EnqueueDAGDAGRun
 	// If the DAG has a queue configured and maxActiveRuns > 0, ensure the number
 	// of active runs in the queue does not exceed this limit.
 	// The scheduler only enforces maxActiveRuns at the global queue level.
-	if dag.Queue != "" && dag.MaxActiveRuns > 0 && len(queuedRuns)+liveCount >= dag.MaxActiveRuns {
+	if dag.Queue != "" && dag.MaxActiveRuns > 1 && len(queuedRuns)+liveCount >= dag.MaxActiveRuns {
 		// The same DAG is already in the queue
 		return nil, &Error{
 			HTTPStatus: http.StatusConflict,

--- a/internal/frontend/api/v2/dags.go
+++ b/internal/frontend/api/v2/dags.go
@@ -519,8 +519,6 @@ func (a *API) ExecuteDAG(ctx context.Context, request api.ExecuteDAGRequestObjec
 	}
 	// If the DAG has a queue configured and maxActiveRuns > 0, ensure the number
 	// of active runs in the queue does not exceed this limit.
-	// No need to check if maxActiveRuns <= 1 for enqueueing as queue level
-	// maxConcurrency will be the only cap.
 	if dag.MaxActiveRuns > 0 && len(queuedRuns)+liveCount >= dag.MaxActiveRuns {
 		// The same DAG is already in the queue
 		return nil, &Error{

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -378,7 +378,7 @@ func (s *Scheduler) handleQueue(ctx context.Context, ch chan models.QueuedItem, 
 
 			// Check concurrency limits based on queue configuration
 			queueCfg = s.getQueueConfig(dag.ProcGroup(), dag)
-			if alive >= queueCfg.MaxConcurrency {
+			if queueCfg.MaxConcurrency > 0 && alive >= queueCfg.MaxConcurrency {
 				logger.Info(ctx, "Queue concurrency limit reached", "queue", queueName, "limit", queueCfg.MaxConcurrency, "alive", alive)
 				goto SEND_RESULT
 			}


### PR DESCRIPTION
For enqueue pass, we don't need to check whether active runs is exceeded if `maxActiveRuns <= 1` because the only cap will be the queue level `maxConcurrency` limit.