### PR TITLE
feat(executor): capture stderr and display as error messages in the WebUI

### DIFF
--- a/internal/digraph/executor/command.go
+++ b/internal/digraph/executor/command.go
@@ -50,8 +50,6 @@ func (e *commandExecutor) Run(ctx context.Context) error {
 	}
 	// Wrap stderr with a tailing writer so we can include recent
 	// stderr output (rolling, up to limit) in error messages.
-	// If no stderr writer is configured, default to os.Stderr to
-	// preserve the inheritance behavior of exec.Cmd.
 	tw := newTailWriter(e.config.Stderr, 0)
 	e.stderrTail = tw
 	e.config.Stderr = tw

--- a/internal/digraph/executor/tail_writer.go
+++ b/internal/digraph/executor/tail_writer.go
@@ -1,0 +1,58 @@
+package executor
+
+import (
+    "io"
+    "os"
+    "strings"
+    "sync"
+)
+
+// tailWriter forwards to an underlying writer and keeps only
+// the last completed line written. Safe for concurrent use.
+type tailWriter struct {
+    mu         sync.Mutex
+    underlying io.Writer // may be nil; defaults to os.Stderr
+    lastLine   string    // last completed line (without newline)
+    partial    string    // carry-over for incomplete line fragments
+}
+
+// newTailWriter creates a tailWriter that keeps only the last line.
+// If out is nil, it defaults to os.Stderr to preserve exec's behavior.
+func newTailWriter(out io.Writer) *tailWriter {
+    if out == nil {
+        out = os.Stderr
+    }
+    return &tailWriter{underlying: out}
+}
+
+func (t *tailWriter) Write(p []byte) (int, error) {
+    // Forward to underlying first
+    var n int
+    var err error
+    if t.underlying != nil {
+        n, err = t.underlying.Write(p)
+    } else {
+        n = len(p)
+    }
+
+    // Update last completed line
+    t.mu.Lock()
+    data := t.partial + string(p)
+    parts := strings.Split(data, "\n")
+    // All except last are complete lines
+    complete := parts[:len(parts)-1]
+    t.partial = parts[len(parts)-1]
+    if len(complete) > 0 {
+        t.lastLine = complete[len(complete)-1]
+    }
+    t.mu.Unlock()
+
+    return n, err
+}
+
+// Tail returns the last completed line. If none yet, returns empty string.
+func (t *tailWriter) Tail() string {
+    t.mu.Lock()
+    defer t.mu.Unlock()
+    return t.lastLine
+}

