### PR TITLE
fix: proc handle is not removed when a DAG failed with error

### DIFF
--- a/internal/cmd/agent_executor.go
+++ b/internal/cmd/agent_executor.go
@@ -32,7 +32,9 @@ func ExecuteAgent(ctx *Context, agentInstance *agent.Agent, dag *digraph.DAG, da
 			"dag", dag.Name,
 			"dagRunId", dagRunID,
 			"err", err)
-
+		if ctx.Proc != nil {
+			_ = ctx.Proc.Stop(ctx)
+		}
 		if ctx.Quiet {
 			os.Exit(1)
 		} else {

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -48,6 +48,8 @@ type Context struct {
 	ProcStore       models.ProcStore
 	QueueStore      models.QueueStore
 	ServiceRegistry models.ServiceRegistry
+
+	Proc models.ProcHandle
 }
 
 // LogToFile creates a new logger context with a file writer.

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -175,6 +175,7 @@ func tryExecuteDAG(ctx *Context, dag *digraph.DAG, dagRunID string, root digraph
 	defer func() {
 		_ = proc.Stop(ctx)
 	}()
+	ctx.Proc = proc
 
 	// Unlock the process group
 	ctx.ProcStore.Unlock(ctx, dag.ProcGroup())

--- a/internal/cmdutil/eval.go
+++ b/internal/cmdutil/eval.go
@@ -111,7 +111,7 @@ func EvalString(ctx context.Context, input string, opts ...EvalOption) (string, 
 		quotedRefPattern := regexp.MustCompile(`"\$\{([A-Za-z0-9_]\w*(?:\.[^}]+)?)\}"`)
 		value = quotedRefPattern.ReplaceAllStringFunc(value, func(match string) string {
 			// Extract the reference (VAR or VAR.path)
-			ref := match[2 : len(match)-2] // Remove "$ and }"
+			ref := match[3 : len(match)-2] // Remove "$ and }"
 
 			// Check if it's a JSON path reference
 			if strings.Contains(ref, ".") {
@@ -124,11 +124,13 @@ func EvalString(ctx context.Context, input string, opts ...EvalOption) (string, 
 					extracted = ExpandReferences(ctx, testRef, vars)
 				}
 				if extracted != testRef { // Successfully extracted
+					// strconv.Quote already includes the outer quotes
 					return strconv.Quote(extracted)
 				}
 			} else {
 				// Simple variable
 				if val, ok := vars[ref]; ok {
+					// strconv.Quote already includes the outer quotes
 					return strconv.Quote(val)
 				}
 			}

--- a/internal/cmdutil/eval_test.go
+++ b/internal/cmdutil/eval_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -507,9 +508,9 @@ func TestEvalString(t *testing.T) {
 		},
 		{
 			name:    "quoted JSON variable escaping",
-			input:   `params: "aJson="${ITEM}"`,
+			input:   `params: aJson="${ITEM}"`,
 			opts:    []EvalOption{WithVariables(map[string]string{"ITEM": `{"file": "file1.txt", "config": "prod"}`})},
-			want:    "params: \"aJson=\"{\"file\": \"file1.txt\", \"config\": \"prod\"}\"",
+			want:    `params: aJson=` + strconv.Quote(`{"file": "file1.txt", "config": "prod"}`),
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
- Fix the issue proc handle is not removed when a DAG execution failed with error due to os.Exit call
- Fix variable parsing issue