--- a/internal/digraph/executor/tail_writer.go
+++ b/internal/digraph/executor/tail_writer.go
@@ -8,7 +8,7 @@ import (
 
 // defaultStderrTailLimit is the fallback maximum number of bytes
 // to retain from recent stderr output if no override is provided.
-const defaultStderrTailLimit = 1000
+const defaultStderrTailLimit = 5000
 
 // tailWriter forwards to an underlying writer and keeps a rolling
 // tail of recent output up to `max` bytes. Safe for concurrent use.
@@ -21,8 +21,7 @@ type tailWriter struct {
 
 // newTailWriter creates a tailWriter that keeps a rolling buffer
 // of recent output with a maximum size of `max` bytes. If max <= 0,
-// it tries to read from environment variable DAGU_STDERR_TAIL_LIMIT,
-// falling back to defaultStderrTailLimit when unset or invalid.
+// it falls back to defaultStderrTailLimit.
 // If out is nil, it defaults to os.Stderr to preserve exec's behavior.
 func newTailWriter(out io.Writer, max int) *tailWriter {
 	if out == nil {

--- a/internal/digraph/executor/tail_writer_test.go
+++ b/internal/digraph/executor/tail_writer_test.go
@@ -1,0 +1,62 @@
+package executor
+
+import (
+    "bytes"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestTailWriter_LastLineSimple(t *testing.T) {
+    t.Parallel()
+    var buf bytes.Buffer
+    tw := newTailWriter(&buf)
+
+    input := "line1\nline2\n"
+    n, err := tw.Write([]byte(input))
+    assert.NoError(t, err)
+    assert.Equal(t, len(input), n)
+
+    // Underlying receives full content
+    assert.Equal(t, input, buf.String())
+    // Tail returns last completed line
+    assert.Equal(t, "line2", tw.Tail())
+}
+
+func TestTailWriter_AcrossWrites(t *testing.T) {
+    t.Parallel()
+    var buf bytes.Buffer
+    tw := newTailWriter(&buf)
+
+    _, _ = tw.Write([]byte("one\nlin"))
+    assert.Equal(t, "one", tw.Tail()) // first completed line
+
+    _, _ = tw.Write([]byte("e2\npar"))
+    assert.Equal(t, "line2", tw.Tail()) // completes second line
+
+    _, _ = tw.Write([]byte("tial"))
+    assert.Equal(t, "line2", tw.Tail()) // still last completed line
+
+    _, _ = tw.Write([]byte("\n"))
+    assert.Equal(t, "partial", tw.Tail()) // new completed line
+}
+
+func TestTailWriter_NoCompletedLineYet(t *testing.T) {
+    t.Parallel()
+    tw := newTailWriter(&bytes.Buffer{})
+
+    _, _ = tw.Write([]byte("no newline yet"))
+    assert.Equal(t, "", tw.Tail()) // no completed line
+
+    _, _ = tw.Write([]byte("\n"))
+    assert.Equal(t, "no newline yet", tw.Tail())
+}
+
+func TestTailWriter_EmptyLineHandling(t *testing.T) {
+    t.Parallel()
+    tw := newTailWriter(&bytes.Buffer{})
+
+    _, _ = tw.Write([]byte("err\n\nlast\n"))
+    assert.Equal(t, "last", tw.Tail())
+}
+

--- a/internal/digraph/executor/tail_writer_test.go
+++ b/internal/digraph/executor/tail_writer_test.go
@@ -1,62 +1,65 @@
 package executor
 
 import (
-    "bytes"
-    "testing"
+	"bytes"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestTailWriter_LastLineSimple(t *testing.T) {
-    t.Parallel()
-    var buf bytes.Buffer
-    tw := newTailWriter(&buf)
+func TestTailWriter_RollingBufferSimple(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	tw := newTailWriter(&buf, 100)
 
-    input := "line1\nline2\n"
-    n, err := tw.Write([]byte(input))
-    assert.NoError(t, err)
-    assert.Equal(t, len(input), n)
+	input := "line1\nline2\n"
+	n, err := tw.Write([]byte(input))
+	assert.NoError(t, err)
+	assert.Equal(t, len(input), n)
 
-    // Underlying receives full content
-    assert.Equal(t, input, buf.String())
-    // Tail returns last completed line
-    assert.Equal(t, "line2", tw.Tail())
+	// Underlying receives full content
+	assert.Equal(t, input, buf.String())
+	// Tail returns recent output (not just the last line)
+	assert.Equal(t, input, tw.Tail())
 }
 
-func TestTailWriter_AcrossWrites(t *testing.T) {
-    t.Parallel()
-    var buf bytes.Buffer
-    tw := newTailWriter(&buf)
+func TestTailWriter_AcrossWritesAndLimit(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	limit := 10
+	tw := newTailWriter(&buf, limit)
 
-    _, _ = tw.Write([]byte("one\nlin"))
-    assert.Equal(t, "one", tw.Tail()) // first completed line
+	_, _ = tw.Write([]byte("one\nlin")) // "one\nlin"
+	assert.True(t, len(tw.Tail()) <= limit)
+	assert.True(t, bytes.HasSuffix([]byte(tw.Tail()), []byte("one\nlin")))
 
-    _, _ = tw.Write([]byte("e2\npar"))
-    assert.Equal(t, "line2", tw.Tail()) // completes second line
+	_, _ = tw.Write([]byte("e2\npar")) // "one\nline2\npar"
+	assert.True(t, len(tw.Tail()) <= limit)
+	assert.True(t, bytes.HasSuffix([]byte(tw.Tail()), []byte("e2\npar")))
 
-    _, _ = tw.Write([]byte("tial"))
-    assert.Equal(t, "line2", tw.Tail()) // still last completed line
-
-    _, _ = tw.Write([]byte("\n"))
-    assert.Equal(t, "partial", tw.Tail()) // new completed line
+	_, _ = tw.Write([]byte("tial")) // "one\nline2\npartial"
+	assert.True(t, len(tw.Tail()) <= limit)
+	assert.True(t, bytes.HasSuffix([]byte(tw.Tail()), []byte("partial")))
 }
 
-func TestTailWriter_NoCompletedLineYet(t *testing.T) {
-    t.Parallel()
-    tw := newTailWriter(&bytes.Buffer{})
+func TestTailWriter_NoNewlineStillIncluded(t *testing.T) {
+	t.Parallel()
+	tw := newTailWriter(&bytes.Buffer{}, 50)
 
-    _, _ = tw.Write([]byte("no newline yet"))
-    assert.Equal(t, "", tw.Tail()) // no completed line
+	_, _ = tw.Write([]byte("no newline yet"))
+	// Now tail contains the partial line
+	assert.Equal(t, "no newline yet", tw.Tail())
 
-    _, _ = tw.Write([]byte("\n"))
-    assert.Equal(t, "no newline yet", tw.Tail())
+	_, _ = tw.Write([]byte("\n"))
+	assert.Equal(t, "no newline yet\n", tw.Tail())
 }
 
-func TestTailWriter_EmptyLineHandling(t *testing.T) {
-    t.Parallel()
-    tw := newTailWriter(&bytes.Buffer{})
+func TestTailWriter_TrimToLimit(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	tw := newTailWriter(&buf, 5)
 
-    _, _ = tw.Write([]byte("err\n\nlast\n"))
-    assert.Equal(t, "last", tw.Tail())
+	_, _ = tw.Write([]byte("abcdef"))
+	// Only last 5 bytes should remain
+	assert.Equal(t, "bcdef", tw.Tail())
 }
-

--- a/internal/integration/config_test.go
+++ b/internal/integration/config_test.go
@@ -95,6 +95,25 @@ steps:
 		})
 	})
 
+	t.Run("CommandErrorIncludesLastStderrLine", func(t *testing.T) {
+		t.Parallel()
+
+		dag := th.DAG(t, `steps:
+  - name: fail
+    command: bash
+    script: |
+      echo first 1>&2
+      echo second 1>&2
+      exit 7
+`)
+		agent := dag.Agent()
+
+		err := agent.Run(agent.Context)
+		require.Error(t, err)
+		// Should contain the last stderr line
+		require.Contains(t, err.Error(), "second")
+	})
+
 	t.Run("NamedParams", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/integration/config_test.go
+++ b/internal/integration/config_test.go
@@ -95,7 +95,7 @@ steps:
 		})
 	})
 
-	t.Run("CommandErrorIncludesRecentStderr", func(t *testing.T) {
+	t.Run("CommandErrorIncludesLastStderrLine", func(t *testing.T) {
 		t.Parallel()
 
 		dag := th.DAG(t, `steps:
@@ -110,8 +110,7 @@ steps:
 
 		err := agent.Run(agent.Context)
 		require.Error(t, err)
-		// Should contain recent stderr, not just the last line
-		require.Contains(t, err.Error(), "first")
+		// Should contain the last stderr line
 		require.Contains(t, err.Error(), "second")
 	})
 

--- a/internal/integration/config_test.go
+++ b/internal/integration/config_test.go
@@ -95,7 +95,7 @@ steps:
 		})
 	})
 
-	t.Run("CommandErrorIncludesLastStderrLine", func(t *testing.T) {
+	t.Run("CommandErrorIncludesRecentStderr", func(t *testing.T) {
 		t.Parallel()
 
 		dag := th.DAG(t, `steps:
@@ -110,7 +110,8 @@ steps:
 
 		err := agent.Run(agent.Context)
 		require.Error(t, err)
-		// Should contain the last stderr line
+		// Should contain recent stderr, not just the last line
+		require.Contains(t, err.Error(), "first")
 		require.Contains(t, err.Error(), "second")
 	})
 

--- a/internal/integration/container_test.go
+++ b/internal/integration/container_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dagu-org/dagu/internal/test"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+    "github.com/stretchr/testify/require"
 )
 
 func TestDockerExecutor(t *testing.T) {
@@ -411,4 +412,29 @@ steps:
 	dag.AssertOutputs(t, map[string]any{
 		"EXEC_EXISTING_OUT": "hello-existing",
 	})
+}
+
+func TestDockerExecutor_ErrorIncludesRecentStderr(t *testing.T) {
+    t.Parallel()
+
+    th := test.Setup(t)
+
+    dag := th.DAG(t, `
+steps:
+  - name: fail
+    executor:
+      type: docker
+      config:
+        image: alpine:3
+        autoRemove: true
+    command: sh -c 'echo first 1>&2; echo second 1>&2; exit 7'
+`)
+
+    agent := dag.Agent()
+
+    err := agent.Run(agent.Context)
+    require.Error(t, err)
+    // Should contain recent stderr from docker executor
+    require.Contains(t, err.Error(), "first")
+    require.Contains(t, err.Error(), "second")
 }


### PR DESCRIPTION
Adds a feature that buffers the trailing of stderr output from the command and Docker executors, and displays the captured content in the Web UI.